### PR TITLE
make chatgpt response tests more robust

### DIFF
--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -59,7 +59,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
           Message.new_user!("Return the response 'Colorful Threads'.")
         ])
 
-      assert response == "Colorful Threads"
+      assert response =~ "Colorful Threads"
     end
 
     @tag :live_call
@@ -110,7 +110,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
         |> MessageDelta.merge_delta(delta_3)
 
       assert merged.role == :assistant
-      assert merged.content == "Hi"
+      assert merged.content =~ "Hi"
       assert merged.status == :complete
     end
 
@@ -134,12 +134,12 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
           callback
         )
 
-      assert message.content == "Hi"
+      assert message.content =~ "Hi"
       assert message.index == 0
       assert_receive {:message_received, received_item}, 500
       assert %Message{} = received_item
       assert received_item.role == :assistant
-      assert received_item.content == "Hi"
+      assert received_item.content =~ "Hi"
       assert received_item.index == 0
     end
 


### PR DESCRIPTION
Even when given specific instructions like `"Return the response 'Hi'."` ChatGPT (and LLMs in general) don't always follow the instructions *exactly* (for example, ChatGPT will often respond to the above prompt with `"Hi!"` - and the extra `!` makes the test fail).

As a result, equality testing on the response makes for flaky tests. This change keeps the test prompts, but instead matches on the responses with `=~`. Still not perfect, but less likely to be flaky, which in tests seems like a win.

@brainlid the other way to handle this problem is to just test on what's guaranteed by the API contract (i.e. just check the response is [string or null](https://platform.openai.com/docs/api-reference/chat/object) in the ChatGPT case). Up to you if you want to take that route instead.