### PR TITLE
Initial formalization of the behaviour for LLM

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -16,6 +16,7 @@ defmodule LangChain.Chains.LLMChain do
   require Logger
   alias LangChain.PromptTemplate
   alias __MODULE__
+  alias LangChain.LLM
   alias LangChain.Message
   alias LangChain.MessageDelta
   alias LangChain.Function
@@ -196,12 +197,8 @@ defmodule LangChain.Chains.LLMChain do
   # internal reusable function for running the chain
   @spec do_run(t()) :: {:ok, t()} | {:error, String.t()}
   defp do_run(%LLMChain{} = chain) do
-    # submit to LLM. The "llm" is a struct. Match to get the name of the module
-    # then execute the `.call` function on that module.
-    %module{} = chain.llm
-
     # handle and output response
-    case module.call(chain.llm, chain.messages, chain.functions, chain.callback_fn) do
+    case LLM.call(chain.llm, chain.messages, chain.functions, chain.callback_fn) do
       {:ok, [%Message{} = message]} ->
         if chain.verbose, do: IO.inspect(message, label: "SINGLE MESSAGE RESPONSE")
         {:ok, add_message(chain, message)}

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -14,12 +14,15 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   import Ecto.Changeset
   import LangChain.Utils.ApiOverride
   alias __MODULE__
+  alias LangChain.LLM
   alias LangChain.Config
   alias LangChain.Message
   alias LangChain.LangChainError
   alias LangChain.ForOpenAIApi
   alias LangChain.Utils
   alias LangChain.MessageDelta
+
+  @behaviour LLM
 
   # NOTE: As of gpt-4 and gpt-3.5, only one function_call is issued at a time
   # even when multiple requests could be issued based on the prompt.
@@ -52,7 +55,6 @@ defmodule LangChain.ChatModels.ChatOpenAI do
 
   @type t :: %ChatOpenAI{}
 
-  @type call_response :: {:ok, Message.t() | [Message.t()]} | {:error, String.t()}
   @type callback_data ::
           {:ok, Message.t() | MessageDelta.t() | [Message.t() | MessageDelta.t()]}
           | {:error, String.t()}
@@ -142,12 +144,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   structs as they are are received, then converting those to the full
   `LangChain.Message` once fully complete.
   """
-  @spec call(
-          t(),
-          String.t() | [Message.t()],
-          [LangChain.Function.t()],
-          nil | (Message.t() | MessageDelta.t() -> any())
-        ) :: call_response()
+  @impl LLM
   def call(openai, prompt, functions \\ [], callback_fn \\ nil)
 
   def call(%ChatOpenAI{} = openai, prompt, functions, callback_fn) when is_binary(prompt) do

--- a/lib/llm.ex
+++ b/lib/llm.ex
@@ -1,0 +1,21 @@
+defmodule LangChain.LLM do
+  @moduledoc """
+  A behaviour for LLM
+  """
+
+  alias LangChain.Message
+  alias LangChain.MessageDelta
+
+  @type call_response :: {:ok, Message.t() | [Message.t()]} | {:error, String.t()}
+
+  @callback call(
+              struct(),
+              String.t() | [Message.t()],
+              [LangChain.Function.t()],
+              nil | (Message.t() | MessageDelta.t() -> any())
+            ) :: call_response()
+
+  def call(%model{} = config, messages, functions, callback_fn) do
+    model.call(config, messages, functions, callback_fn)
+  end
+end


### PR DESCRIPTION
Hi there!
First of all, thank you for this initiative!

I'm working in a project where we want to experiment with various different LLMs, and, while having most of them implemented inside library would be nice, I see that the LLM implementation is actually decoupled from the "LangChain framework", if we formalized the behaviour or a protocol it would enable users of the library to more confidently attach their own LLM implementations and maybe contribute back to the library!

I tried to provide with minimal changes that keeps all of the implementation same, just moves the `@spec` of `ChatOpenAI.call/4` into a behaviour callback.