### PR TITLE
Set pattern match in `DataExtractionChain` to look for `role: :assistant` rather than `role: :function_call`

### DIFF
--- a/lib/chains/data_extraction_chain.ex
+++ b/lib/chains/data_extraction_chain.ex
@@ -88,7 +88,7 @@ defmodule LangChain.Chains.DataExtractionChain do
       |> LLMChain.add_messages(messages)
       |> LLMChain.run()
       |> case do
-        {:ok, _updated_chain, %Message{role: :function_call, arguments: %{"info" => info}}}
+        {:ok, _updated_chain, %Message{role: :assistant, arguments: %{"info" => info}}}
         when is_list(info) ->
           {:ok, info}
 


### PR DESCRIPTION
... This appears to be the only valid result at this stage.

I see no place where you would expect to receive a response with `role: :function_call` in the current implementation after calling `LLMChain.run()`.

Context here is #14 as I am able to reproduce the same error with the example in that issue as well as the example provided in the moduledoc for `LangChain.Chains.DataExtractionChain`.