### PR TITLE
add "update_custom_context" to LLMChain

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -224,6 +224,48 @@ defmodule LangChain.Chains.LLMChain do
   end
 
   @doc """
+  Update the LLMChain's `custom_context` map. Passing in a `context_update` map
+  will by default merge the map into the existing `custom_context`.
+
+  Use the `:as` option to:
+  - `:merge` - Merge update changes in. Default.
+  - `:replace` - Replace the context with the `context_update`.
+  """
+  @spec update_custom_context(t(), context_update :: %{atom() => any()}, opts :: Keyword.t()) ::
+          t() | no_return()
+  def update_custom_context(chain, context_update, opts \\ [])
+
+  def update_custom_context(
+        %LLMChain{custom_context: %{} = context} = chain,
+        %{} = context_update,
+        opts
+      ) do
+    new_context =
+      case Keyword.get(opts, :as) || :merge do
+        :merge ->
+          Map.merge(context, context_update)
+
+        :replace ->
+          context_update
+
+        other ->
+          raise LangChain.LangChainError,
+                "Invalid update_custom_context :as option of #{inspect(other)}"
+      end
+
+    %LLMChain{chain | custom_context: new_context}
+  end
+
+  def update_custom_context(
+        %LLMChain{custom_context: nil} = chain,
+        %{} = context_update,
+        _opts
+      ) do
+    # can't merge a map with `nil`. Replace it.
+    %LLMChain{chain | custom_context: context_update}
+  end
+
+  @doc """
   Apply a received MessageDelta struct to the chain. The LLMChain tracks the
   current merged MessageDelta state. When the final delta is received that
   completes the message, the LLMChain is updated to clear the `delta` and the

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -554,6 +554,46 @@ defmodule LangChain.Chains.LLMChainTest do
     end
   end
 
+  describe "update_custom_context/3" do
+    test "updates using merge by default" do
+      chain =
+        LLMChain.new!(%{
+          llm: ChatOpenAI.new!(%{stream: false}),
+          custom_context: %{existing: "a", count: 1}
+        })
+
+      updated_1 = LLMChain.update_custom_context(chain, %{count: 5})
+      assert updated_1.custom_context == %{existing: "a", count: 5}
+
+      updated_2 = LLMChain.update_custom_context(updated_1, %{more: true}, as: :merge)
+      assert updated_2.custom_context == %{existing: "a", count: 5, more: true}
+    end
+
+    test "handles update when custom_context is nil" do
+      chain =
+        LLMChain.new!(%{
+          llm: ChatOpenAI.new!(%{stream: false}),
+          custom_context: nil
+        })
+
+      assert chain.custom_context == nil
+
+      updated = LLMChain.update_custom_context(chain, %{some: :thing})
+      assert updated.custom_context == %{some: :thing}
+    end
+
+    test "support updates using replace" do
+      chain =
+        LLMChain.new!(%{
+          llm: ChatOpenAI.new!(%{stream: false}),
+          custom_context: %{count: 1}
+        })
+
+      updated = LLMChain.update_custom_context(chain, %{color: "blue"}, as: :replace)
+      assert updated.custom_context == %{color: "blue"}
+    end
+  end
+
   describe "execute_function/2" do
     test "fires callback with function result message"
 


### PR DESCRIPTION
- added tests

Makes it easy to update the LLMChain's attached `custom_context`. This is relevant because a Function may alter the data that was passed in through the context. A subsequent Function execution should receive the updated value in the `custom_context`.