### PR TITLE
Allow functions to update context

### DIFF
--- a/lib/function.ex
+++ b/lib/function.ex
@@ -56,6 +56,8 @@ defmodule LangChain.Function do
   Context examples may be user_id, account_id, account struct, billing level,
   etc.
 
+  This Context can be updated by Functions. Simply return a tuple of `{response, new_context}` - the response for the LLM to _see_ and the new Context value. This is especially useful when you want to maintain some kind of state between function invocations.
+
   The `parameters_schema` is an Elixir map that follows a
   [JSONSchema](https://json-schema.org/learn/getting-started-step-by-step.html)
   structure. It is used to define the required data structure format for


### PR DESCRIPTION
## Changes

This PR adds the ability for `Function`'s to update the `custom_context` of the chain by returning a tuple of `{response, context}` 

This will unlock the ability for state to be passed between functions without the need to wrap the chain itself in a GenServer or some similar state management mechanism. 

## Use case

You have functions which augment your Chain's Context with additional information, for instance user metadata. Later in the Chain you then want to use this information to add more context for the LLM to use.

### Example

Define one function which fetches the user's birthday

```elixir
Function.new!(%{
    name: "get_user_birthday",
    description: "Returns the birthday of the user.",
    function: fn _arguments, context ->
      birthday = "22/12/1970"
      # The answer is returned to the LLM for immediate usage, but we also store the date in our context for easy access later
      {birthday, Map.put(context, :birthday, birthday)}
    end
  })
```

Define a second function which fetches other users with the same birthday

```elixir
Function.new!(%{
    name: "get_users_with_birthday",
    description: "Returns users who were born on a given day.",
    function: fn _arguments, context ->
      get_user_born_on(context.birthday)
    end
  })
```