### PR TITLE
support openai seed - improves "live" test behavior

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -45,6 +45,9 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     # lengthy response, a longer time limit may be required. However, when it
     # goes on too long by itself, it tends to hallucinate more.
     field :receive_timeout, :integer, default: @receive_timeout
+    # Seed for more deterministic output. Helpful for testing.
+    # https://platform.openai.com/docs/guides/text-generation/reproducible-outputs
+    field :seed, :integer
     # How many chat completion choices to generate for each input message.
     field :n, :integer, default: 1
     field :json_response, :boolean, default: false
@@ -62,6 +65,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     :model,
     :temperature,
     :frequency_penalty,
+    :seed,
     :n,
     :stream,
     :receive_timeout,
@@ -128,6 +132,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       messages: Enum.map(messages, &ForOpenAIApi.for_api/1),
       response_format: set_response_format(openai)
     }
+    |> Utils.conditionally_add_to_map(:seed, openai.seed)
     |> Utils.conditionally_add_to_map(:functions, get_functions_for_api(functions))
   end
 

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -5,16 +5,19 @@ defmodule LangChain.Utils do
 
   @doc """
   Only add the key to the map if the value is present. When the value is a list,
-  the key will not be added when the list is empty.
+  the key will not be added when the list is empty. If the value is `nil`, it
+  will not be added.
   """
   @spec conditionally_add_to_map(%{atom() => any()}, key :: atom(), value :: nil | list()) :: %{
           atom() => any()
         }
   def conditionally_add_to_map(map, key, value)
 
+  def conditionally_add_to_map(map, _key, nil), do: map
+
   def conditionally_add_to_map(map, _key, []), do: map
 
-  def conditionally_add_to_map(map, key, value) when is_list(value) do
+  def conditionally_add_to_map(map, key, value) do
     Map.put(map, key, value)
   end
 

--- a/test/chains/data_extraction_chain_test.exs
+++ b/test/chains/data_extraction_chain_test.exs
@@ -20,8 +20,8 @@ defmodule LangChain.Chains.DataExtractionChainTest do
       required: []
     }
 
-    # Model setup
-    {:ok, chat} = ChatOpenAI.new(%{temperature: 0})
+    # Model setup - specify the model and seed
+    {:ok, chat} = ChatOpenAI.new(%{model: "gpt-4", temperature: 0, seed: 0})
 
     # run the chain, chain.run(prompt to extract data from)
     data_prompt =

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -126,7 +126,7 @@ defmodule LangChain.Chains.LLMChainTest do
 
       # We can construct an LLMChain from a PromptTemplate and an LLM.
       {:ok, updated_chain, response} =
-        %{llm: ChatOpenAI.new!(%{temperature: 1, stream: false}), verbose: true}
+        %{llm: ChatOpenAI.new!(%{temperature: 1, seed: 0, stream: false}), verbose: true}
         |> LLMChain.new!()
         |> LLMChain.apply_prompt_templates([prompt], %{product: "colorful socks"})
         |> LLMChain.run()
@@ -152,7 +152,7 @@ defmodule LangChain.Chains.LLMChainTest do
           send(self(), {:test_stream_message, message})
       end
 
-      model = ChatOpenAI.new!(%{temperature: 1, stream: true})
+      model = ChatOpenAI.new!(%{temperature: 1, seed: 0, stream: true})
 
       # We can construct an LLMChain from a PromptTemplate and an LLM.
       {:ok, updated_chain, response} =
@@ -459,7 +459,7 @@ defmodule LangChain.Chains.LLMChainTest do
       # create and run the chain
       {:ok, updated_chain, %Message{} = message} =
         LLMChain.new!(%{
-          llm: ChatOpenAI.new!(),
+          llm: ChatOpenAI.new!(%{seed: 0}),
           custom_context: custom_context,
           verbose: true
         })
@@ -482,7 +482,7 @@ defmodule LangChain.Chains.LLMChainTest do
       # create and run the chain
       {:error, reason} =
         LLMChain.new!(%{
-          llm: ChatOpenAI.new!(%{stream: false}),
+          llm: ChatOpenAI.new!(%{seed: 0, stream: false}),
           verbose: true
         })
         |> LLMChain.run()
@@ -495,7 +495,7 @@ defmodule LangChain.Chains.LLMChainTest do
       # create and run the chain
       {:error, reason} =
         LLMChain.new!(%{
-          llm: ChatOpenAI.new!(%{stream: true}),
+          llm: ChatOpenAI.new!(%{seed: 0, stream: true}),
           verbose: true
         })
         |> LLMChain.run()
@@ -538,7 +538,7 @@ defmodule LangChain.Chains.LLMChainTest do
 
       {:ok, _updated_chain, %Message{} = response} =
         LLMChain.new!(%{
-          llm: ChatOpenAI.new!(%{stream: false}),
+          llm: ChatOpenAI.new!(%{seed: 0, stream: false}),
           custom_context: nil,
           verbose: true
         })

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -69,7 +69,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       # set_fake_llm_response({:ok, Message.new_assistant("\n\nRainbow Sox Co.")})
 
       # https://js.langchain.com/docs/modules/models/chat/
-      {:ok, chat} = ChatOpenAI.new(%{temperature: 1})
+      {:ok, chat} = ChatOpenAI.new(%{temperature: 1, seed: 0})
 
       {:ok, [%Message{role: :assistant, content: response}]} =
         ChatOpenAI.call(chat, [
@@ -81,7 +81,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
 
     @tag :live_call
     test "executing a function", %{hello_world: hello_world} do
-      {:ok, chat} = ChatOpenAI.new(%{verbose: true})
+      {:ok, chat} = ChatOpenAI.new(%{seed: 0})
 
       {:ok, message} =
         Message.new_user("Only using the functions you have been provided with, give a greeting.")
@@ -100,13 +100,13 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       end
 
       # https://js.langchain.com/docs/modules/models/chat/
-      {:ok, chat} = ChatOpenAI.new(%{temperature: 1, stream: true})
+      {:ok, chat} = ChatOpenAI.new(%{seed: 0, temperature: 1, stream: true})
 
       {:ok, _post_results} =
         ChatOpenAI.call(
           chat,
           [
-            Message.new_user!("Return the response 'Hi'.")
+            Message.new_user!("Return the exact response 'Hi'.")
           ],
           [],
           callback
@@ -139,7 +139,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
 
       # https://js.langchain.com/docs/modules/models/chat/
       # NOTE streamed. Should receive complete message.
-      {:ok, chat} = ChatOpenAI.new(%{temperature: 1, stream: false})
+      {:ok, chat} = ChatOpenAI.new(%{seed: 0, temperature: 1, stream: false})
 
       {:ok, [message]} =
         ChatOpenAI.call(
@@ -162,7 +162,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
 
     @tag :live_call
     test "handles when request is too large" do
-      {:ok, chat} = ChatOpenAI.new(%{model: "gpt-3.5-turbo-0301", stream: false, temperature: 1})
+      {:ok, chat} = ChatOpenAI.new(%{model: "gpt-3.5-turbo-0301", seed: 0, stream: false, temperature: 1})
 
       {:error, reason} = ChatOpenAI.call(chat, [too_large_user_request()])
       assert reason =~ "maximum context length"
@@ -357,7 +357,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
         send(self(), {:streamed_fn, data})
       end
 
-      {:ok, chat} = ChatOpenAI.new(%{stream: true, verbose: true})
+      {:ok, chat} = ChatOpenAI.new(%{seed: 0, stream: true})
 
       {:ok, message} =
         Message.new_user("Answer the following math question: What is 100 + 300 - 200?")
@@ -375,7 +375,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
 
     @tag :live_call
     test "STREAMING handles receiving an error when no messages sent" do
-      chat = ChatOpenAI.new!(%{stream: true})
+      chat = ChatOpenAI.new!(%{seed: 0, stream: true})
 
       {:error, reason} = ChatOpenAI.call(chat, [], [], nil)
 
@@ -388,7 +388,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
         send(self(), {:streamed_fn, data})
       end
 
-      {:ok, chat} = ChatOpenAI.new(%{stream: true, receive_timeout: 50, verbose: true})
+      {:ok, chat} = ChatOpenAI.new(%{seed: 0, stream: true, receive_timeout: 50})
 
       {:error, reason} =
         ChatOpenAI.call(chat, [Message.new_user!("Why is the sky blue?")], [], callback)


### PR DESCRIPTION
- Fixed the live calculator test. Was broken.
- Added "seed" support for [OpenAI's Reproducible outputs](https://platform.openai.com/docs/guides/text-generation/reproducible-outputs). This reduces (doesn't guarantee) errors in `live_call` tests that run against ChatGPT because it would vary the output.