### PR TITLE
Add retry strategy to OpenAI Chat API requests

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -225,7 +225,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
         receive_timeout: openai.receive_timeout,
         retry: :transient,
         max_retries: 3,
-        retry_delay: fn attempt -> :timer.sleep(1000 * attempt) end
+        retry_delay: fn attempt -> :timer.sleep(300 * attempt) end
       )
 
     req

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -212,6 +212,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   #
   # Executes the callback function passing the response only parsed to the data
   # structures.
+  # Retries the request up to 3 times on transient errors with a 1 second delay
   @doc false
   @spec do_api_request(t(), [Message.t()], [Function.t()], (any() -> any())) ::
           list() | struct() | {:error, String.t()}
@@ -221,7 +222,10 @@ defmodule LangChain.ChatModels.ChatOpenAI do
         url: openai.endpoint,
         json: for_api(openai, messages, functions),
         auth: {:bearer, get_api_key()},
-        receive_timeout: openai.receive_timeout
+        receive_timeout: openai.receive_timeout,
+        retry: :transient,
+        max_retries: 3,
+        retry_delay: fn attempt -> :timer.sleep(1000 * attempt) end
       )
 
     req


### PR DESCRIPTION
[Due to the intermittent issues exposed by Finch disconnecting](https://github.com/brainlid/langchain/issues/42), this PR adds Req retry logic to API requests. 

Retries are attempted up to 3 times and trigger for all HTTP errors with a 1 second delay.

I figure a test wasn't required given the Req library tests this and I've just added in options to trigger it.
