### PR TITLE
Fix OpenAI returns "Unrecognized request argument supplied: api_key"

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -131,7 +131,6 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   def for_api(%ChatOpenAI{} = openai, messages, functions) do
     %{
       model: openai.model,
-      api_key: openai.api_key,
       temperature: openai.temperature,
       frequency_penalty: openai.frequency_penalty,
       n: openai.n,

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -56,7 +56,6 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert data.temperature == 1
       assert data.frequency_penalty == 0.5
       assert data.response_format == %{"type" => "text"}
-      assert data.api_key == "api_key"
     end
 
     test "generates a map for an API call with JSON response set to true" do


### PR DESCRIPTION
Hello guys! 

I was testing this lib, when I came across the error `Unrecognized request argument supplied: api_key` that ChatGPT than returned when execute the `LLMChain.run`

So I looked deeper into what the problem was and discovered that this line bellow:

```elixir
def for_api(%ChatOpenAI{} = openai, messages, functions) do
  %{
    model: openai.model,
    api_key: openai.api_key, # this line is not necessary, because this go into body request
    temperature: openai.temperature,
    frequency_penalty: openai.frequency_penalty,
    n: openai.n,
    stream: openai.stream,
    messages: Enum.map(messages, &ForOpenAIApi.for_api/1),
    response_format: set_response_format(openai)
  }
  |> Utils.conditionally_add_to_map(:seed, openai.seed)
  |> Utils.conditionally_add_to_map(:functions, get_functions_for_api(functions))
end
```
When I removed the line `api_key: openai.api_key` the response is success from ChatGTP.

**Error with api_key sended on body**:

```json
{
    "error": {
	"message": "Unrecognized request argument supplied: api_key",
	"type": "invalid_request_error",
	"param": null,
	"code": null
  }
}
```
After fix this, API returns sucess!

```json
{
	"id": "chatcmpl-8UkwsICWfiAusriGgaMCR9IH0SjZX",
	"object": "chat.completion",
	"created": 1702341002,
	"model": "gpt-4-0613",
	"choices": [
		{
			"index": 0,
			"message": {
				"role": "assistant",
				"content": "A palavra \"paralelepípedo\" tem 14 letras."
			},
			"finish_reason": "stop"
		}
	],
	"usage": {
		"prompt_tokens": 18,
		"completion_tokens": 14,
		"total_tokens": 32
	},
	"system_fingerprint": null
}
```
Sorry if I'm wrong