### PR TITLE
Fix Req retry delay

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -252,7 +252,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
         receive_timeout: openai.receive_timeout,
         retry: :transient,
         max_retries: 3,
-        retry_delay: fn attempt -> :timer.sleep(300 * attempt) end
+        retry_delay: fn attempt -> 300 * attempt end
       )
 
     req


### PR DESCRIPTION
:retry_delay function should return an integer however :timer.sleep sleeps for X and returns :ok. On Req main we raise a better error message.