### PR TITLE
Add support for Google AI / Gemini Pro model

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -1,0 +1,378 @@
+defmodule LangChain.ChatModels.ChatGoogleAI do
+  @moduledoc """
+  Parses and validates inputs for making a request for the Google AI  Chat API.
+
+  Converts response into more specialized `LangChain` data structures.
+  """
+  use Ecto.Schema
+  require Logger
+  import Ecto.Changeset
+  alias __MODULE__
+  alias LangChain.Config
+  alias LangChain.ChatModels.ChatModel
+  alias LangChain.Message
+  alias LangChain.LangChainError
+  alias LangChain.ForOpenAIApi
+  alias LangChain.Utils
+
+  @behaviour ChatModel
+
+  @default_base_url "https://generativelanguage.googleapis.com"
+  @default_api_version "v1beta"
+  @default_endpoint "#{@default_base_url}#{@default_api_version}"
+
+  # allow up to 2 minutes for response.
+  @receive_timeout 60_000
+
+  @primary_key false
+  embedded_schema do
+    field :endpoint, :string, default: @default_endpoint
+
+    # The version of the API to use.
+    field :version, :string, default: @default_api_version
+    field :model, :string, default: "gemini-pro"
+    field :api_key, :string
+
+    # What sampling temperature to use, between 0 and 2. Higher values like 0.8
+    # will make the output more random, while lower values like 0.2 will make it
+    # more focused and deterministic.
+    field :temperature, :float, default: 0.9
+
+    # The topP parameter changes how the model selects tokens for output. Tokens
+    # are selected from the most to least probable until the sum of their
+    # probabilities equals the topP value. For example, if tokens A, B, and C have
+    # a probability of 0.3, 0.2, and 0.1 and the topP value is 0.5, then the model
+    # will select either A or B as the next token by using the temperature and exclude
+    # C as a candidate. The default topP value is 0.95.
+    field :top_p, :float, default: 1.0
+
+    # The topK parameter changes how the model selects tokens for output. A topK of
+    # 1 means the selected token is the most probable among all the tokens in the
+    # model's vocabulary (also called greedy decoding), while a topK of 3 means that
+    # the next token is selected from among the 3 most probable using the temperature.
+    # For each token selection step, the topK tokens with the highest probabilities 
+    # are sampled. Tokens are then further filtered based on topP with the final token
+    # selected using temperature sampling.
+    field :top_k, :float, default: 1.0
+
+    # Duration in seconds for the response to be received. When streaming a very
+    # lengthy response, a longer time limit may be required. However, when it
+    # goes on too long by itself, it tends to hallucinate more.
+    field :receive_timeout, :integer, default: @receive_timeout
+
+    field :stream, :boolean, default: false
+  end
+
+  @type t :: %ChatGoogleAI{}
+
+  @create_fields [
+    :endpoint,
+    :model,
+    :api_key,
+    :temperature,
+    :top_p,
+    :top_k,
+    :receive_timeout,
+    :stream
+  ]
+  @required_fields [
+    :endpoint,
+    :version,
+    :model
+  ]
+
+  @spec get_api_key(t) :: String.t()
+  defp get_api_key(%ChatGoogleAI{api_key: api_key}) do
+    # if no API key is set default to `""` which will raise an API error
+    api_key || Config.resolve(:google_ai_key, "")
+  end
+
+  @doc """
+  Setup a ChatGoogleAI client configuration.
+  """
+  @spec new(attrs :: map()) :: {:ok, t} | {:error, Ecto.Changeset.t()}
+  def new(%{} = attrs \\ %{}) do
+    %ChatGoogleAI{}
+    |> cast(attrs, @create_fields)
+    |> common_validation()
+    |> apply_action(:insert)
+  end
+
+  @doc """
+  Setup a ChatGoogleAI client configuration and return it or raise an error if invalid.
+  """
+  @spec new!(attrs :: map()) :: t() | no_return()
+  def new!(attrs \\ %{}) do
+    case new(attrs) do
+      {:ok, chain} ->
+        chain
+
+      {:error, changeset} ->
+        raise LangChainError, changeset
+    end
+  end
+
+  defp common_validation(changeset) do
+    changeset
+    |> validate_required(@required_fields)
+  end
+
+  def for_api(%ChatGoogleAI{} = google_ai, messages, functions) do
+    req = %{
+      "contents" =>
+        Stream.map(messages, &for_api/1)
+        |> Enum.flat_map(fn
+          list when is_list(list) -> list
+          not_list -> [not_list]
+        end),
+      "generationConfig" => %{
+        "temperature" => google_ai.temperature,
+        "topP" => google_ai.top_p,
+        "topK" => google_ai.top_k
+      }
+    }
+
+    if functions && not Enum.empty?(functions) do
+      req
+      |> Map.put("tools", [
+        %{
+          # Google AI functions use an OpenAI compatible format.
+          # See: https://ai.google.dev/docs/function_calling#how_it_works
+          "functionDeclarations" => Enum.map(functions, &ForOpenAIApi.for_api/1)
+        }
+      ])
+    end
+  end
+
+  defp for_api(%Message{role: :assistant, function_name: fun_name} = fun)
+       when is_binary(fun_name) do
+    %{
+      "role" => map_role(:assistant),
+      "parts" => [
+        %{
+          "functionCall" => %{
+            "name" => fun_name,
+            "args" => fun.arguments
+          }
+        }
+      ]
+    }
+  end
+
+  defp for_api(%Message{role: :function} = message) do
+    %{
+      "role" => map_role(:function),
+      "parts" => [
+        %{
+          "functionResponse" => %{
+            "name" => message.function_name,
+            "response" => message.function_response
+          }
+        }
+      ]
+    }
+  end
+
+  defp for_api(%Message{role: :system} = message) do
+    # No system messages support means we need to fake a prompt and response
+    # to pretend like it worked.
+    [
+      %{
+        "role" => :user,
+        "parts" => [%{"text" => message.content}]
+      },
+      %{
+        "role" => :model,
+        "parts" => [%{"text" => ""}]
+      }
+    ]
+  end
+
+  defp for_api(%Message{} = message) do
+    %{
+      "role" => map_role(message.role),
+      "parts" => [%{"text" => message.content}]
+    }
+  end
+
+  defp map_role(role) do
+    case role do
+      :assistant -> :model
+      # System prompts are not supported yet. Google recommends using user prompt.
+      :system -> :user
+      role -> role
+    end
+  end
+
+  @doc """
+  Calls the Google AI API passing the ChatGoogleAI struct with configuration, plus
+  either a simple message or the list of messages to act as the prompt.
+
+  Optionally pass in a list of functions available to the LLM for requesting
+  execution in response.
+
+  Optionally pass in a callback function that can be executed as data is
+  received from the API.
+
+  **NOTE:** This function *can* be used directly, but the primary interface
+  should be through `LangChain.Chains.LLMChain`. The `ChatGoogleAI` module is more focused on
+  translating the `LangChain` data structures to and from the OpenAI API.
+
+  Another benefit of using `LangChain.Chains.LLMChain` is that it combines the
+  storage of messages, adding functions, adding custom context that should be
+  passed to functions, and automatically applying `LangChain.MessageDelta`
+  structs as they are are received, then converting those to the full
+  `LangChain.Message` once fully complete.
+  """
+  @impl ChatModel
+  def call(openai, prompt, functions \\ [], callback_fn \\ nil)
+
+  def call(%ChatGoogleAI{} = google_ai, prompt, functions, callback_fn) when is_binary(prompt) do
+    messages = [
+      Message.new_system!(),
+      Message.new_user!(prompt)
+    ]
+
+    call(google_ai, messages, functions, callback_fn)
+  end
+
+  def call(%ChatGoogleAI{} = google_ai, messages, functions, callback_fn)
+      when is_list(messages) do
+    try do
+      case do_api_request(google_ai, messages, functions, callback_fn) do
+        {:error, reason} ->
+          {:error, reason}
+
+        parsed_data ->
+          {:ok, parsed_data}
+      end
+    rescue
+      err in LangChainError ->
+        {:error, err.message}
+    end
+  end
+
+  @doc false
+  @spec do_api_request(t(), [Message.t()], [Function.t()], (any() -> any())) ::
+          list() | struct() | {:error, String.t()}
+  def do_api_request(%ChatGoogleAI{stream: false} = google_ai, messages, functions, callback_fn) do
+    req =
+      Req.new(
+        url: build_url(google_ai),
+        json: for_api(google_ai, messages, functions),
+        receive_timeout: google_ai.receive_timeout,
+        retry: :transient,
+        max_retries: 3,
+        retry_delay: fn attempt -> 300 * attempt end
+      )
+
+    req
+    |> Req.post()
+    |> case do
+      {:ok, %Req.Response{body: data}} ->
+        case do_process_response(data) do
+          {:error, reason} ->
+            {:error, reason}
+
+          result ->
+            Utils.fire_callback(google_ai, result, callback_fn)
+            result
+        end
+
+      {:error, %Mint.TransportError{reason: :timeout}} ->
+        {:error, "Request timed out"}
+
+      other ->
+        Logger.error("Unexpected and unhandled API response! #{inspect(other)}")
+        other
+    end
+  end
+
+  @spec build_url(t()) :: String.t()
+  defp build_url(%ChatGoogleAI{endpoint: endpoint, version: version, model: model} = google_ai) do
+    "#{endpoint}/#{version}/models/#{model}:#{get_action(google_ai)}?key=#{get_api_key(google_ai)}"
+  end
+
+  @spec get_action(t()) :: String.t()
+  defp get_action(%ChatGoogleAI{stream: false}), do: "generateContent"
+  defp get_action(%ChatGoogleAI{stream: true}), do: "streamGenerateContent"
+
+  def do_process_response(%{"candidates" => candidates}) when is_list(candidates) do
+    candidates
+    |> Enum.map(&do_process_response/1)
+  end
+
+  def do_process_response(
+        %{
+          "content" => %{"parts" => [%{"functionCall" => %{"args" => raw_args, "name" => name}}]}
+        } = data
+      ) do
+    case Message.new(%{
+           "role" => "assistant",
+           "function_name" => name,
+           "arguments" => raw_args,
+           "complete" => true,
+           "index" => data["index"]
+         }) do
+      {:ok, message} ->
+        message
+
+      {:error, changeset} ->
+        {:error, Utils.changeset_error_to_string(changeset)}
+    end
+  end
+
+  def do_process_response(%{
+        "finishReason" => finish,
+        "content" => %{"parts" => parts, "role" => role},
+        "index" => index
+      })
+      when is_list(parts) do
+    status =
+      case finish do
+        "STOP" ->
+          :complete
+
+        "LENGTH" ->
+          :length
+
+        other ->
+          Logger.warning("Unsupported finishReason in response. Reason: #{inspect(other)}")
+          nil
+      end
+
+    content = Enum.map_join(parts, & &1["text"])
+
+    case Message.new(%{
+           "content" => content,
+           "role" => unmap_role(role),
+           "status" => status,
+           "index" => index
+         }) do
+      {:ok, message} ->
+        message
+
+      {:error, changeset} ->
+        {:error, Utils.changeset_error_to_string(changeset)}
+    end
+  end
+
+  def do_process_response(%{"error" => %{"message" => reason}}) do
+    Logger.error("Received error from API: #{inspect(reason)}")
+    {:error, reason}
+  end
+
+  def do_process_response({:error, %Jason.DecodeError{} = response}) do
+    error_message = "Received invalid JSON: #{inspect(response)}"
+    Logger.error(error_message)
+    {:error, error_message}
+  end
+
+  def do_process_response(other) do
+    Logger.error("Trying to process an unexpected response. #{inspect(other)}")
+    {:error, "Unexpected response"}
+  end
+
+  defp unmap_role("model"), do: "assistant"
+  defp unmap_role(role), do: role
+end

--- a/lib/chat_models/chat_model.ex
+++ b/lib/chat_models/chat_model.ex
@@ -1,0 +1,12 @@
+defmodule LangChain.ChatModels.ChatModel do
+  @type call_response :: {:ok, Message.t() | [Message.t()]} | {:error, String.t()}
+
+  @type t :: Ecto.Schema.t()
+
+  @callback call(
+              t(),
+              String.t() | [Message.t()],
+              [LangChain.Function.t()],
+              nil | (Message.t() | MessageDelta.t() -> any())
+            ) :: call_response()
+end

--- a/lib/message.ex
+++ b/lib/message.ex
@@ -47,13 +47,14 @@ defmodule LangChain.Message do
       default: :user
 
     field :function_name, :string
+    field :function_response, :any, virtual: true
     field :arguments, :any, virtual: true
   end
 
   @type t :: %Message{}
   @type status :: :complete | :cancelled | :length
 
-  @create_fields [:role, :content, :status, :function_name, :arguments, :index]
+  @create_fields [:role, :content, :status, :function_name, :function_response, :arguments, :index]
   @required_fields [:role]
 
   @doc """
@@ -283,7 +284,7 @@ defmodule LangChain.Message do
   @spec new_function(name :: String.t(), result :: any()) ::
           {:ok, t()} | {:error, Ecto.Changeset.t()}
   def new_function(name, result) do
-    new(%{role: :function, function_name: name, content: result})
+    new(%{role: :function, function_name: name, function_response: result})
   end
 
   @doc """
@@ -330,7 +331,7 @@ defimpl LangChain.ForOpenAIApi, for: LangChain.Message do
     %{
       "role" => :function,
       "name" => fun.function_name,
-      "content" => fun.content
+      "content" => Jason.encode!(fun.function_response)
     }
   end
 

--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -44,7 +44,7 @@ defmodule LangChain.MessageDelta do
 
     field :role, Ecto.Enum, values: [:unknown, :assistant], default: :unknown
 
-    field :arguments, :string
+    field :arguments, :any, virtual: true
   end
 
   @type t :: %MessageDelta{}

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -4,6 +4,7 @@ defmodule LangChain.Utils do
   """
   alias Ecto.Changeset
   require Logger
+  alias LangChain.LangChainError
 
   @doc """
   Only add the key to the map if the value is present. When the value is a list,
@@ -109,5 +110,112 @@ defmodule LangChain.Utils do
     |> Enum.each(fn item -> callback_fn.(item) end)
 
     :ok
+  end
+
+  @doc """
+  Create a function to handle the Finch streaming request. 
+  """
+  @spec finch_stream_fn(
+          %{optional(:stream) => boolean()},
+          process_response_fn :: function(),
+          callback_fn :: function()
+        ) :: function()
+  def finch_stream_fn(model, process_response_fn, callback_fn) do
+    fn request, finch_request, finch_name, finch_options ->
+      resp_fun = fn
+        {:status, status}, response ->
+          %{response | status: status}
+
+        {:headers, headers}, response ->
+          %{response | headers: headers}
+
+        {:data, raw_data}, response ->
+          # cleanup data because it isn't structured well for JSON.
+          new_data = decode_streamed_data(raw_data, process_response_fn)
+          # execute the callback function for each MessageDelta
+          fire_callback(model, new_data, callback_fn)
+          old_body = if response.body == "", do: [], else: response.body
+
+          # Returns %Req.Response{} where the body contains ALL the stream delta
+          # chunks converted to MessageDelta structs. The body is a list of lists like this...
+          #
+          # body: [
+          #         [
+          #           %LangChain.MessageDelta{
+          #             content: nil,
+          #             index: 0,
+          #             function_name: nil,
+          #             role: :assistant,
+          #             arguments: nil,
+          #             complete: false
+          #           }
+          #         ],
+          #         ...
+          #       ]
+          #
+          # The reason for the inner list is for each entry in the "n" choices. By default only 1.
+          %{response | body: old_body ++ new_data}
+      end
+
+      case Finch.stream(finch_request, finch_name, Req.Response.new(), resp_fun, finch_options) do
+        {:ok, response} ->
+          {request, response}
+
+        {:error, %Mint.TransportError{reason: :timeout}} ->
+          {request, LangChainError.exception("Request timed out")}
+
+        {:error, exception} ->
+          Logger.error("Failed request to API: #{inspect(exception)}")
+          {request, exception}
+      end
+    end
+  end
+
+  defp decode_streamed_data(data, process_response_fn) do
+    # Data comes back like this:
+    #
+    # "data: {\"id\":\"chatcmpl-7e8yp1xBhriNXiqqZ0xJkgNrmMuGS\",\"object\":\"chat.completion.chunk\",\"created\":1689801995,\"model\":\"gpt-4-0613\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":null,\"function_call\":{\"name\":\"calculator\",\"arguments\":\"\"}},\"finish_reason\":null}]}\n\n
+    #  data: {\"id\":\"chatcmpl-7e8yp1xBhriNXiqqZ0xJkgNrmMuGS\",\"object\":\"chat.completion.chunk\",\"created\":1689801995,\"model\":\"gpt-4-0613\",\"choices\":[{\"index\":0,\"delta\":{\"function_call\":{\"arguments\":\"{\\n\"}},\"finish_reason\":null}]}\n\n"
+    #
+    # In that form, the data is not ready to be interpreted as JSON. Let's clean
+    # it up first.
+
+    data
+    |> String.split("data: ")
+    |> Enum.map(fn str ->
+      str
+      |> String.trim()
+      |> case do
+        "" ->
+          :empty
+
+        "[DONE]" ->
+          :empty
+
+        json ->
+          json
+          |> Jason.decode()
+          |> case do
+            {:ok, parsed} ->
+              parsed
+
+            {:error, reason} ->
+              {:error, reason}
+          end
+          |> process_response_fn.()
+      end
+    end)
+    # returning a list of elements. "junk" elements were replaced with `:empty`.
+    # Filter those out down and return the final list of MessageDelta structs.
+    |> Enum.filter(fn d -> d != :empty end)
+    # if there was a single error returned in a list, flatten it out to just
+    # return the error
+    |> case do
+      [{:error, reason}] ->
+        raise LangChainError, reason
+
+      other ->
+        other
+    end
   end
 end

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -1,0 +1,307 @@
+defmodule ChatModels.ChatGoogleAITest do
+  alias LangChain.ChatModels.ChatGoogleAI
+  use LangChain.BaseCase
+  import LangChain.Fixtures
+
+  doctest LangChain.ChatModels.ChatGoogleAI
+  alias LangChain.ChatModels.ChatGoogleAI
+  alias LangChain.Message
+  alias LangChain.MessageDelta
+  alias LangChain.Function
+
+  setup do
+    {:ok, hello_world} =
+      Function.new(%{
+        name: "hello_world",
+        description: "Give a hello world greeting.",
+        function: fn -> IO.puts("Hello world!") end
+      })
+
+    %{hello_world: hello_world}
+  end
+
+  describe "new/1" do
+    test "works with minimal attr" do
+      assert {:ok, %ChatGoogleAI{} = google_ai} = ChatGoogleAI.new(%{"model" => "gemini-pro"})
+      assert google_ai.model == "gemini-pro"
+    end
+
+    test "returns error when invalid" do
+      assert {:error, changeset} = ChatGoogleAI.new(%{"model" => nil})
+      refute changeset.valid?
+      assert {"can't be blank", _} = changeset.errors[:model]
+    end
+
+    test "supports overriding the API endpoint" do
+      override_url = "http://localhost:1234/"
+
+      model =
+        ChatGoogleAI.new!(%{
+          endpoint: override_url
+        })
+
+      assert model.endpoint == override_url
+    end
+
+    test "supports overriding the API version" do
+      version = "v1"
+
+      model =
+        ChatGoogleAI.new!(%{
+          version: version
+        })
+
+      assert model.version == version
+    end
+  end
+
+  describe "for_api/3" do
+    setup do
+      {:ok, google_ai} =
+        ChatGoogleAI.new(%{
+          "model" => "gemini-pro",
+          "temperature" => 1.0,
+          "top_p" => 1.0,
+          "top_k" => 1.0
+        })
+
+      %{google_ai: google_ai}
+    end
+
+    test "generates a map for an API call", %{google_ai: google_ai} do
+      data = ChatGoogleAI.for_api(google_ai, [], [])
+      assert data["contents"] == []
+      assert data["generationConfig"]["temperature"] == 1.0
+      assert data["generationConfig"]["topP"] == 1.0
+      assert data["generationConfig"]["topK"] == 1.0
+    end
+
+    test "generates a map containing user and assistant messages", %{google_ai: google_ai} do
+      user_message = "Hello Assistant!"
+      assistant_message = "Hello User!"
+
+      data =
+        ChatGoogleAI.for_api(
+          google_ai,
+          [Message.new_user!(user_message), Message.new_assistant!(assistant_message)],
+          []
+        )
+
+      assert get_in(data, ["contents", Access.at(0), "role"]) == :user
+
+      assert get_in(data, ["contents", Access.at(0), "parts", Access.at(0), "text"]) ==
+               user_message
+
+      assert get_in(data, ["contents", Access.at(1), "role"]) == :model
+
+      assert get_in(data, ["contents", Access.at(1), "parts", Access.at(0), "text"]) ==
+               assistant_message
+    end
+
+    test "generates a map containing function and function call messages", %{google_ai: google_ai} do
+      message = "Can you do an action for me?"
+      arguments = %{"args" => "data"}
+      function_result = %{"result" => "data"}
+
+      data =
+        ChatGoogleAI.for_api(
+          google_ai,
+          [
+            Message.new_user!(message),
+            Message.new_function_call!("userland_action", Jason.encode!(arguments)),
+            Message.new_function!("userland_action", function_result)
+          ],
+          []
+        )
+
+      assert get_in(data, ["contents", Access.at(0), "role"]) == :user
+
+      assert get_in(data, ["contents", Access.at(0), "parts", Access.at(0), "text"]) ==
+               message
+
+      assert get_in(data, ["contents", Access.at(1), "role"]) == :model
+
+      assert get_in(data, [
+               "contents",
+               Access.at(1),
+               "parts",
+               Access.at(0),
+               "functionCall",
+               "name"
+             ]) == "userland_action"
+
+      assert get_in(data, [
+               "contents",
+               Access.at(1),
+               "parts",
+               Access.at(0),
+               "functionCall",
+               "args"
+             ]) == arguments
+
+      assert get_in(data, ["contents", Access.at(2), "role"]) == :function
+
+      assert get_in(data, [
+               "contents",
+               Access.at(2),
+               "parts",
+               Access.at(0),
+               "functionResponse",
+               "name"
+             ]) == "userland_action"
+
+      assert get_in(data, [
+               "contents",
+               Access.at(2),
+               "parts",
+               Access.at(0),
+               "functionResponse",
+               "response"
+             ]) == function_result
+    end
+
+    test "expands system messages into two", %{google_ai: google_ai} do
+      message = "These are some instructions."
+
+      data = ChatGoogleAI.for_api(google_ai, [Message.new_system!(message)], [])
+      assert get_in(data, ["contents", Access.at(0), "role"]) == :user
+
+      assert get_in(data, ["contents", Access.at(0), "parts", Access.at(0), "text"]) ==
+               message
+
+      assert get_in(data, ["contents", Access.at(1), "role"]) == :model
+
+      assert get_in(data, ["contents", Access.at(1), "parts", Access.at(0), "text"]) == ""
+    end
+
+    test "generates a map containing function declarations", %{
+      google_ai: google_ai,
+      hello_world: hello_world
+    } do
+      data = ChatGoogleAI.for_api(google_ai, [], [hello_world])
+      assert data["contents"] == []
+
+      assert get_in(data, [
+               "tools",
+               Access.at(0),
+               "functionDeclarations",
+               Access.at(0),
+               "name"
+             ]) ==
+               "hello_world"
+
+      assert get_in(data, [
+               "tools",
+               Access.at(0),
+               "functionDeclarations",
+               Access.at(0),
+               "description"
+             ]) ==
+               "Give a hello world greeting."
+    end
+  end
+
+  describe "do_process_response/2" do
+    test "handles receiving a message" do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{"role" => "model", "parts" => [%{"text" => "Hello User!"}]},
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ]
+      }
+
+      assert [%Message{} = struct] = ChatGoogleAI.do_process_response(response)
+      assert struct.role == :assistant
+      assert struct.content == "Hello User!"
+      assert struct.index == 0
+      assert struct.status == :complete
+    end
+
+    test "error if receiving non-text content" do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{"role" => "bad_role", "parts" => [%{"text" => "Hello user"}]},
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ]
+      }
+
+      assert [{:error, error_string}] = ChatGoogleAI.do_process_response(response)
+      assert error_string == "role: is invalid"
+    end
+
+    test "handles receiving function calls" do
+      args = %{"args" => "data"}
+
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "role" => "model",
+              "parts" => [%{"functionCall" => %{"args" => args, "name" => "hello_world"}}]
+            },
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ]
+      }
+
+      assert [%Message{} = struct] = ChatGoogleAI.do_process_response(response)
+      assert struct.role == :assistant
+      assert struct.index == 0
+      assert struct.function_name == "hello_world"
+      assert struct.arguments == args
+    end
+
+    test "handles receiving MessageDeltas as well" do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "role" => "model",
+              "parts" => [%{"text" => "This is the first part of a mes"}]
+            },
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ]
+      }
+
+      assert [%MessageDelta{} = struct] = ChatGoogleAI.do_process_response(response, MessageDelta)
+      assert struct.role == :assistant
+      assert struct.content == "This is the first part of a mes"
+      assert struct.index == 0
+      assert struct.status == :incomplete
+    end
+
+    test "handles API error messages" do
+      response = %{
+        "error" => %{
+          "code" => 400,
+          "message" => "Invalid request",
+          "status" => "INVALID_ARGUMENT"
+        }
+      }
+
+      assert {:error, error_string} = ChatGoogleAI.do_process_response(response)
+      assert error_string == "Invalid request"
+    end
+
+    test "handles Jason.DecodeError" do
+      response = {:error, %Jason.DecodeError{}}
+
+      assert {:error, error_string} = ChatGoogleAI.do_process_response(response)
+      assert "Received invalid JSON:" <> _ = error_string
+    end
+
+    test "handles unexpected response with error" do
+      response = %{}
+      assert {:error, "Unexpected response"} = ChatGoogleAI.do_process_response(response)
+    end
+  end
+end

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -1,7 +1,6 @@
 defmodule ChatModels.ChatGoogleAITest do
   alias LangChain.ChatModels.ChatGoogleAI
   use LangChain.BaseCase
-  import LangChain.Fixtures
 
   doctest LangChain.ChatModels.ChatGoogleAI
   alias LangChain.ChatModels.ChatGoogleAI


### PR DESCRIPTION
## Summary

This PR adds a `ChatGoogleAI` model that wraps interactions with the [Google AI Rest APIs](https://ai.google.dev/tutorials/rest_quickstart#multi-turn_conversations_chat) for the purposes of integrating with langchain, thus closing #6.

This change supports the full set of Gemini Pro features, including non-streamed responses, streamed responses and function calling.

## Details

### Differences with OpenAI

- Google uses the `"model"` role instead of `"assistant`"
- Streaming chunks have an identical schema to single-shot messages. This allowed a lot of reuse of the message parsing code for both Messages and MessageDeltas.
- I implemented the `for_api/` behaviour using plain old pattern matching. The protocol appoach seems a little roundabout. 

### Quirks

- Google AI doesn't support system prompts at the moment. I asked in the Google Discord server and was told this is a known issue and big ask, but the best thing to do in the meantime is simulate a system message with a user message. This would be great, but the API validates that all user messages in a multi-turn conversation are followed by model message. The way around this is to expand system messages into a user message and shim model message. This is non-ideal and hopefully system prompt support is added soon.
- Streaming text chunks in the SSE format requires the `alt=sse` query param added to the url. This is undocumented, but i noticed it being used in the [official SDKs](https://github.com/google/generative-ai-js).
- Google users `finishReason: "STOP"` for basically everything, including message deltas. This doesn't jive well with some of the existing logic for tracking when e.g. streaming deltas completes. This behaviour is faked in the `ChatGoogleAI` module.