### PR TITLE
Cleanup non-api test warning output

### DIFF
--- a/test/prompt_template_test.exs
+++ b/test/prompt_template_test.exs
@@ -5,6 +5,8 @@ defmodule LangChain.PromptTemplateTest do
   alias LangChain.LangChainError
   alias LangChain.Message
 
+  import ExUnit.CaptureIO
+
   describe "new/1" do
     test "create with text and no inputs" do
       {:ok, %PromptTemplate{} = p} = PromptTemplate.new(%{text: "text"})
@@ -112,7 +114,9 @@ defmodule LangChain.PromptTemplateTest do
     end
 
     test "returns substitutions removed when replacement missing" do
-      result = PromptTemplate.format_text("This is <%= @missing %>", %{other: "something"})
+      {result, _} = with_io(:standard_error, fn ->
+        PromptTemplate.format_text("This is <%= @missing %>", %{other: "something"})
+      end)
       assert result == "This is "
     end
   end

--- a/test/tools/calculator_test.exs
+++ b/test/tools/calculator_test.exs
@@ -7,6 +7,8 @@ defmodule LangChain.Tools.CalculatorTest do
   alias LangChain.Function
   alias LangChain.ChatModels.ChatOpenAI
 
+  import ExUnit.CaptureIO
+
   describe "new/0" do
     test "defines the function correctly" do
       assert {:ok, %Function{} = function} = Calculator.new()
@@ -41,7 +43,10 @@ defmodule LangChain.Tools.CalculatorTest do
     end
 
     test "returns an error when evaluation fails" do
-      assert "ERROR" == Calculator.execute(%{"expression" => "cow + dog"}, nil)
+      {result, _} = with_io(:standard_error, fn ->
+        Calculator.execute(%{"expression" => "cow + dog"}, nil)
+      end)
+      assert "ERROR" == result
     end
   end
 


### PR DESCRIPTION
* Uses `with_io` to capture warning output