### PR TITLE
Add clause to match call_response spec

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -223,6 +223,10 @@ defmodule LangChain.Chains.LLMChain do
         if chain.verbose, do: IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
         {:ok, updated_chain}
 
+      {:ok, %Message{} = message} ->
+        if chain.verbose, do: IO.inspect(message, label: "SINGLE MESSAGE RESPONSE NO WRAPPED ARRAY")
+        {:ok, add_message(chain, message)}
+
       {:error, reason} ->
         if chain.verbose, do: IO.inspect(reason, label: "ERROR")
         Logger.error("Error during chat call. Reason: #{inspect(reason)}")


### PR DESCRIPTION
Adds a clause to match an `{:ok, Message.t()}` payload according to the [spec for the call function](https://github.com/brainlid/langchain/blob/main/lib/chat_models/chat_model.ex#L2)

Addresses #71 