### PR TITLE
Add max_tokens option for OpenAI calls

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -59,6 +59,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     field :n, :integer, default: 1
     field :json_response, :boolean, default: false
     field :stream, :boolean, default: false
+    field :max_tokens, :integer, default: nil
   end
 
   @type t :: %ChatOpenAI{}
@@ -73,7 +74,8 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     :n,
     :stream,
     :receive_timeout,
-    :json_response
+    :json_response,
+    :max_tokens
   ]
   @required_fields [:endpoint, :model]
 
@@ -136,6 +138,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       messages: Enum.map(messages, &ForOpenAIApi.for_api/1),
       response_format: set_response_format(openai)
     }
+    |> Utils.conditionally_add_to_map(:max_tokens, openai.max_tokens)
     |> Utils.conditionally_add_to_map(:seed, openai.seed)
     |> Utils.conditionally_add_to_map(:functions, get_functions_for_api(functions))
   end

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -73,6 +73,22 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert data.frequency_penalty == 0.5
       assert data.response_format == %{"type" => "json_object"}
     end
+
+    test "generates a map for an API call with max_tokens set" do
+      {:ok, openai} =
+        ChatOpenAI.new(%{
+          "model" => "gpt-3.5-turbo-0613",
+          "temperature" => 1,
+          "frequency_penalty" => 0.5,
+          "max_tokens" => 1234
+        })
+
+      data = ChatOpenAI.for_api(openai, [], [])
+      assert data.model == "gpt-3.5-turbo-0613"
+      assert data.temperature == 1
+      assert data.frequency_penalty == 0.5
+      assert data.max_tokens == 1234
+    end
   end
 
   describe "call/2" do


### PR DESCRIPTION
One of the optional fields that the OpenAI Api allows for in chat completions is `max_tokens`.

https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens