### PR TITLE
[BUG][GOOGLEAI] : Invalid default url for google ai

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -20,7 +20,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
 
   @default_base_url "https://generativelanguage.googleapis.com"
   @default_api_version "v1beta"
-  @default_endpoint "#{@default_base_url}#{@default_api_version}"
+  @default_endpoint "#{@default_base_url}/#{@default_api_version}"
 
   # allow up to 2 minutes for response.
   @receive_timeout 60_000


### PR DESCRIPTION
![image](https://github.com/brainlid/langchain/assets/3807725/62a505e4-e78c-40ad-a6de-41ec87197d5b)
![image](https://github.com/brainlid/langchain/assets/3807725/077a752f-34ba-4907-a1c7-a28d85ca1279)
