### PR TITLE
update Utils.fire_callback for Anthropic support

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -368,7 +368,6 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     }
     |> Message.new()
     |> to_response()
-    |> List.wrap()
   end
 
   def do_process_response(%{

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -103,11 +103,19 @@ defmodule LangChain.Utils do
 
   def fire_callback(_model, _data, nil), do: :ok
 
-  def fire_callback(_model, data, callback_fn) when is_function(callback_fn) do
+  # fire a set of callbacks when receiving a list
+  def fire_callback(_model, data, callback_fn) when is_list(data) and is_function(callback_fn) do
     # OPTIONAL: Execute callback function
     data
     |> List.flatten()
     |> Enum.each(fn item -> callback_fn.(item) end)
+
+    :ok
+  end
+
+  def fire_callback(_model, data, callback_fn) when is_struct(data) and is_function(callback_fn) do
+    # OPTIONAL: Execute callback function
+    callback_fn.(data)
 
     :ok
   end

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -413,26 +413,42 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
   describe "works within a chain" do
     @tag live_call: true, live_anthropic: true
     test "works with a streaming response" do
+      callback_fn = fn data ->
+        # IO.inspect(data, label: "DATA")
+        send(self(), {:streamed_fn, data})
+      end
+
       {:ok, _result_chain, last_message} =
         LLMChain.new!(%{llm: %ChatAnthropic{stream: true}})
         |> LLMChain.add_message(Message.new_user!("Say, 'Hi!'!"))
-        |> LLMChain.run()
+        |> LLMChain.run(callback_fn: callback_fn)
 
       assert last_message.content == "Hi!"
       assert last_message.status == :complete
       assert last_message.role == :assistant
+
+      assert_received {:streamed_fn, data}
+      assert %MessageDelta{role: :assistant} = data
     end
 
     @tag live_call: true, live_anthropic: true
     test "works with NON streaming response" do
+      callback_fn = fn data ->
+        # IO.inspect(data, label: "DATA")
+        send(self(), {:streamed_fn, data})
+      end
+
       {:ok, _result_chain, last_message} =
         LLMChain.new!(%{llm: %ChatAnthropic{stream: false}})
         |> LLMChain.add_message(Message.new_user!("Say, 'Hi!'!"))
-        |> LLMChain.run()
+        |> LLMChain.run(callback_fn: callback_fn)
 
       assert last_message.content == "Hi!"
       assert last_message.status == :complete
       assert last_message.role == :assistant
+
+      assert_received {:streamed_fn, data}
+      assert %Message{role: :assistant} = data
     end
   end
 end


### PR DESCRIPTION
- allow for a single message. Don't assume a list.
- added live full-stack tests to Anthropic