### PR TITLE
Updates for ContentPart images with messages to support ChatGPT's "detail" level option

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -141,7 +141,8 @@ defmodule LangChain.Chains.LLMChain do
   ## Options
 
   - `:while_needs_response` - repeatedly evaluates functions and submits to the
-    LLM so long as we still expect to get a response.
+    LLM so long as we still expect to get a response. Best fit for
+    conversational LLMs where a `ToolResult` is used by the LLM to continue.
   - `:callback_fn` - the callback function to execute as messages are received.
 
   The `callback_fn` is a function that receives one argument. It is the

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -654,11 +654,17 @@ defmodule LangChain.ChatModels.ChatAnthropic do
         :png ->
           "image/png"
 
+        :gif ->
+          "image/gif"
+
         :jpg ->
           "image/jpeg"
 
         :jpeg ->
           "image/jpeg"
+
+        :webp ->
+          "image/webp"
 
         value when is_binary(value) ->
           value

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -253,6 +253,12 @@ defmodule LangChain.ChatModels.ChatOpenAI do
         :png ->
           "data:image/png;base64,"
 
+        :gif ->
+          "data:image/gif;base64,"
+
+        :webp ->
+          "data:image/webp;base64,"
+
         other ->
           message = "Received unsupported media type for ContentPart: #{inspect(other)}"
           Logger.error(message)

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -265,7 +265,14 @@ defmodule LangChain.ChatModels.ChatOpenAI do
           raise LangChainError, message
       end
 
-    %{"type" => "image_url", "image_url" => %{"url" => media_prefix <> part.content}}
+    detail_option = Keyword.get(part.options, :detail, nil)
+
+    %{
+      "type" => "image_url",
+      "image_url" =>
+        %{"url" => media_prefix <> part.content}
+        |> Utils.conditionally_add_to_map("detail", detail_option)
+    }
   end
 
   # ToolCall support

--- a/lib/message/content_part.ex
+++ b/lib/message/content_part.ex
@@ -101,6 +101,11 @@ defmodule LangChain.Message.ContentPart do
 
   - `:media` - Provide the "media type" for the image. Examples: "image/jpeg",
     "image/png", etc. ChatGPT does not require this but other LLMs may.
+  - `:detail` - if the LLM supports it, most images must be resized or cropped
+    before given to the LLM for analysis. A detail option may specify the level
+    detail of the image to present to the LLM. The higher the detail, the more
+    tokens consumed. Currently only supported by OpenAI and the values of "low",
+    "high", and "auto".
 
   ChatGPT requires media type information to prefix the base64 content. Setting
   the `media: "image/jpeg"` type will do that. Otherwise the data must be
@@ -118,9 +123,9 @@ defmodule LangChain.Message.ContentPart do
   @doc """
   Create a new ContentPart that contains a URL to an image. Raises an exception if not valid.
   """
-  @spec image_url!(String.t()) :: t() | no_return()
-  def image_url!(content) do
-    new!(%{type: :image_url, content: content})
+  @spec image_url!(String.t(), Keyword.t()) :: t() | no_return()
+  def image_url!(content, opts \\ []) do
+    new!(%{type: :image_url, content: content, options: opts})
   end
 
   @doc false

--- a/lib/message/tool_call.ex
+++ b/lib/message/tool_call.ex
@@ -2,6 +2,15 @@ defmodule LangChain.Message.ToolCall do
   @moduledoc """
   Represents an LLM's request to use tool. It specifies the tool to execute and
   may provide arguments for the tool to use.
+
+  ## Example
+
+      ToolCall.new!(%{
+        call_id: "call_123",
+        name: "give_greeting"
+        arguments: %{"name" => "Howard"}
+      })
+
   """
   use Ecto.Schema
   import Ecto.Changeset

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -186,6 +186,14 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", media: :jpeg))
       assert %{"image_url" => %{"url" => ^expected}} = result
 
+      expected = "data:image/gif;base64,image_base64_data"
+      result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", media: :gif))
+      assert %{"image_url" => %{"url" => ^expected}} = result
+
+      expected = "data:image/webp;base64,image_base64_data"
+      result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", media: :webp))
+      assert %{"image_url" => %{"url" => ^expected}} = result
+
       expected = "data:image/png;base64,image_base64_data"
       result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", media: :png))
       assert %{"image_url" => %{"url" => ^expected}} = result

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -177,6 +177,12 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert result == expected
     end
 
+    test "turns an image ContentPart into the expected JSON format with detail option" do
+      expected = %{"type" => "image_url", "image_url" => %{"url" => "image_base64_data", "detail" => "low"}}
+      result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", detail: "low"))
+      assert result == expected
+    end
+
     test "turns ContentPart's media type the expected JSON values" do
       expected = "data:image/jpg;base64,image_base64_data"
       result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", media: :jpg))
@@ -207,6 +213,12 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
     test "turns an image_url ContentPart into the expected JSON format" do
       expected = %{"type" => "image_url", "image_url" => %{"url" => "url-to-image"}}
       result = ChatOpenAI.for_api(ContentPart.image_url!("url-to-image"))
+      assert result == expected
+    end
+
+    test "turns an image_url ContentPart into the expected JSON format with detail option" do
+      expected = %{"type" => "image_url", "image_url" => %{"url" => "url-to-image", "detail" => "low"}}
+      result = ChatOpenAI.for_api(ContentPart.image_url!("url-to-image", detail: "low"))
       assert result == expected
     end
 

--- a/test/message/content_part_test.exs
+++ b/test/message/content_part_test.exs
@@ -46,6 +46,13 @@ defmodule LangChain.Message.ContentPartTest do
       assert part.type == :image
       assert part.content == "ZmFrZV9pbWFnZV9kYXRh"
     end
+
+    test "supports 'detail' option" do
+      %ContentPart{} = part = ContentPart.image!(Base.encode64("fake_image_data"), detail: "low")
+      assert part.type == :image
+      assert part.content == "ZmFrZV9pbWFnZV9kYXRh"
+      assert part.options == [detail: "low"]
+    end
   end
 
   describe("image_url!/1") do
@@ -57,5 +64,15 @@ defmodule LangChain.Message.ContentPartTest do
       assert part.type == :image_url
       assert part.content == url
     end
+
+    test "supports 'detail' option with ChatGPT" do
+      url =
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+
+      %ContentPart{} = part = ContentPart.image_url!(url, detail: "low")
+      assert part.type == :image_url
+      assert part.content == url
+      assert part.options == [detail: "low"]
+     end
   end
 end


### PR DESCRIPTION
Enhances support for more standard/accepted image types with ContentParts