### PR TITLE
add openai image endpoint support (aka DALL-E-2 & DALL-E-3)

### DIFF
--- a/lib/images.ex
+++ b/lib/images.ex
@@ -1,0 +1,74 @@
+defmodule LangChain.Images do
+  @moduledoc """
+  Functions for working with `LangChain.GeneratedImage` files.
+  """
+  require Logger
+  alias LangChain.Images.GeneratedImage
+
+  @doc """
+  Save the generated image file to a local directory. If the GeneratedFile is an
+  URL, it is first downloaded then saved. If the is a Base64 encoded image, it
+  is decoded and saved.
+  """
+  @spec(save_to_file(GeneratedImage.t(), String.t()) :: {:ok, String.t()}, {:error, String.t()})
+  def save_to_file(%GeneratedImage{type: :url} = image, target_path) do
+    # When a generated image is type `:url`, the content is the URL
+    case Req.get(image.content) do
+      {:ok, %Req.Response{body: body, status: 200}} ->
+        # Save the file locally
+        do_write_to_file(body, target_path)
+
+      {:ok, %Req.Response{status: 404}} ->
+        {:error, "Image file not found"}
+
+      {:ok, %Req.Response{status: 500}} ->
+        {:error, "Failed with server error 500"}
+
+      {:error, reason} ->
+        # Handle error
+        Logger.error("Failed to download image: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  def save_to_file(%GeneratedImage{type: :base64} = image, target_path) do
+    case Base.decode64(image.content) do
+      {:ok, binary_data} ->
+        do_write_to_file(binary_data, target_path)
+
+      :error ->
+        {:error, "Failed to base64 decode image data"}
+    end
+  end
+
+  # write the contents to the file
+  @spec do_write_to_file(binary(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defp do_write_to_file(data, target_path) do
+    case File.write(target_path, data) do
+      :ok ->
+        {:ok, target_path}
+
+      {:error, :eacces} ->
+        {:error, "Missing write permissions for the parent directory"}
+
+      {:error, :eexist} ->
+        {:error, "A file or directory already exists"}
+
+      {:error, :enoent} ->
+        {:error, "File path is invalid"}
+
+      {:error, :enospc} ->
+        {:error, "No space left on device"}
+
+      {:error, :enotdir} ->
+        {:error, "Part of path is not a directory"}
+
+      {:error, reason} ->
+        Logger.error(
+          "Failed to save base64 image to file #{inspect(target_path)}. Reason: #{inspect(reason)}"
+        )
+
+        {:error, "Unrecognized error reason encountered: #{inspect(reason)}"}
+    end
+  end
+end

--- a/lib/images.ex
+++ b/lib/images.ex
@@ -3,14 +3,55 @@ defmodule LangChain.Images do
   Functions for working with `LangChain.GeneratedImage` files.
   """
   require Logger
+  alias LangChain.LangChainError
   alias LangChain.Images.GeneratedImage
+
+  @doc """
+  Save a list of `%GeneratedImage{}` images.
+
+  Pipe friendly for handling the result a `LangChain.Images.OpenAIImage.call/1`
+  where it handles a success or passes the error result through.
+  """
+  @spec save_images([GeneratedImage.t()], path :: String.t(), filename_prefix :: String.t()) ::
+          {:ok, [String.t()]} | {:error, String.t()}
+  def save_images({:ok, images}, path, filename_prefix) do
+    # unwrap the tuple
+    save_images(images, path, filename_prefix)
+  end
+
+  def save_images(images, path, filename_prefix) when is_list(images) do
+    try do
+      Enum.with_index(images, fn %GeneratedImage{} = image, idx ->
+        index_as_string = to_string(idx + 1)
+        number = String.pad_leading(index_as_string, 2, "0")
+        filename = filename_prefix <> number <> ".#{to_string(image.image_type)}"
+
+        # if it saved successfully, return the generated filename
+        case save_to_file(image, Path.join([path, filename])) do
+          :ok ->
+            filename
+
+          {:error, reason} ->
+            raise LangChainError, "File save error. Reason: #{inspect(reason)}"
+        end
+      end)
+    else
+      result when is_list(result) ->
+        {:ok, result}
+    rescue
+      err in [LangChainError] ->
+        {:error, err.message}
+    end
+  end
+
+  def save_images({:error, _reason} = error, _path, _filename_prefix), do: error
 
   @doc """
   Save the generated image file to a local directory. If the GeneratedFile is an
   URL, it is first downloaded then saved. If the is a Base64 encoded image, it
   is decoded and saved.
   """
-  @spec(save_to_file(GeneratedImage.t(), String.t()) :: {:ok, String.t()}, {:error, String.t()})
+  @spec save_to_file(GeneratedImage.t(), String.t()) :: :ok | {:error, String.t()}
   def save_to_file(%GeneratedImage{type: :url} = image, target_path) do
     # When a generated image is type `:url`, the content is the URL
     case Req.get(image.content) do
@@ -42,11 +83,11 @@ defmodule LangChain.Images do
   end
 
   # write the contents to the file
-  @spec do_write_to_file(binary(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec do_write_to_file(binary(), String.t()) :: :ok | {:error, String.t()}
   defp do_write_to_file(data, target_path) do
     case File.write(target_path, data) do
       :ok ->
-        {:ok, target_path}
+        :ok
 
       {:error, :eacces} ->
         {:error, "Missing write permissions for the parent directory"}

--- a/lib/images/generated_image.ex
+++ b/lib/images/generated_image.ex
@@ -2,6 +2,17 @@ defmodule LangChain.Images.GeneratedImage do
   @moduledoc """
   Represents a generated image where we have either the base64 encoded contents
   or a temporary URL to it.
+
+  ## Example
+
+  Created when an image generation request completes and we have an image.
+
+      GeneratedImage.new!(%{
+        image_type: :png,
+        type: :url,
+        content: "https://example.com/my_image.png",
+        prompt: "The prompt used for image generation"
+      })
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -57,5 +68,4 @@ defmodule LangChain.Images.GeneratedImage do
     changeset
     |> validate_required([:image_type, :type, :content])
   end
-
 end

--- a/lib/images/generated_image.ex
+++ b/lib/images/generated_image.ex
@@ -1,0 +1,61 @@
+defmodule LangChain.Images.GeneratedImage do
+  @moduledoc """
+  Represents a generated image where we have either the base64 encoded contents
+  or a temporary URL to it.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  require Logger
+  alias __MODULE__
+  alias LangChain.LangChainError
+
+  @primary_key false
+  embedded_schema do
+    field :image_type, Ecto.Enum, values: [:png, :jpg], default: :png
+    field :type, Ecto.Enum, values: [:base64, :url], default: :url
+    # When a :url, content is the URL. When base64, content is the encoded data.
+    field :content, :string
+
+    # The prompt used when generating the image. It may have been altered by the
+    # LLM from the original request.
+    field :prompt, :string
+    field :metadata, :map
+    field :created_at, :utc_datetime
+  end
+
+  @type t :: %GeneratedImage{}
+
+  @update_fields [:image_type, :type, :content, :prompt, :metadata, :created_at]
+  @create_fields @update_fields
+
+  @doc """
+  Build a new GeneratedImage and return an `:ok`/`:error` tuple with the result.
+  """
+  @spec new(attrs :: map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def new(attrs \\ %{}) do
+    %GeneratedImage{}
+    |> cast(attrs, @create_fields)
+    |> common_validations()
+    |> apply_action(:insert)
+  end
+
+  @doc """
+  Build a new GeneratedImage and return it or raise an error if invalid.
+  """
+  @spec new!(attrs :: map()) :: t() | no_return()
+  def new!(attrs \\ %{}) do
+    case new(attrs) do
+      {:ok, message} ->
+        message
+
+      {:error, changeset} ->
+        raise LangChainError, changeset
+    end
+  end
+
+  defp common_validations(changeset) do
+    changeset
+    |> validate_required([:image_type, :type, :content])
+  end
+
+end

--- a/lib/images/open_ai_image.ex
+++ b/lib/images/open_ai_image.ex
@@ -175,27 +175,12 @@ defmodule LangChain.Images.OpenAIImage do
   end
 
   @doc """
-  Calls the OpenAI API passing the OpenAIImage struct with configuration, plus
-  either a simple message or the list of messages to act as the prompt.
+  Calls the OpenAI API passing the OpenAIImage struct with configuration.
 
-  Optionally pass in a list of tools available to the LLM for requesting
-  execution in response.
-
-  Optionally pass in a callback function that can be executed as data is
-  received from the API.
-
-  **NOTE:** This function *can* be used directly, but the primary interface
-  should be through `LangChain.Chains.LLMChain`. The `OpenAIImage` module is more
-  focused on translating the `LangChain` data structures to and from the OpenAI
-  API.
-
-  Another benefit of using `LangChain.Chains.LLMChain` is that it combines the
-  storage of messages, adding tools, adding custom context that should be
-  passed to tools, and automatically applying `LangChain.MessageDelta`
-  structs as they are are received, then converting those to the full
-  `LangChain.Message` once fully complete.
+  When successful, it returns `{:ok, generated_images}` where that is a list of
+  `LangChain.Images.GeneratedImage` structs.
   """
-  @spec call(t()) :: {:ok, %{String.t() => any()}} | {:error, String.t()}
+  @spec call(t()) :: {:ok, [GeneratedImage.t()]} | {:error, String.t()}
   def call(openai, callback_fn \\ nil)
 
   def call(%OpenAIImage{} = openai, callback_fn) do

--- a/lib/images/open_ai_image.ex
+++ b/lib/images/open_ai_image.ex
@@ -1,0 +1,365 @@
+defmodule LangChain.Images.OpenAIImage do
+  @moduledoc """
+  Represents the [OpenAI Images API
+  endpoint](https://platform.openai.com/docs/api-reference/images) for working
+  with DALL-E-2 and DALL-E-3.
+
+  Parses and validates inputs for making a request from the OpenAI Image API.
+
+  Converts responses into more specialized `LangChain` data structures and
+  provide functions for saving generated images.
+
+  """
+  use Ecto.Schema
+  require Logger
+  import Ecto.Changeset
+  import LangChain.Utils.ApiOverride
+  alias __MODULE__
+  alias LangChain.Images.GeneratedImage
+  alias LangChain.Config
+  alias LangChain.LangChainError
+  alias LangChain.Utils
+
+  # allow up to 2 minutes for response.
+  @receive_timeout 1_200_000
+
+  @primary_key false
+  embedded_schema do
+    field :endpoint, :string, default: "https://api.openai.com/v1/images/generations"
+    # API key for OpenAI. If not set, will use global api key. Allows for usage
+    # of a different API key per-call if desired. For instance, allowing a
+    # customer to provide their own.
+    field :api_key, :string
+    # Duration in seconds for the response to be received. When streaming a very
+    # lengthy response, a longer time limit may be required. However, when it
+    # goes on too long by itself, it tends to hallucinate more.
+    field :receive_timeout, :integer, default: @receive_timeout
+
+    # Defaults to `dall-e-2`. The other model option is `dall-e-3`.
+    # The model to use for image generation.
+    field :model, :string, default: "dall-e-2"
+
+    # A text description of the desired image(s). The maximum length is 1000
+    # characters for `dall-e-2` and 4000 characters for `dall-e-3`.
+    field :prompt, :string
+
+    # The number of images to generate. Must be between 1 and 10. For dall-e-3,
+    # only n=1 is supported.
+    field :n, :integer, default: 1
+
+    #  The quality of the image that will be generated. `hd` creates images with
+    #  finer details and greater consistency across the image. This param is
+    #  only supported for `dall-e-3`.
+    field :quality, :string, default: "standard"
+
+    # The format in which the generated images are returned. Must be one of
+    # `url` or `b64_json`. URLs are only valid for 60 minutes after the image
+    # has been generated.
+    field :response_format, :string, default: "url"
+
+    # The size of the generated images. Must be one of `256x256`, `512x512`, or
+    # `1024x1024` for `dall-e-2`. Must be one of `1024x1024`, `1792x1024`, or `1024x1792`
+    # for `dall-e-3` models.
+    field :size, :string, default: "1024x1024"
+
+    # The style of the generated images. Must be one of `vivid` or `natural`.
+    # Vivid causes the model to lean towards generating hyper-real and dramatic
+    # images. Natural causes the model to produce more natural, less hyper-real
+    # looking images. This param is only supported for `dall-e-3`.
+    field :style, :string, default: "vivid"
+
+    # A unique identifier representing your end-user, which can help OpenAI to
+    # monitor and detect abuse
+    field :user, :string
+  end
+
+  @type t :: %OpenAIImage{}
+
+  @create_fields [
+    :endpoint,
+    :api_key,
+    :receive_timeout,
+    :model,
+    :prompt,
+    :n,
+    :quality,
+    :response_format,
+    :size,
+    :style,
+    :user
+  ]
+  @required_fields [:endpoint, :model, :prompt]
+
+  @spec get_api_key(t()) :: String.t()
+  defp get_api_key(%OpenAIImage{api_key: api_key}) do
+    # if no API key is set default to `""` which will raise a OpenAI API error
+    api_key || Config.resolve(:openai_key, "")
+  end
+
+  @spec get_org_id() :: String.t() | nil
+  defp get_org_id() do
+    Config.resolve(:openai_org_id)
+  end
+
+  @doc """
+  Setup a OpenAIImage client configuration.
+  """
+  @spec new(attrs :: map()) :: {:ok, t} | {:error, Ecto.Changeset.t()}
+  def new(%{} = attrs) do
+    %OpenAIImage{}
+    |> cast(attrs, @create_fields)
+    |> common_validation()
+    |> conditional_validations_for_model()
+    |> apply_action(:insert)
+  end
+
+  @doc """
+  Setup a OpenAIImage client configuration and return it or raise an error if
+  invalid.
+  """
+  @spec new!(attrs :: map()) :: t() | no_return()
+  def new!(attrs) do
+    case new(attrs) do
+      {:ok, chain} ->
+        chain
+
+      {:error, changeset} ->
+        raise LangChainError, changeset
+    end
+  end
+
+  defp common_validation(changeset) do
+    changeset
+    |> validate_required(@required_fields)
+    |> validate_inclusion(:model, ["dall-e-2", "dall-e-3"])
+    |> validate_inclusion(:quality, ["standard", "hd"])
+    |> validate_inclusion(:response_format, ["url", "b64_json"])
+    |> validate_inclusion(:style, ["vivid", "natural"])
+    |> validate_number(:receive_timeout, greater_than_or_equal_to: 0)
+  end
+
+  defp conditional_validations_for_model(changeset) do
+    case get_field(changeset, :model) do
+      "dall-e-3" ->
+        changeset
+        |> validate_length(:prompt, max: 4_000)
+        |> validate_number(:n, equal_to: 1)
+        |> validate_inclusion(:size, ["1024x1024", "1792x1024", "1024x1792"])
+
+      "dall-e-2" ->
+        changeset
+        |> validate_length(:prompt, max: 1_000)
+        |> validate_number(:n, greater_than_or_equal_to: 1, less_than_or_equal_to: 10)
+        |> validate_inclusion(:size, ["256x256", "512x512", "1024x1024"])
+
+      _other ->
+        changeset
+    end
+  end
+
+  @doc """
+  Return the params formatted for an API request.
+  """
+  @spec for_api(t) :: %{atom() => any()}
+  def for_api(%OpenAIImage{} = openai) do
+    %{
+      model: openai.model,
+      prompt: openai.prompt,
+      n: openai.n,
+      quality: openai.quality,
+      response_format: openai.response_format,
+      size: openai.size,
+      style: openai.style
+    }
+    |> Utils.conditionally_add_to_map(:user, openai.user)
+  end
+
+  @doc """
+  Calls the OpenAI API passing the OpenAIImage struct with configuration, plus
+  either a simple message or the list of messages to act as the prompt.
+
+  Optionally pass in a list of tools available to the LLM for requesting
+  execution in response.
+
+  Optionally pass in a callback function that can be executed as data is
+  received from the API.
+
+  **NOTE:** This function *can* be used directly, but the primary interface
+  should be through `LangChain.Chains.LLMChain`. The `OpenAIImage` module is more
+  focused on translating the `LangChain` data structures to and from the OpenAI
+  API.
+
+  Another benefit of using `LangChain.Chains.LLMChain` is that it combines the
+  storage of messages, adding tools, adding custom context that should be
+  passed to tools, and automatically applying `LangChain.MessageDelta`
+  structs as they are are received, then converting those to the full
+  `LangChain.Message` once fully complete.
+  """
+  @spec call(t()) :: {:ok, %{String.t() => any()}} | {:error, String.t()}
+  def call(openai, callback_fn \\ nil)
+
+  def call(%OpenAIImage{} = openai, callback_fn) do
+    if override_api_return?() do
+      Logger.warning("Found override API response. Will not make live API call.")
+
+      case get_api_override() do
+        {:ok, {:ok, data} = response} ->
+          # fire callback for fake responses too
+          Utils.fire_callback(openai, data, callback_fn)
+          response
+
+        # fake error response
+        {:ok, {:error, _reason} = response} ->
+          response
+
+        _other ->
+          raise LangChainError,
+                "An unexpected fake API response was set. Should be an `{:ok, value}`"
+      end
+    else
+      try do
+        # make base api request and perform high-level success/failure checks
+        case do_api_request(openai, callback_fn) do
+          {:error, reason} ->
+            {:error, reason}
+
+          {:ok, parsed_data} ->
+            {:ok, parsed_data}
+        end
+      rescue
+        err in LangChainError ->
+          {:error, err.message}
+      end
+    end
+  end
+
+  # Make the API request from the OpenAI server.
+  #
+  # The result of the function is:
+  #
+  # - `{:ok, %{images: [images], prompt: "the re-written prompt"}}
+  # - `{:error, reason}` - Where reason is a string explanation of what went
+  #   wrong.
+  #
+  # If a callback_fn is provided, it will fire with each
+
+  # Executes the callback function passing the response parsed to the data
+  # structures. Retries the request up to 3 times on transient errors with a
+  # brief delay
+  @doc false
+  @spec do_api_request(t(), retry_count :: integer()) :: {:ok, list()} | {:error, String.t()}
+  def do_api_request(openai, retry_count \\ 3)
+
+  def do_api_request(_openai, 0) do
+    raise LangChainError, "Retries exceeded. Connection failed."
+  end
+
+  def do_api_request(%OpenAIImage{} = openai, retry_count) do
+    req =
+      Req.new(
+        url: openai.endpoint,
+        json: for_api(openai),
+        # required for OpenAI API
+        auth: {:bearer, get_api_key(openai)},
+        # required for Azure OpenAI version
+        headers: [
+          {"api-key", get_api_key(openai)}
+        ],
+        receive_timeout: openai.receive_timeout,
+        retry: :transient,
+        max_retries: 3,
+        retry_delay: fn attempt -> 300 * attempt end
+      )
+
+    req
+    |> maybe_add_org_id_header()
+    |> Req.post()
+    # parse the body and return it as parsed structs
+    |> case do
+      {:ok, %Req.Response{body: data}} ->
+        case do_process_response(data, openai) do
+          {:error, reason} ->
+            {:error, reason}
+
+          result ->
+            result
+        end
+
+      {:error, %Mint.TransportError{reason: :timeout}} ->
+        {:error, "Request timed out"}
+
+      {:error, %Mint.TransportError{reason: :closed}} ->
+        # Force a retry by making a recursive call decrementing the counter
+        Logger.debug(fn -> "Mint connection closed: retry count = #{inspect(retry_count)}" end)
+        do_api_request(openai, retry_count - 1)
+
+      other ->
+        Logger.error("Unexpected and unhandled API response! #{inspect(other)}")
+        other
+    end
+  end
+
+  @doc false
+  @spec do_process_response(data :: %{String.t() => any()} | {:error, any()}, t()) ::
+          {:ok, [GeneratedImage.t()]} | {:error, String.t()}
+  def do_process_response(%{"data" => images} = response, %OpenAIImage{} = request)
+      when is_list(images) do
+    created_at = DateTime.from_unix!(response["created"])
+
+    results =
+      Enum.map(images, fn
+        %{"b64_json" => base64_raw_content} = image_info ->
+          GeneratedImage.new!(%{
+            type: :base64,
+            image_type: :png,
+            content: base64_raw_content,
+            created_at: created_at,
+            prompt: Map.get(image_info, "revised_prompt", request.prompt),
+            metadata: %{"model" => request.model, "quality" => request.quality}
+          })
+
+        %{"url" => base64_raw_content} = image_info ->
+          GeneratedImage.new!(%{
+            type: :url,
+            image_type: :png,
+            content: base64_raw_content,
+            created_at: created_at,
+            prompt: Map.get(image_info, "revised_prompt", request.prompt),
+            metadata: %{"model" => request.model, "quality" => request.quality}
+          })
+
+        other ->
+          message = "Unsupported image data response from OpenAI! #{inspect(other)}"
+          Logger.error(message)
+          nil
+      end)
+
+    {:ok, results |> Enum.reject(&is_nil(&1))}
+  end
+
+  def do_process_response(%{"error" => %{"code" => code} = error}, %OpenAIImage{} = _request) do
+    Logger.warning("Error from OpenAI: #{error["message"]}")
+
+    reason =
+      case code do
+        "content_policy_violation" = value ->
+          value
+
+        other ->
+          Logger.error("Unhandled error code from API: #{inspect(other)}")
+          other
+      end
+
+    {:error, reason}
+  end
+
+  defp maybe_add_org_id_header(%Req.Request{} = req) do
+    org_id = get_org_id()
+
+    if org_id do
+      Req.Request.put_header(req, "OpenAI-Organization", org_id)
+    else
+      req
+    end
+  end
+end

--- a/test/images/generated_image_test.exs
+++ b/test/images/generated_image_test.exs
@@ -1,0 +1,61 @@
+defmodule LangChain.Images.GeneratedImageTest do
+	use ExUnit.Case
+	doctest LangChain.Images.GeneratedImage
+	alias LangChain.Images.GeneratedImage
+  alias LangChain.LangChainError
+
+  describe "new/1" do
+    test "creates valid model with minimal setup" do
+      prompt = "A happy little chipmunk with full cheeks."
+      {:ok, %GeneratedImage{} = img} = GeneratedImage.new(%{prompt: prompt})
+      assert img.prompt == prompt
+    end
+
+    test "supports all valid settings" do
+      {:ok, img} =
+        GeneratedImage.new(%{
+          endpoint: "https://example.com",
+          api_key: "overridden",
+          receive_timeout: 2_000,
+          model: "dall-e-3",
+          prompt: "A well worn baseball sitting in a well worn glove",
+          quality: "hd",
+          response_format: "b64_json",
+          size: "1792x1024",
+          style: "natural",
+          user: "user-123"
+        })
+
+      assert img.endpoint == "https://example.com"
+      assert img.api_key == "overridden"
+      assert img.receive_timeout == 2_000
+      assert img.model == "dall-e-3"
+      assert img.prompt == "A well worn baseball sitting in a well worn glove"
+      assert img.quality == "hd"
+      assert img.response_format == "b64_json"
+      assert img.size == "1792x1024"
+      assert img.style == "natural"
+      assert img.user == "user-123"
+    end
+
+    test "returns error when invalid" do
+      {:error, changeset} = GeneratedImage.new(%{model: "dang-e-infinity"})
+      assert {"can't be blank", _} = changeset.errors[:prompt]
+      assert {"is invalid", _} = changeset.errors[:model]
+    end
+  end
+
+  describe "new!/1" do
+    test "returns struct when valid" do
+      prompt = "A happy little chipmunk with full cheeks."
+      %GeneratedImage{} = img = GeneratedImage.new!(%{prompt: prompt})
+      assert img.prompt == prompt
+    end
+
+    test "raises LangChain.LangChainError when invalid" do
+      assert_raise LangChainError, "prompt: can't be blank", fn ->
+        GeneratedImage.new!(%{})
+      end
+    end
+  end
+end

--- a/test/images/generated_image_test.exs
+++ b/test/images/generated_image_test.exs
@@ -1,59 +1,52 @@
 defmodule LangChain.Images.GeneratedImageTest do
-	use ExUnit.Case
-	doctest LangChain.Images.GeneratedImage
-	alias LangChain.Images.GeneratedImage
+  use ExUnit.Case
+  doctest LangChain.Images.GeneratedImage
+  alias LangChain.Images.GeneratedImage
   alias LangChain.LangChainError
 
   describe "new/1" do
     test "creates valid model with minimal setup" do
       prompt = "A happy little chipmunk with full cheeks."
-      {:ok, %GeneratedImage{} = img} = GeneratedImage.new(%{prompt: prompt})
+
+      {:ok, %GeneratedImage{} = img} =
+        GeneratedImage.new(%{prompt: prompt, content: "https://example.com/image.png"})
+
       assert img.prompt == prompt
     end
 
     test "supports all valid settings" do
       {:ok, img} =
         GeneratedImage.new(%{
-          endpoint: "https://example.com",
-          api_key: "overridden",
-          receive_timeout: 2_000,
-          model: "dall-e-3",
           prompt: "A well worn baseball sitting in a well worn glove",
-          quality: "hd",
-          response_format: "b64_json",
-          size: "1792x1024",
-          style: "natural",
-          user: "user-123"
+          content: "base64_data",
+          image_type: :jpg,
+          type: :base64
         })
 
-      assert img.endpoint == "https://example.com"
-      assert img.api_key == "overridden"
-      assert img.receive_timeout == 2_000
-      assert img.model == "dall-e-3"
       assert img.prompt == "A well worn baseball sitting in a well worn glove"
-      assert img.quality == "hd"
-      assert img.response_format == "b64_json"
-      assert img.size == "1792x1024"
-      assert img.style == "natural"
-      assert img.user == "user-123"
+      assert img.content == "base64_data"
+      assert img.image_type == :jpg
+      assert img.type == :base64
     end
 
     test "returns error when invalid" do
-      {:error, changeset} = GeneratedImage.new(%{model: "dang-e-infinity"})
-      assert {"can't be blank", _} = changeset.errors[:prompt]
-      assert {"is invalid", _} = changeset.errors[:model]
+      {:error, changeset} = GeneratedImage.new(%{content: nil})
+      assert {"can't be blank", _} = changeset.errors[:content]
     end
   end
 
   describe "new!/1" do
     test "returns struct when valid" do
       prompt = "A happy little chipmunk with full cheeks."
-      %GeneratedImage{} = img = GeneratedImage.new!(%{prompt: prompt})
+
+      %GeneratedImage{} =
+        img = GeneratedImage.new!(%{prompt: prompt, content: "https://example.com/chipmunk.png"})
+
       assert img.prompt == prompt
     end
 
     test "raises LangChain.LangChainError when invalid" do
-      assert_raise LangChainError, "prompt: can't be blank", fn ->
+      assert_raise LangChainError, "content: can't be blank", fn ->
         GeneratedImage.new!(%{})
       end
     end

--- a/test/images/open_ai_image_test.exs
+++ b/test/images/open_ai_image_test.exs
@@ -1,0 +1,137 @@
+defmodule LangChain.Images.OpenAIImageTest do
+  use ExUnit.Case
+  doctest LangChain.Images.OpenAIImage
+  # alias LangChain.Images
+  alias LangChain.Images.GeneratedImage
+  alias LangChain.Images.OpenAIImage
+  alias LangChain.LangChainError
+
+  describe "new/1" do
+    test "creates valid model with minimal setup" do
+      prompt = "A happy little chipmunk with full cheeks."
+      {:ok, %OpenAIImage{} = img} = OpenAIImage.new(%{prompt: prompt})
+      assert img.prompt == prompt
+    end
+
+    test "supports all valid settings" do
+      {:ok, img} =
+        OpenAIImage.new(%{
+          endpoint: "https://example.com",
+          api_key: "overridden",
+          receive_timeout: 2_000,
+          model: "dall-e-3",
+          prompt: "A well worn baseball sitting in a well worn glove",
+          quality: "hd",
+          response_format: "b64_json",
+          size: "1792x1024",
+          style: "natural",
+          user: "user-123"
+        })
+
+      assert img.endpoint == "https://example.com"
+      assert img.api_key == "overridden"
+      assert img.receive_timeout == 2_000
+      assert img.model == "dall-e-3"
+      assert img.prompt == "A well worn baseball sitting in a well worn glove"
+      assert img.quality == "hd"
+      assert img.response_format == "b64_json"
+      assert img.size == "1792x1024"
+      assert img.style == "natural"
+      assert img.user == "user-123"
+    end
+
+    test "returns error when invalid" do
+      {:error, changeset} = OpenAIImage.new(%{model: "dang-e-infinity"})
+      assert {"can't be blank", _} = changeset.errors[:prompt]
+      assert {"is invalid", _} = changeset.errors[:model]
+    end
+  end
+
+  describe "new!/1" do
+    test "returns struct when valid" do
+      prompt = "A happy little chipmunk with full cheeks."
+      %OpenAIImage{} = img = OpenAIImage.new!(%{prompt: prompt})
+      assert img.prompt == prompt
+    end
+
+    test "raises LangChain.LangChainError when invalid" do
+      assert_raise LangChainError, "prompt: can't be blank", fn ->
+        OpenAIImage.new!(%{})
+      end
+    end
+  end
+
+  describe "call/1" do
+    @tag live_call: true
+    test "generates and saves an image using b64_json" do
+      prompt = "A well worn baseball sitting in a well worn glove"
+
+      result =
+        %{
+          model: "dall-e-2",
+          prompt: prompt,
+          quality: "standard",
+          response_format: "url",
+          size: "256x256",
+          style: "natural"
+        }
+        |> OpenAIImage.new!()
+        |> OpenAIImage.call()
+
+      assert {:ok, [%GeneratedImage{} = image]} = result
+      assert String.starts_with?(image.content, "http")
+      assert image.type == :url
+      assert image.image_type == :png
+      assert image.prompt == prompt
+      assert image.created_at != nil
+      assert image.metadata != nil
+    end
+  end
+
+  describe "do_process_response/2" do
+    test "handles successful b64_json response" do
+      request = OpenAIImage.new!(%{prompt: "pretend"})
+      content = :base64.encode("pretend_content")
+      # created is a Unix timestamp in UTC
+      data = %{"created" => 1_715_047_358, "data" => [%{"b64_json" => content}]}
+      {:ok, [%GeneratedImage{} = image]} = OpenAIImage.do_process_response(data, request)
+      assert image.type == :base64
+      assert image.image_type == :png
+      assert image.content == content
+      assert image.prompt == request.prompt
+      assert image.created_at == ~U[2024-05-07 02:02:38Z]
+      assert %{"model" => "dall-e-2"} = image.metadata
+    end
+
+    test "handles successful url response" do
+      request = OpenAIImage.new!(%{prompt: "pretend"})
+      content = "https://example.com/images/pretend_content.png"
+      # created is a Unix timestamp in UTC
+      data = %{"created" => 1_715_047_358, "data" => [%{"url" => content}]}
+      {:ok, [%GeneratedImage{} = image]} = OpenAIImage.do_process_response(data, request)
+      assert image.type == :url
+      assert image.image_type == :png
+      assert image.content == content
+      assert image.prompt == request.prompt
+      assert image.created_at == ~U[2024-05-07 02:02:38Z]
+      assert %{"model" => "dall-e-2"} = image.metadata
+    end
+
+    test "handles when rejected for content violation" do
+      response = %{
+        "error" => %{
+          "code" => "content_policy_violation",
+          "message" =>
+            "Your request was rejected as a result of our safety system. Your prompt may contain text that is not allowed by our safety system.",
+          "param" => nil,
+          "type" => "invalid_request_error"
+        }
+      }
+
+      request = OpenAIImage.new!(%{prompt: "violation"})
+
+      assert {:error, "content_policy_violation"} =
+               OpenAIImage.do_process_response(response, request)
+    end
+  end
+end

--- a/test/images/open_ai_image_test.exs
+++ b/test/images/open_ai_image_test.exs
@@ -62,7 +62,7 @@ defmodule LangChain.Images.OpenAIImageTest do
   end
 
   describe "call/1" do
-    @tag live_call: true
+    @tag live_call: true, live_open_ai: true
     test "generates and saves an image using b64_json" do
       prompt = "A well worn baseball sitting in a well worn glove"
 

--- a/test/images_test.exs
+++ b/test/images_test.exs
@@ -4,6 +4,43 @@ defmodule LangChain.ImagesTest do
   alias LangChain.Images.GeneratedImage
   alias LangChain.Images
 
+  defp generated_base64() do
+    GeneratedImage.new!(%{
+      image_type: :png,
+      type: :base64,
+      content:
+        "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII="
+    })
+  end
+
+  describe "save_images/3" do
+    @tag tmp_dir: true
+    test "saves a list of generated images to the path and using the file prefix", %{
+      tmp_dir: tmp_dir
+    } do
+      image = generated_base64()
+      {:ok, [image_file]} = Images.save_images([image], tmp_dir, "my-prefix-")
+      assert image_file == "my-prefix-01.png"
+
+      assert File.exists?(Path.join([tmp_dir, "my-prefix-01.png"]))
+    end
+
+    @tag tmp_dir: true
+    test "saves a list of generated images wrapped in an {:ok, images} tuple", %{tmp_dir: tmp_dir} do
+      image = generated_base64()
+      {:ok, [image_file]} = Images.save_images({:ok, [image]}, tmp_dir, "my-prefix-")
+      assert image_file == "my-prefix-01.png"
+
+      assert File.exists?(Path.join([tmp_dir, "my-prefix-01.png"]))
+    end
+
+    @tag tmp_dir: true
+    test "passes through an {:error, reason} tuple", %{tmp_dir: tmp_dir} do
+      result = Images.save_images({:error, "File not found"}, tmp_dir, "01-01-")
+      assert result == {:error, "File not found"}
+    end
+  end
+
   describe "save_to_file/2" do
     # NOTE: Use an ExUnit created temp directory for saving the file to
     @tag tmp_dir: true, live_call: true
@@ -16,7 +53,7 @@ defmodule LangChain.ImagesTest do
         })
 
       target = Path.join(tmp_dir, "wikipedia.png")
-      assert {:ok, target} == Images.save_to_file(public_image, target)
+      assert :ok == Images.save_to_file(public_image, target)
     end
 
     @tag tmp_dir: true, live_call: true
@@ -43,7 +80,7 @@ defmodule LangChain.ImagesTest do
         })
 
       target = Path.join(tmp_dir, "sample.png")
-      assert {:ok, ^target} = Images.save_to_file(public_image, target)
+      assert :ok = Images.save_to_file(public_image, target)
     end
   end
 end

--- a/test/images_test.exs
+++ b/test/images_test.exs
@@ -1,0 +1,49 @@
+defmodule LangChain.ImagesTest do
+  use ExUnit.Case
+  doctest LangChain.Images
+  alias LangChain.Images.GeneratedImage
+  alias LangChain.Images
+
+  describe "save_to_file/2" do
+    # NOTE: Use an ExUnit created temp directory for saving the file to
+    @tag tmp_dir: true, live_call: true
+    test "saves a URL image to a file", %{tmp_dir: tmp_dir} do
+      public_image =
+        GeneratedImage.new!(%{
+          image_type: :png,
+          type: :url,
+          content: "https://pngimg.com/uploads/wikipedia/wikipedia_PNG4.png"
+        })
+
+      target = Path.join(tmp_dir, "wikipedia.png")
+      assert {:ok, target} == Images.save_to_file(public_image, target)
+    end
+
+    @tag tmp_dir: true, live_call: true
+    test "handles invalid URL", %{tmp_dir: tmp_dir} do
+      public_image =
+        GeneratedImage.new!(%{
+          image_type: :png,
+          type: :url,
+          content: "https://pngimg.com/uploads/wikipedia/wikipedia_PNG4_missing.png"
+        })
+
+      target = Path.join(tmp_dir, "invalid_image.png")
+      {:error, "Image file not found"} = Images.save_to_file(public_image, target)
+    end
+
+    @tag tmp_dir: true
+    test "saves a base64 encoded image to a file", %{tmp_dir: tmp_dir} do
+      public_image =
+        GeneratedImage.new!(%{
+          image_type: :png,
+          type: :base64,
+          content:
+            "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII="
+        })
+
+      target = Path.join(tmp_dir, "sample.png")
+      assert {:ok, ^target} = Images.save_to_file(public_image, target)
+    end
+  end
+end


### PR DESCRIPTION
This adds support for the OpenAI-specific API interface for generating images using DALL-E-2 and DALL-E-3.

It returns a `LangChain.Images.GeneratedImage` struct and LangChain.Images` module makes it easy to download generated images.