### PR TITLE
allow PromptTemplates to convert to ContentParts

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -368,6 +368,11 @@ defmodule LangChain.Chains.LLMChain do
     }
   end
 
+  def add_message(%LLMChain{} = _chain, %PromptTemplate{} = template) do
+    raise LangChain.LangChainError,
+          "PromptTemplates must be converted to messages. You can use LLMChain.apply_prompt_templates/3. Received: #{inspect(template)}"
+  end
+
   @doc """
   Add a set of Message structs to the chain. This enables quickly building a chain
   for submitting to an LLM.

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -234,6 +234,10 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     }
   end
 
+  def for_api(%LangChain.PromptTemplate{} = _template) do
+    raise LangChain.LangChainError, "PromptTemplates must be converted to messages."
+  end
+
   def for_api(%ContentPart{type: :text} = part) do
     %{"type" => "text", "text" => part.content}
   end

--- a/lib/message.ex
+++ b/lib/message.ex
@@ -69,6 +69,7 @@ defmodule LangChain.Message do
   alias LangChain.Message.ContentPart
   alias LangChain.Message.ToolCall
   alias LangChain.Message.ToolResult
+  alias LangChain.PromptTemplate
   alias LangChain.LangChainError
   alias LangChain.Utils
 
@@ -169,10 +170,10 @@ defmodule LangChain.Message do
       {:ok, text} when is_binary(text) ->
         changeset
 
-      {:ok, [%ContentPart{} | _] = value} ->
+      {:ok, content} when is_list(content) ->
         if role in [:user, :assistant] do
-          # if a list, verify all elements are a ContentPart
-          if Enum.all?(value, &match?(%ContentPart{}, &1)) do
+          # if a list, verify all elements are a ContentPart or PromptTemplate
+          if Enum.all?(content, &(match?(%ContentPart{}, &1) or match?(%PromptTemplate{}, &1))) do
             changeset
           else
             add_error(changeset, :content, "must be text or a list of ContentParts")

--- a/test/message_test.exs
+++ b/test/message_test.exs
@@ -5,6 +5,7 @@ defmodule LangChain.MessageTest do
   alias LangChain.Message.ToolCall
   alias LangChain.Message.ToolResult
   alias LangChain.Message.ContentPart
+  alias LangChain.PromptTemplate
   alias LangChain.LangChainError
 
   describe "new/1" do
@@ -162,6 +163,23 @@ defmodule LangChain.MessageTest do
 
       assert msg.content == [
                %ContentPart{type: :text, content: "Describe what is in this image:"},
+               %ContentPart{type: :image, content: "ZmFrZV9pbWFnZV9kYXRh", options: []}
+             ]
+    end
+
+    test "accepts PromptTemplates in content list" do
+      assert {:ok, %Message{} = msg} =
+               Message.new_user([
+                 PromptTemplate.from_template!(
+                   "My name is <%= @name %> and here's a picture of me:"
+                 ),
+                 ContentPart.image!(:base64.encode("fake_image_data"))
+               ])
+
+      assert msg.role == :user
+
+      assert msg.content == [
+               %PromptTemplate{text: "My name is <%= @name %> and here's a picture of me:"},
                %ContentPart{type: :image, content: "ZmFrZV9pbWFnZV9kYXRh", options: []}
              ]
     end


### PR DESCRIPTION
- added PromptTemplate.to_content_part!
- added error detection when trying to send PromptTemplates that aren't converted to messages
- convert them to ContentPart type text