### PR TITLE
Fixed google ai default endpoint

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -21,9 +21,8 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
 
   @behaviour ChatModel
 
-  @default_base_url "https://generativelanguage.googleapis.com"
+  @default_endpoint "https://generativelanguage.googleapis.com"
   @default_api_version "v1beta"
-  @default_endpoint "#{@default_base_url}/#{@default_api_version}"
 
   # allow up to 2 minutes for response.
   @receive_timeout 60_000


### PR DESCRIPTION
Hello!

In the ChatGoogleAI is wrong the default endpoint. 

https://github.com/brainlid/langchain/blob/48add20d097cb0ade21b311a2c5c9bbd61000e93/lib/chat_models/chat_google_ai.ex#L24-L26

https://github.com/brainlid/langchain/blob/48add20d097cb0ade21b311a2c5c9bbd61000e93/lib/chat_models/chat_google_ai.ex#L32-L36

Then, when the final url is geneated, the `version` is added again:

https://github.com/brainlid/langchain/blob/48add20d097cb0ade21b311a2c5c9bbd61000e93/lib/chat_models/chat_google_ai.ex#L338-L342

This PR only define `@default_endpoint` with the base url without the api version.

Thanks!