### PR TITLE
Fix elixir 1.17 warnings

### DIFF
--- a/test/chat_models/chat_ollama_ai_test.exs
+++ b/test/chat_models/chat_ollama_ai_test.exs
@@ -157,7 +157,7 @@ defmodule ChatModels.ChatOllamaAITest do
       assert {:ok, deltas} = result
       assert length(deltas) > 0
 
-      deltas_except_last = Enum.slice(deltas, 0..-2)
+      deltas_except_last = Enum.slice(deltas, 0..-2//-1)
 
       for delta <- deltas_except_last do
         assert delta.__struct__ == LangChain.MessageDelta


### PR DESCRIPTION
Fixes
```
warning: 0..-2 has a default step of -1, please write 0..-2//-1 instead
  test/chat_models/chat_ollama_ai_test.exs:160: ChatModels.ChatOllamaAITest."test call/2 basic content example with streaming"/1
```