### PR TITLE
Big update - RC ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
 * The attribute `processed_content` was added to a `LangChain.Message`. When a MessageProcessor is run on a received assistant message, the results of the processing are accumulated there. The original `content` remains unchanged for when it is sent back to the LLM and used when fixing or correcting it's generated content.
 * Callback support for LLM ratelimit information returned in API response headers. These are currently implemented for Anthropic and OpenAI.
 * Callback support for LLM token usage information returned when available.
+* `LangChain.ChatModels.ChatModel` additions
+  * Added `add_callback/2` makes it easier to add a callback to an chat model.
+  * Added `serialize_config/1` to serialize an LLM chat model configuration to a map that can be restored later.
+  * Added `restore_from_map/1` to restore a configured LLM chat model from a database (for example).
+* `LangChain.Chain.LLMChain` additions
+  * New function `add_callback/2` makes it easier to add a callback to an existing `LLMChain`.
+  * New function `add_llm_callback/2` makes it easier to add a callback to a chain's LLM. This is particularly useful when an LLM model is restored from a database when loading a past conversation and wanting to preserve the original configuration.
+
 
 **Changed:**
 
@@ -22,6 +30,7 @@
 * Many smaller changes and contributions were made. This includes updates to the README for clarity,
 * `LangChain.Utils.fire_callback/3` was refactored into `LangChain.Utils.fire_streamed_callback/2` where it is only used for processing deltas and uses the new callback mechanism.
 * Notebooks were moved to the separate demo project
+* `LangChain.ChatModels.ChatGoogleAI`'s key `:version` was changed to `:api_version` to be more consistent with other models and allow for model serializers to use the `:version` key.
 
 ### Migrations Steps
 

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -45,6 +45,7 @@ defmodule LangChain.Chains.LLMChain do
   use Ecto.Schema
   import Ecto.Changeset
   require Logger
+  alias LangChain.ChatModels.ChatModel
   alias LangChain.Callbacks
   alias LangChain.Chains.ChainCallbacks
   alias LangChain.PromptTemplate
@@ -817,6 +818,15 @@ defmodule LangChain.Chains.LLMChain do
   @spec add_callback(t(), ChainCallbacks.chain_callback_handler()) :: t()
   def add_callback(%LLMChain{callbacks: callbacks} = chain, additional_callback) do
     %LLMChain{chain | callbacks: callbacks ++ [additional_callback]}
+  end
+
+  @doc """
+  Add a `LangChain.ChatModels.LLMCallbacks` callback map to the chain's `:llm` model if
+  it supports the `:callback` key.
+  """
+  @spec add_llm_callback(t(), map()) :: t()
+  def add_llm_callback(%LLMChain{llm: model} = chain, callback_map) do
+    %LLMChain{chain | llm: ChatModel.add_callback(model, callback_map)}
   end
 
   # a pipe-friendly execution of callbacks that returns the chain

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -58,6 +58,8 @@ defmodule LangChain.ChatModels.ChatAnthropic do
 
   @behaviour ChatModel
 
+  @current_config_version 1
+
   # allow up to 1 minute for response.
   @receive_timeout 60_000
 
@@ -866,4 +868,35 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   end
 
   defp get_token_usage(_response_body), do: %{}
+
+  @doc """
+  Generate a config map that can later restore the model's configuration.
+  """
+  @impl ChatModel
+  @spec serialize_config(t()) :: %{String.t() => any()}
+  def serialize_config(%ChatAnthropic{} = model) do
+    Utils.to_serializable_map(
+      model,
+      [
+        :endpoint,
+        :model,
+        :api_version,
+        :temperature,
+        :max_tokens,
+        :receive_timeout,
+        :top_p,
+        :top_k,
+        :stream
+      ],
+      @current_config_version
+    )
+  end
+
+  @doc """
+  Restores the model from the config.
+  """
+  @impl ChatModel
+  def restore_from_map(%{"version" => 1} = data) do
+    ChatAnthropic.new(data)
+  end
 end

--- a/lib/chat_models/chat_model.ex
+++ b/lib/chat_models/chat_model.ex
@@ -1,7 +1,9 @@
 defmodule LangChain.ChatModels.ChatModel do
+  require Logger
   alias LangChain.Message
   alias LangChain.MessageDelta
   alias LangChain.Function
+  alias LangChain.Utils
 
   @type call_response ::
           {:ok, Message.t() | [Message.t()] | [MessageDelta.t()]} | {:error, String.t()}
@@ -17,6 +19,10 @@ defmodule LangChain.ChatModels.ChatModel do
               [LangChain.Function.t()]
             ) :: call_response()
 
+  @callback serialize_config(t()) :: %{String.t() => any()}
+
+  @callback restore_from_map(%{String.t() => any()}) :: {:ok, struct()} | {:error, String.t()}
+
   @doc """
   Add a `LangChain.ChatModels.LLMCallbacks` callback map to the ChatModel if
   it includes the `:callback` key.
@@ -28,4 +34,30 @@ defmodule LangChain.ChatModels.ChatModel do
   end
 
   def add_callback(model, _callback_map), do: model
+
+  @doc """
+  Create a serializable map from a ChatModel's current configuration that can
+  later be restored.
+  """
+  def serialize_config(%chat_module{} = model) do
+    # plucks the module from the struct and, because of the behaviour, assumes
+    # the module defines a `serialize_config/1` function that is executed.
+    chat_module.serialize_config(model)
+  end
+
+  @doc """
+  Restore a ChatModel from a serialized config map.
+  """
+  @spec restore_from_map(nil | %{String.t() => any()}) :: {:ok, struct()} | {:error, String.t()}
+  def restore_from_map(nil), do: {:error, "No data to restore"}
+
+  def restore_from_map(%{"module" => module_name} = data) do
+    case Utils.module_from_name(module_name) do
+      {:ok, module} ->
+        module.restore_from_map(data)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
 end

--- a/lib/chat_models/chat_model.ex
+++ b/lib/chat_models/chat_model.ex
@@ -16,4 +16,16 @@ defmodule LangChain.ChatModels.ChatModel do
               String.t() | [Message.t()],
               [LangChain.Function.t()]
             ) :: call_response()
+
+  @doc """
+  Add a `LangChain.ChatModels.LLMCallbacks` callback map to the ChatModel if
+  it includes the `:callback` key.
+  """
+  @spec add_callback(%{optional(:callbacks) => nil | map()}, map()) :: map() | struct()
+  def add_callback(%_{callbacks: callbacks} = model, callback_map) do
+    existing_callbacks = callbacks || []
+    %{model | callbacks: existing_callbacks ++ [callback_map]}
+  end
+
+  def add_callback(model, _callback_map), do: model
 end

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -87,6 +87,8 @@ defmodule LangChain.ChatModels.ChatOpenAI do
 
   @behaviour ChatModel
 
+  @current_config_version 1
+
   # NOTE: As of gpt-4 and gpt-3.5, only one function_call is issued at a time
   # even when multiple requests could be issued based on the prompt.
 
@@ -879,4 +881,37 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   end
 
   defp get_token_usage(_response_body), do: nil
+
+  @doc """
+  Generate a config map that can later restore the model's configuration.
+  """
+  @impl ChatModel
+  @spec serialize_config(t()) :: %{String.t() => any()}
+  def serialize_config(%ChatOpenAI{} = model) do
+    Utils.to_serializable_map(
+      model,
+      [
+        :endpoint,
+        :model,
+        :temperature,
+        :frequency_penalty,
+        :receive_timeout,
+        :seed,
+        :n,
+        :json_response,
+        :stream,
+        :max_tokens,
+        :stream_options
+      ],
+      @current_config_version
+    )
+  end
+
+  @doc """
+  Restores the model from the config.
+  """
+  @impl ChatModel
+  def restore_from_map(%{"version" => 1} = data) do
+    ChatOpenAI.new(data)
+  end
 end

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -22,6 +22,8 @@ defmodule LangChain.ChatModels.ChatVertexAI do
 
   @behaviour ChatModel
 
+  @current_config_version 1
+
   # allow up to 2 minutes for response.
   @receive_timeout 60_000
 
@@ -585,4 +587,34 @@ defmodule LangChain.ChatModels.ChatVertexAI do
   defp unmap_role("model"), do: "assistant"
   defp unmap_role("function"), do: "tool"
   defp unmap_role(role), do: role
+
+  @doc """
+  Generate a config map that can later restore the model's configuration.
+  """
+  @impl ChatModel
+  @spec serialize_config(t()) :: %{String.t() => any()}
+  def serialize_config(%ChatVertexAI{} = model) do
+    Utils.to_serializable_map(
+      model,
+      [
+        :endpoint,
+        :model,
+        :temperature,
+        :top_p,
+        :top_k,
+        :receive_timeout,
+        :json_response,
+        :stream
+      ],
+      @current_config_version
+    )
+  end
+
+  @doc """
+  Restores the model from the config.
+  """
+  @impl ChatModel
+  def restore_from_map(%{"version" => 1} = data) do
+    ChatVertexAI.new(data)
+  end
 end

--- a/lib/images/open_ai_image.ex
+++ b/lib/images/open_ai_image.ex
@@ -188,7 +188,7 @@ defmodule LangChain.Images.OpenAIImage do
       Logger.warning("Found override API response. Will not make live API call.")
 
       case get_api_override() do
-        {:ok, {:ok, _data} = response} ->
+        {:ok, {:ok, _data, _callback_name} = response} ->
           response
 
         # fake error response

--- a/lib/images/open_ai_image.ex
+++ b/lib/images/open_ai_image.ex
@@ -188,9 +188,7 @@ defmodule LangChain.Images.OpenAIImage do
       Logger.warning("Found override API response. Will not make live API call.")
 
       case get_api_override() do
-        {:ok, {:ok, data} = response} ->
-          # fire callback for fake responses too
-          Utils.fire_callback(openai, data, callback_fn)
+        {:ok, {:ok, _data} = response} ->
           response
 
         # fake error response

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule LangChain.MixProject do
     [
       {:ecto, "~> 3.10 or ~> 3.11"},
       {:gettext, "~> 0.20"},
-      {:req, ">= 0.4.8"},
+      {:req, ">= 0.5.0"},
       {:abacus, "~> 2.1.0"},
       {:nx, ">= 0.7.0", optional: true},
       {:ex_doc, "~> 0.27", only: :dev, runtime: false}

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -1541,6 +1541,24 @@ defmodule LangChain.Chains.LLMChainTest do
     end
   end
 
+  describe "add_llm_callback/2" do
+    test "appends a callback handler to the chain's LLM", %{chat: chat} do
+      handler1 = %{on_llm_new_message: fn _chain, _msg -> IO.puts("MESSAGE 1!") end}
+      handler2 = %{on_llm_new_message: fn _chain, _msg -> IO.puts("MESSAGE 2!") end}
+
+      # none to start with
+      assert chat.callbacks == []
+
+      chain =
+        %{llm: chat}
+        |> LLMChain.new!()
+        |> LLMChain.add_llm_callback(handler1)
+        |> LLMChain.add_llm_callback(handler2)
+
+      assert chain.llm.callbacks == [handler1, handler2]
+    end
+  end
+
   # TODO: Sequential chains
   # https://js.langchain.com/docs/modules/chains/sequential_chain
 

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -1290,4 +1290,39 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
     #   assert false
     # end
   end
+
+  describe "serialize_config/2" do
+    test "does not include the API key or callbacks" do
+      model = ChatAnthropic.new!(%{model: "claude-3-haiku-20240307"})
+      result = ChatAnthropic.serialize_config(model)
+      assert result["version"] == 1
+      refute Map.has_key?(result, "api_key")
+      refute Map.has_key?(result, "callbacks")
+    end
+
+    test "creates expected map" do
+      model =
+        ChatAnthropic.new!(%{
+          model: "claude-3-haiku-20240307",
+          temperature: 0,
+          max_tokens: 1234
+        })
+
+      result = ChatAnthropic.serialize_config(model)
+
+      assert result == %{
+               "endpoint" => "https://api.anthropic.com/v1/messages",
+               "model" => "claude-3-haiku-20240307",
+               "max_tokens" => 1234,
+               "receive_timeout" => 60000,
+               "stream" => false,
+               "temperature" => 0.0,
+               "api_version" => "2023-06-01",
+               "top_k" => nil,
+               "top_p" => nil,
+               "module" => "Elixir.LangChain.ChatModels.ChatAnthropic",
+               "version" => 1
+             }
+    end
+  end
 end

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -19,7 +19,9 @@ defmodule ChatModels.ChatGoogleAITest do
         function: fn _args, _context -> {:ok, "Hello world!"} end
       })
 
-    %{hello_world: hello_world}
+    model = ChatGoogleAI.new!(%{})
+
+    %{model: model, hello_world: hello_world}
   end
 
   describe "new/1" do
@@ -46,14 +48,14 @@ defmodule ChatModels.ChatGoogleAITest do
     end
 
     test "supports overriding the API version" do
-      version = "v1"
+      api_version = "v1"
 
       model =
         ChatGoogleAI.new!(%{
-          version: version
+          api_version: api_version
         })
 
-      assert model.version == version
+      assert model.api_version == api_version
     end
   end
 
@@ -179,7 +181,7 @@ defmodule ChatModels.ChatGoogleAITest do
   end
 
   describe "do_process_response/2" do
-    test "handles receiving a message" do
+    test "handles receiving a message", %{model: model} do
       response = %{
         "candidates" => [
           %{
@@ -190,14 +192,14 @@ defmodule ChatModels.ChatGoogleAITest do
         ]
       }
 
-      assert [%Message{} = struct] = ChatGoogleAI.do_process_response(response)
+      assert [%Message{} = struct] = ChatGoogleAI.do_process_response(model, response)
       assert struct.role == :assistant
       [%ContentPart{type: :text, content: "Hello User!"}] = struct.content
       assert struct.index == 0
       assert struct.status == :complete
     end
 
-    test "error if receiving non-text content" do
+    test "error if receiving non-text content", %{model: model} do
       response = %{
         "candidates" => [
           %{
@@ -208,11 +210,11 @@ defmodule ChatModels.ChatGoogleAITest do
         ]
       }
 
-      assert [{:error, error_string}] = ChatGoogleAI.do_process_response(response)
+      assert [{:error, error_string}] = ChatGoogleAI.do_process_response(model, response)
       assert error_string == "role: is invalid"
     end
 
-    test "handles receiving function calls" do
+    test "handles receiving function calls", %{model: model} do
       args = %{"args" => "data"}
 
       response = %{
@@ -228,7 +230,7 @@ defmodule ChatModels.ChatGoogleAITest do
         ]
       }
 
-      assert [%Message{} = struct] = ChatGoogleAI.do_process_response(response)
+      assert [%Message{} = struct] = ChatGoogleAI.do_process_response(model, response)
       assert struct.role == :assistant
       assert struct.index == 0
       [call] = struct.tool_calls
@@ -236,7 +238,7 @@ defmodule ChatModels.ChatGoogleAITest do
       assert call.arguments == args
     end
 
-    test "handles receiving MessageDeltas as well" do
+    test "handles receiving MessageDeltas as well", %{model: model} do
       response = %{
         "candidates" => [
           %{
@@ -250,14 +252,14 @@ defmodule ChatModels.ChatGoogleAITest do
         ]
       }
 
-      assert [%MessageDelta{} = struct] = ChatGoogleAI.do_process_response(response, MessageDelta)
+      assert [%MessageDelta{} = struct] = ChatGoogleAI.do_process_response(model, response, MessageDelta)
       assert struct.role == :assistant
       assert struct.content == "This is the first part of a mes"
       assert struct.index == 0
       assert struct.status == :incomplete
     end
 
-    test "handles API error messages" do
+    test "handles API error messages", %{model: model} do
       response = %{
         "error" => %{
           "code" => 400,
@@ -266,20 +268,20 @@ defmodule ChatModels.ChatGoogleAITest do
         }
       }
 
-      assert {:error, error_string} = ChatGoogleAI.do_process_response(response)
+      assert {:error, error_string} = ChatGoogleAI.do_process_response(model, response)
       assert error_string == "Invalid request"
     end
 
-    test "handles Jason.DecodeError" do
+    test "handles Jason.DecodeError", %{model: model} do
       response = {:error, %Jason.DecodeError{}}
 
-      assert {:error, error_string} = ChatGoogleAI.do_process_response(response)
+      assert {:error, error_string} = ChatGoogleAI.do_process_response(model, response)
       assert "Received invalid JSON:" <> _ = error_string
     end
 
-    test "handles unexpected response with error" do
+    test "handles unexpected response with error", %{model: model} do
       response = %{}
-      assert {:error, "Unexpected response"} = ChatGoogleAI.do_process_response(response)
+      assert {:error, "Unexpected response"} = ChatGoogleAI.do_process_response(model, response)
     end
   end
 
@@ -338,6 +340,43 @@ defmodule ChatModels.ChatGoogleAITest do
                %{"text" => "Hello!"},
                %{"text" => "What's up?"}
              ]
+    end
+  end
+
+  describe "serialize_config/2" do
+    test "does not include the API key or callbacks" do
+      model = ChatGoogleAI.new!(%{model: "gpt-4o"})
+      result = ChatGoogleAI.serialize_config(model)
+      assert result["version"] == 1
+      refute Map.has_key?(result, "api_key")
+      refute Map.has_key?(result, "callbacks")
+    end
+
+    test "creates expected map" do
+      model =
+        ChatGoogleAI.new!(%{
+          model: "gpt-4o",
+          temperature: 0,
+          frequency_penalty: 0.5,
+          seed: 123,
+          max_tokens: 1234,
+          stream_options: %{include_usage: true}
+        })
+
+      result = ChatGoogleAI.serialize_config(model)
+
+      assert result == %{
+               "endpoint" => "https://generativelanguage.googleapis.com/v1beta",
+               "model" => "gpt-4o",
+               "module" => "Elixir.LangChain.ChatModels.ChatGoogleAI",
+               "receive_timeout" => 60000,
+               "stream" => false,
+               "temperature" => 0.0,
+               "version" => 1,
+               "api_version" => "v1beta",
+               "top_k" => 1.0,
+               "top_p" => 1.0
+             }
     end
   end
 end

--- a/test/chat_models/chat_model_test.exs
+++ b/test/chat_models/chat_model_test.exs
@@ -20,4 +20,39 @@ defmodule LangChain.ChatModels.ChatModelTest do
       assert updated == non_model
     end
   end
+
+  describe "serialize_config/1" do
+    test "creates a map from a chat model" do
+      model = ChatOpenAI.new!(%{model: "gpt-4o"})
+      result = ChatModel.serialize_config(model)
+      assert Map.get(result, "module") == "Elixir.LangChain.ChatModels.ChatOpenAI"
+      assert Map.get(result, "model") == "gpt-4o"
+      assert Map.get(result, "version") == 1
+    end
+  end
+
+  describe "restore_from_map/1" do
+    test "return error when nil data given" do
+      assert {:error, reason} = ChatModel.restore_from_map(nil)
+      assert reason == "No data to restore"
+    end
+
+    test "return error when module not found" do
+      assert {:error, reason} =
+               ChatModel.restore_from_map(%{
+                 "module" => "Elixir.InvalidModule",
+                 "version" => 1,
+                 "model" => "howdy"
+               })
+
+      assert reason == "ChatModel module \"Elixir.InvalidModule\" not found"
+    end
+
+    test "restores using the module" do
+      model = ChatOpenAI.new!(%{model: "gpt-4o"})
+      serialized = ChatModel.serialize_config(model)
+      {:ok, restored} = ChatModel.restore_from_map(serialized)
+      assert restored == model
+    end
+  end
 end

--- a/test/chat_models/chat_model_test.exs
+++ b/test/chat_models/chat_model_test.exs
@@ -1,0 +1,23 @@
+defmodule LangChain.ChatModels.ChatModelTest do
+  use ExUnit.Case
+  doctest LangChain.ChatModels.ChatModel
+  alias LangChain.ChatModels.ChatModel
+  alias LangChain.ChatModels.ChatOpenAI
+
+  describe "add_callback/2" do
+    test "appends the callback to the model" do
+      model = %ChatOpenAI{}
+      assert model.callbacks == []
+      handler = %{on_llm_new_message: fn _model, _msg -> :ok end}
+      %ChatOpenAI{} = updated = ChatModel.add_callback(model, handler)
+      assert updated.callbacks == [handler]
+    end
+
+    test "does nothing on a model that doesn't support callbacks" do
+      handler = %{on_llm_new_message: fn _model, _msg -> :ok end}
+      non_model = %{something: "else"}
+      updated = ChatModel.add_callback(non_model, handler)
+      assert updated == non_model
+    end
+  end
+end

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -1813,4 +1813,44 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       }
     ]
   end
+
+  describe "serialize_config/2" do
+    test "does not include the API key or callbacks" do
+      model = ChatOpenAI.new!(%{model: "gpt-4o"})
+      result = ChatOpenAI.serialize_config(model)
+      assert result["version"] == 1
+      refute Map.has_key?(result, "api_key")
+      refute Map.has_key?(result, "callbacks")
+    end
+
+    test "creates expected map" do
+      model =
+        ChatOpenAI.new!(%{
+          model: "gpt-4o",
+          temperature: 0,
+          frequency_penalty: 0.5,
+          seed: 123,
+          max_tokens: 1234,
+          stream_options: %{include_usage: true}
+        })
+
+      result = ChatOpenAI.serialize_config(model)
+
+      assert result == %{
+               "endpoint" => "https://api.openai.com/v1/chat/completions",
+               "frequency_penalty" => 0.5,
+               "json_response" => false,
+               "max_tokens" => 1234,
+               "model" => "gpt-4o",
+               "n" => 1,
+               "receive_timeout" => 60000,
+               "seed" => 123,
+               "stream" => false,
+               "stream_options" => %{"include_usage" => true},
+               "temperature" => 0.0,
+               "version" => 1,
+               "module" => "Elixir.LangChain.ChatModels.ChatOpenAI"
+             }
+    end
+  end
 end

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -321,4 +321,37 @@ defmodule ChatModels.ChatVertexAITest do
              ]
     end
   end
+
+  describe "serialize_config/2" do
+    test "does not include the API key or callbacks" do
+      model = ChatVertexAI.new!(%{model: "gemini-pro", endpoint: "http://localhost:1234/"})
+      result = ChatVertexAI.serialize_config(model)
+      assert result["version"] == 1
+      refute Map.has_key?(result, "api_key")
+      refute Map.has_key?(result, "callbacks")
+    end
+
+    test "creates expected map" do
+      model =
+        ChatVertexAI.new!(%{
+          model: "gemini-pro",
+          endpoint: "http://localhost:1234/"
+        })
+
+      result = ChatVertexAI.serialize_config(model)
+
+      assert result == %{
+               "endpoint" => "http://localhost:1234/",
+               "model" => "gemini-pro",
+               "module" => "Elixir.LangChain.ChatModels.ChatVertexAI",
+               "receive_timeout" => 60000,
+               "stream" => false,
+               "temperature" => 0.9,
+               "top_k" => 1.0,
+               "top_p" => 1.0,
+               "version" => 1,
+               "json_response" => false
+             }
+    end
+  end
 end


### PR DESCRIPTION
Major clean-up and updates. Test are all passing. There may be issues in some chat models that don't have good test coverage for non-live tests. This is why it's an RC! Plus docs update would be good.

functions for adding callbacks
- LLMChain supports adding a callback to it's model
- makes it easier when restoring a model via config or from a router and hooking up a callback chain

chat models support config serialization
- closes https://github.com/brainlid/langchain/discussions/104 discussion
- ChatModel top-level functions
- ChatOpenAI
- ChatAnthropic
- ChatBumblebee
- Utils functions
- ChatGoogleAI - added callback support (I think)
- ChatVertexAI

ollama updated for initial support of callbacks
- supports serializing

updated ChatMistralAI
- callbacks support
- new api
- serializing