### PR TITLE
WIP: Add LLMChain.set_tool_choice

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -194,6 +194,10 @@ defmodule LangChain.Chains.LLMChain do
     |> apply_action!(:update)
   end
 
+  @doc """
+  Set the tool_choice for the LLMChain.
+  """
+  @spec set_tool_choice(t(), ChatModel.tool_choice()) :: t() | no_return()
   def set_tool_choice(%LLMChain{} = chain, tool_choice) do
     chain
     |> change()

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -316,8 +316,14 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   #
   # Retries the request up to 3 times on transient errors with a 1 second delay
   @doc false
-  @spec do_api_request(t(), [Message.t()], ChatModel.tools(), (any() -> any())) ::
-          list() | struct() | {:error, String.t()}
+  @spec do_api_request(
+          t(),
+          [Message.t()],
+          ChatModel.tools(),
+          ChatModel.tool_choice(),
+          (any() -> any())
+        ) ::
+          list() | struct() | {:xerror, String.t()}
   def do_api_request(anthropic, messages, tools, tool_choice, retry_count \\ 3)
 
   def do_api_request(_anthropic, _messages, _functions, _tool_choice, 0) do

--- a/lib/chat_models/chat_model.ex
+++ b/lib/chat_models/chat_model.ex
@@ -11,6 +11,8 @@ defmodule LangChain.ChatModels.ChatModel do
   @type tool :: Function.t()
   @type tools :: [tool()]
 
+  @type tool_choice :: binary() | nil
+
   @type t :: Ecto.Schema.t()
 
   @callback call(

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -499,7 +499,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   # structures.
   # Retries the request up to 3 times on transient errors with a 1 second delay
   @doc false
-  @spec do_api_request(t(), [Message.t()], ChatModel.tools(), any(), integer()) ::
+  @spec do_api_request(t(), [Message.t()], ChatModel.tools(), ChatModel.tool_choice(), integer()) ::
           list() | struct() | {:error, String.t()}
   def do_api_request(openai, messages, tools, tool_choice, retry_count \\ 3)
 

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -213,7 +213,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
           t | Message.t() | Function.t(),
           message :: [map()],
           ChatModel.tools(),
-          tool_choice :: binary() | nil
+          ChatModel.tool_choice()
         ) :: %{
           atom() => any()
         }

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -145,6 +145,16 @@ defmodule LangChain.Chains.LLMChainTest do
     end
   end
 
+  describe "set_tool_choice/2" do
+    test "sets the tool choice", %{chat: chat} do
+      assert {:ok, %LLMChain{} = chain} = LLMChain.new(%{prompt: [], llm: chat})
+      assert chain.tool_choice == nil
+
+      updated_chain = LLMChain.set_tool_choice(chain, "information_extraction")
+      assert updated_chain.tool_choice == "information_extraction"
+    end
+  end
+
   describe "message_processors/2" do
     test "assigns processor list to the struct", %{chain: chain} do
       assert chain.message_processors == []

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -55,7 +55,7 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
     end
   end
 
-  describe "for_api/3" do
+  describe "for_api/4" do
     test "generates a map for an API call" do
       {:ok, anthropic} =
         ChatAnthropic.new(%{
@@ -65,7 +65,7 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
           "api_key" => "api_key"
         })
 
-      data = ChatAnthropic.for_api(anthropic, [], [])
+      data = ChatAnthropic.for_api(anthropic, [], [], nil)
       assert data.model == @test_model
       assert data.temperature == 1
       assert data.top_p == 0.5
@@ -80,7 +80,8 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
           [
             Message.new_system!("You are my helpful hero.")
           ],
-          []
+          [],
+          nil
         )
 
       assert "You are my helpful hero." == data[:system]
@@ -95,7 +96,7 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
           "max_tokens" => 1234
         })
 
-      data = ChatAnthropic.for_api(anthropic, [], [])
+      data = ChatAnthropic.for_api(anthropic, [], [], nil)
       assert data.model == @test_model
       assert data.temperature == 1
       assert data.top_p == 0.5
@@ -120,7 +121,7 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
           function: fn _args, _context -> :ok end
         })
 
-      output = ChatAnthropic.for_api(ChatAnthropic.new!(), [], [tool])
+      output = ChatAnthropic.for_api(ChatAnthropic.new!(), [], [tool], "greet")
 
       assert output[:tools] ==
                [
@@ -140,6 +141,8 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
                    }
                  }
                ]
+
+      assert output[:tool_choice] == %{"type" => "tool", "name" => "greet"}
     end
 
     test "includes multiple tool responses into a single user message" do
@@ -165,7 +168,7 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
           Message.new_assistant!(%{content: "No, \"sudo hi\""})
         ]
 
-      output = ChatAnthropic.for_api(ChatAnthropic.new!(), messages, [])
+      output = ChatAnthropic.for_api(ChatAnthropic.new!(), messages, [], nil)
 
       assert output[:messages] ==
                [

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -75,7 +75,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
     end
   end
 
-  describe "for_api/3" do
+  describe "for_api/4" do
     test "generates a map for an API call" do
       {:ok, openai} =
         ChatOpenAI.new(%{
@@ -85,7 +85,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
           "api_key" => "api_key"
         })
 
-      data = ChatOpenAI.for_api(openai, [], [])
+      data = ChatOpenAI.for_api(openai, [], [], nil)
       assert data.model == @test_model
       assert data.temperature == 1
       assert data.frequency_penalty == 0.5
@@ -101,7 +101,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
           "json_response" => true
         })
 
-      data = ChatOpenAI.for_api(openai, [], [])
+      data = ChatOpenAI.for_api(openai, [], [], nil)
       assert data.model == @test_model
       assert data.temperature == 1
       assert data.frequency_penalty == 0.5
@@ -117,7 +117,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
           "max_tokens" => 1234
         })
 
-      data = ChatOpenAI.for_api(openai, [], [])
+      data = ChatOpenAI.for_api(openai, [], [], nil)
       assert data.model == @test_model
       assert data.temperature == 1
       assert data.frequency_penalty == 0.5
@@ -131,9 +131,26 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
           stream_options: %{include_usage: true}
         })
 
-      data = ChatOpenAI.for_api(openai, [], [])
+      data = ChatOpenAI.for_api(openai, [], [], nil)
       assert data.model == @test_model
       assert data.stream_options == %{"include_usage" => true}
+    end
+
+    test "doesn't set tool_choice when nil" do
+      assert {:ok, %ChatOpenAI{} = chat} = ChatOpenAI.new(%{})
+      data = ChatOpenAI.for_api(chat, [], [], nil)
+
+      assert !Map.has_key?(data, :tool_choice)
+    end
+
+    test "sets the tool_choice" do
+      assert {:ok, %ChatOpenAI{} = chat} = ChatOpenAI.new(%{})
+      data = ChatOpenAI.for_api(chat, [], [], "information_extraction")
+
+      assert data.tool_choice == %{
+               "type" => "function",
+               "function" => %{"name" => "information_extraction"}
+             }
     end
   end
 
@@ -1143,7 +1160,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
         Message.new_user("Answer the following math question: What is 100 + 300 - 200?")
 
       _response =
-        ChatOpenAI.do_api_request(chat, [message], [LangChain.Tools.Calculator.new!()])
+        ChatOpenAI.do_api_request(chat, [message], [LangChain.Tools.Calculator.new!()], nil)
 
       # IO.inspect(response, label: "OPEN AI POST RESPONSE")
 


### PR DESCRIPTION
This PR adds an option to specify `tool_choice`. I found that a lot of structured data extraction responses contained `multi_tool_use.parallel`. Specifying a tool via `tool_choice` avoids having to deal with this, and forces the use of the given tool.

I've only added this to the OpenAI adapter so far. Thoughts?