### PR TITLE
fix: typespec error on Message.new_user/1

### DIFF
--- a/lib/message.ex
+++ b/lib/message.ex
@@ -323,7 +323,7 @@ defmodule LangChain.Message do
   Create a new user message which represents a human message or a message from
   the application.
   """
-  @spec new_user(content :: String.t() | [ContentPart.t()]) ::
+  @spec new_user(content :: String.t() | [ContentPart.t() | PromptTemplate.t()]) ::
           {:ok, t()} | {:error, Ecto.Changeset.t()}
   def new_user(content) do
     new(%{role: :user, content: content, status: :complete})
@@ -333,7 +333,7 @@ defmodule LangChain.Message do
   Create a new user message which represents a human message or a message from
   the application.
   """
-  @spec new_user!(content :: String.t() | [ContentPart.t()]) :: t() | no_return()
+  @spec new_user!(content :: String.t() | [ContentPart.t() | PromptTemplate.t()]) :: t() | no_return()
   def new_user!(content) do
     case new_user(content) do
       {:ok, msg} ->


### PR DESCRIPTION
## What does this PR do?

It fixes a minor typespec error on `Langchain.Message.new_user!/1`.

## Context
 
 I'm working on a small project that does image analysis with AI and I am using this elixir package following the guidelines of [this notebook](https://github.com/brainlid/langchain/blob/main/notebooks/context-specific-image-descriptions.livemd) and I get an error when running `mix dialyzer`.
 
 This notebook recommends building messages as follows:
 ```elixir
 messages = [
  Message.new_system!("""
  ...
  System description
  ....
  """),
  Message.new_user!([
    PromptTemplate.from_template!("""
    ...
    Template description
    ...
    """),
    ContentPart.image!(image_data, media: :jpg, detail: "low")
  ])
]
 ```

This code actually works but the typespec is not compatible with it:
```elixir
  defmodule Langchain.Message do
     @type t :: %Message{}
     @spec new_user!(content :: String.t() | [ContentPart.t()]) :: t() | no_return()
  end
  
  defmodule Langchain.PromptTemplate do
     @type t :: %PromptTemplate{}
     @spec from_template!(text :: String.t()) :: t() | no_return()
  end
  
  defmodule LangChain.Message.ContentPart do
    @type t :: %ContentPart{}
     @spec image!(String.t(), Keyword.t()) :: t() | no_return()
  end
 ```
 
 You can see that the spec of `new_user!/1` accepts a `content` argument as a `String`, or a list of `ContentPart.t()`, but it should also accept `PromptTemplate.t()`.
 
 I would recommend using [credo](https://github.com/rrrene/credo) and [dialyxir](https://github.com/jeremyjh/dialyxir) packages to fix these kind of warnings.


 