### PR TITLE
Remove ApiOverride reference in mix.exs project.docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -111,7 +111,6 @@ defmodule LangChain.MixProject do
           LangChain.Utils,
           LangChain.Utils.ChatTemplates,
           LangChain.Utils.ChainResult,
-          LangChain.Utils.ApiOverride,
           LangChain.Config,
           LangChain.Gettext
         ]


### PR DESCRIPTION
Removing a leftover reference to `ApiOverride` after the switch to Mimic in https://github.com/brainlid/langchain/pull/155