### PR TITLE
Fix streaming error when using Azure OpenAI Service

### DIFF
--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -154,7 +154,7 @@ defmodule LangChain.Utils do
         parsed_data =
           parsed_data
           |> Enum.map(transform_data_fn)
-          |> Enum.reject(&(&1 == :skip))
+          |> Enum.reject(&(&1 == :skip || &1 == []))
 
         # execute the callback function for each MessageDelta and an optional
         # TokenUsage

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -168,4 +168,30 @@ defmodule LangChain.UtilsTest do
       assert reason == "ChatModel module \"Elixir.Missing.Module\" not found"
     end
   end
+
+  describe "handle_stream_fn/3" do
+    test "skips transformed messages with :skip" do
+      function =
+        Utils.handle_stream_fn(%{callbacks: []}, fn _ -> {[[]], ""} end, fn _ ->
+          :skip
+        end)
+
+      {:cont, {_model, %{body: body}}} = function.({:data, ""}, {1, %Req.Response{status: 200}})
+
+      assert body == []
+    end
+
+    test "skips transformed messages with empty list" do
+      empty_transform_message = []
+
+      function =
+        Utils.handle_stream_fn(%{callbacks: []}, fn _ -> {[[]], ""} end, fn _ ->
+          empty_transform_message
+        end)
+
+      {:cont, {_model, %{body: body}}} = function.({:data, ""}, {1, %Req.Response{status: 200}})
+
+      assert body == []
+    end
+  end
 end


### PR DESCRIPTION
Trying out Azure OpenAI service and ran into an issue with streaming chat completions (`gpt-4o` version `2024-05-13`).

A case clause error occurs in `LLMChain.do_run` ([link](https://github.com/brainlid/langchain/blob/6fed31cc53ababe359b712be4bcf3c96e5ea2a9f/lib/chains/llm_chain.ex#L346)). The issue is a message is being transformed and returning `[]`.

```
16:20:35.537 [error] {{:case_clause, {:ok, [[], [%LangChain.MessageDelta{content: "", status: :incomplete, index: 0, role: :assistant, tool_calls: nil}], [%LangChain.MessageDelta{
```

The message from Azure OpenAI that results in a `[]` return value from `do_process_return` is (from [here](https://github.com/brainlid/langchain/blob/6fed31cc53ababe359b712be4bcf3c96e5ea2a9f/lib/chat_models/chat_open_ai.ex#L666-L668)):

```
%{
  "choices" => [],
  "created" => 0,
  "id" => "",
  "model" => "",
  "object" => "",
  "prompt_filter_results" => [
    %{
      "content_filter_results" => %{
        "hate" => %{"filtered" => false, "severity" => "safe"},
        "self_harm" => %{"filtered" => false, "severity" => "safe"},
        "sexual" => %{"filtered" => false, "severity" => "safe"},
        "violence" => %{"filtered" => false, "severity" => "safe"}
      },
      "prompt_index" => 0
    }
  ]
}
```

I went with adding this to `Utils.handle_stream_fn` since it would prevent this error for other transform return values that potentially could return `[]`, but an alternative fix would be to add the following to ChatOpenAI before L664:

```
  def do_process_response(_model, %{"choices" => []}) do
    :skip
  end
```