### PR TITLE
Enable tool support for ollama

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -24,6 +24,7 @@ Mimic.copy(LangChain.ChatModels.ChatOpenAI)
 Mimic.copy(LangChain.ChatModels.ChatAnthropic)
 Mimic.copy(LangChain.ChatModels.ChatMistralAI)
 Mimic.copy(LangChain.ChatModels.ChatBumblebee)
+Mimic.copy(LangChain.ChatModels.ChatOllamaAI)
 Mimic.copy(LangChain.Images.OpenAIImage)
 
 ExUnit.configure(capture_log: true, exclude: [live_call: true])


### PR DESCRIPTION
Adds basic support for tools with ollama `v0.3`, tested with the hairbrush example:

```elixir
alias LangChain.Function
alias LangChain.Message
alias LangChain.Chains.LLMChain
alias LangChain.ChatModels.ChatOllamaAI


# map of data we want to be passed as `context` to the function when
# executed.
custom_context = %{
  "user_id" => 123,
  "hairbrush" => "drawer",
  "dog" => "backyard",
  "sandwich" => "kitchen"
}

# a custom Elixir function made available to the LLM
custom_fn =
  Function.new!(%{
    name: "custom",
    description: "Returns the location of the requested element or item.",
    parameters_schema: %{
      type: "object",
      properties: %{
        thing: %{
          type: "string",
          description: "The thing whose location is being requested."
        }
      },
      required: ["thing"]
    },
    function: fn %{"thing" => thing} = _arguments, context ->
      # our context is a pretend item/location location map
      {:ok, context[thing]}
  end
  })

# create and run the chain
{:ok, updated_chain, %Message{} = message} =
  LLMChain.new!(%{
    llm: ChatOllamaAI.new!(%{model: "llama3.1", verbose: true}),
    custom_context: custom_context,
    verbose: true
  })
  |> LLMChain.add_tools(custom_fn)
  |> LLMChain.add_message(Message.new_user!("Where is the hairbrush located?"))
  |> LLMChain.run(mode: :while_needs_response)

# print the LLM's answer
IO.puts(message.content)
#=> "The hairbrush is located in the drawer."
```