### PR TITLE
change return of LLMChain.run/2 - breaking change

### DIFF
--- a/lib/chains/text_to_title_chain.ex
+++ b/lib/chains/text_to_title_chain.ex
@@ -82,7 +82,7 @@ defmodule LangChain.Chains.TextToTitleChain do
       |> TextToTitleChain.run()
 
   """
-  @spec run(t(), Keyword.t()) :: String.t() | no_return()
+  @spec run(t(), Keyword.t()) :: {:ok, LLMChain.t()} | {:error, LLMChain.t(), String.t()}
   def run(%TextToTitleChain{} = chain, opts \\ []) do
     messages =
       [

--- a/lib/chat_models/llm_callbacks.ex
+++ b/lib/chat_models/llm_callbacks.ex
@@ -37,7 +37,7 @@ defmodule LangChain.ChatModels.LLMCallbacks do
 
   A function declaration that matches the signature.
 
-      def handle_llm_new_delta(_chat_model, _index, delta) do
+      def handle_llm_new_delta(_chat_model, delta) do
         IO.write(delta)
       end
   """

--- a/lib/utils/chain_result.ex
+++ b/lib/utils/chain_result.ex
@@ -20,7 +20,7 @@ defmodule LangChain.Utils.ChainResult do
   """
   @spec to_string(
           LLMChain.t()
-          | {:ok, LLMChain.t(), Message.t()}
+          | {:ok, LLMChain.t()}
           | {:error, LLMChain.t(), String.t()}
         ) ::
           {:ok, String.t()} | {:error, LLMChain.t(), String.t()}
@@ -29,7 +29,7 @@ defmodule LangChain.Utils.ChainResult do
     {:error, chain, reason}
   end
 
-  def to_string({:ok, %LLMChain{} = chain, _message}) do
+  def to_string({:ok, %LLMChain{} = chain}) do
     ChainResult.to_string(chain)
   end
 

--- a/notebooks/context-specific-image-descriptions.livemd
+++ b/notebooks/context-specific-image-descriptions.livemd
@@ -177,14 +177,14 @@ alias LangChain.MessageProcessors.JsonProcessor
 # When we `apply_prompt_templates` below, the data is rendered into the template.
 image_data_from_other_system = "image of urban art mural on underpass at 507 King St E"
 
-{:ok, _updated_chain, response} =
+{:ok, updated_chain} =
   %{llm: openai_chat_model, verbose: true}
   |> LLMChain.new!()
   |> LLMChain.apply_prompt_templates(messages, %{extra_image_info: image_data_from_other_system})
   |> LLMChain.message_processors([JsonProcessor.new!()])
   |> LLMChain.run(mode: :until_success)
 
-response.processed_content
+updated_chain.last_message.processed_content
 ```
 
 Notice that when running the chain, we use the option `mode: :until_success`. Some LLMs are better are generating valid JSON than other LLMs. When we included the `JsonProcesser`, it parses the assistant's content, converting it into an Elixir map. The converted data is stored on the `message.processed_content`.
@@ -238,14 +238,14 @@ alias LangChain.MessageProcessors.JsonProcessor
 # When we `apply_prompt_templates` below, the data is rendered into the template.
 image_data_from_other_system = "image of urban art mural on underpass at 507 King St E"
 
-{:ok, _updated_chain, response} =
+{:ok, updated_chain} =
   %{llm: anthropic_chat_model, verbose: true}
   |> LLMChain.new!()
   |> LLMChain.apply_prompt_templates(messages, %{extra_image_info: image_data_from_other_system})
   |> LLMChain.message_processors([JsonProcessor.new!()])
   |> LLMChain.run(mode: :until_success)
 
-response.processed_content
+updated_chain.last_message.processed_content
 ```
 
 Nice! The Elixir LangChain library abstracted away the differences between the two services. With no code changes, we can make a similar request about the image from Anthropic's Claude LLM as well!

--- a/notebooks/custom_functions.livemd
+++ b/notebooks/custom_functions.livemd
@@ -236,7 +236,7 @@ Additionally, the `stream: false` option says we want the result only when it's 
 ```elixir
 alias LangChain.Chains.LLMChain
 
-{:ok, updated_chain, response} =
+{:ok, updated_chain} =
   %{llm: chat_model, custom_context: context, verbose: true}
   |> LLMChain.new!()
   |> LLMChain.add_messages(messages)
@@ -245,6 +245,7 @@ alias LangChain.Chains.LLMChain
   # function calls and provide a response.
   |> LLMChain.run(mode: :while_needs_response)
 
+response = updated_chain.last_message
 IO.write(response.content)
 response.content
 ```
@@ -382,8 +383,8 @@ MESSAGE PROCESSED: %LangChain.Message{
   tool_calls: [],
   tool_results: nil
 }
-Joan's favorite,    
-Aardvark graces night with charm,   
+Joan's favorite,
+Aardvark graces night with charm,
 Silent earth's delight.
 ```
 

--- a/notebooks/getting_started.livemd
+++ b/notebooks/getting_started.livemd
@@ -28,13 +28,13 @@ alias LangChain.Chains.LLMChain
 alias LangChain.ChatModels.ChatOpenAI
 alias LangChain.Message
 
-{:ok, _updated_chain, response} =
+{:ok, updated_chain} =
   %{llm: ChatOpenAI.new!(%{model: "gpt-4o"})}
   |> LLMChain.new!()
   |> LLMChain.add_message(Message.new_user!("Testing, testing!"))
   |> LLMChain.run()
 
-response.content
+updated_chain.last_message.content
 ```
 
 Nice! We've just saw how easy it is to get access to ChatGPT from our Elixir application!
@@ -48,7 +48,7 @@ When working with ChatGPT and other LLMs, the conversation works as a series of 
 Let's create a system message followed by a user message.
 
 ```elixir
-{:ok, _updated_chain, response} =
+{:ok, updated_chain} =
   %{llm: ChatOpenAI.new!(%{model: "gpt-4"})}
   |> LLMChain.new!()
   |> LLMChain.add_messages([
@@ -59,7 +59,7 @@ Let's create a system message followed by a user message.
   ])
   |> LLMChain.run()
 
-response.content
+updated_chain.last_message.content
 ```
 
 Here's the answer it gave me when I ran it:
@@ -94,7 +94,7 @@ handler = %{
   end
 }
 
-{:ok, _updated_chain, response} =
+{:ok, updated_chain} =
   %{
     # llm config for streaming and the deltas callback
     llm: ChatOpenAI.new!(%{model: "gpt-4o", stream: true, callbacks: [handler]}),
@@ -108,7 +108,7 @@ handler = %{
   ])
   |> LLMChain.run()
 
-response.content
+updated_chain.last_message.content
 # streamed
 # ==> Washington D.C. stands,
 # ... Monuments reflect history,

--- a/test/chains/data_extraction_chain_test.exs
+++ b/test/chains/data_extraction_chain_test.exs
@@ -66,9 +66,9 @@ defmodule LangChain.Chains.DataExtractionChainTest do
     # run the chain, chain.run(prompt to extract data from)
     data_prompt =
       "Alex is 5 feet tall. Claudia is 4 feet taller than Alex and jumps higher than him.
-       Claudia is a brunette and Alex is blonde. Alex's dog Frosty is a labrador and likes to play hide and seek."
+       Claudia is a brunette and Alex is blonde. Alex's dog Frosty is a labrador and likes to play hide and seek. Identify each person and their relevant information."
 
-    {:ok, result} = DataExtractionChain.run(chat, schema_parameters, data_prompt, verbose: false)
+    {:ok, result} = DataExtractionChain.run(chat, schema_parameters, data_prompt, verbose: true)
 
     assert result == [
              %{

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -60,9 +60,15 @@ defmodule LangChain.Chains.LLMChainTest do
       Function.new!(%{
         name: "fail_once",
         description: "Return a function that fails once and succeeds on the second request.",
+        # make it `async: false` so the test process remains the same and our
+        # process dictionary hack will work.
+        async: false,
         function: fn _args, _context ->
           # uses the process dictionary to store the test state
-          if Process.get(:test_func_failed_once, false) do
+          #
+          # if we haven't failed once yet, do that. After failing once, the
+          # state is changed and it will pass the next time.
+          if false == Process.get(:test_func_failed_once, false) do
             Process.put(:test_func_failed_once, true)
             {:error, "Not what I wanted"}
           else
@@ -228,7 +234,7 @@ defmodule LangChain.Chains.LLMChainTest do
         )
 
       # We can construct an LLMChain from a PromptTemplate and an LLM.
-      {:ok, updated_chain, response} =
+      {:ok, updated_chain, [response]} =
         %{llm: ChatOpenAI.new!(%{temperature: 1, seed: 0, stream: false}), verbose: true}
         |> LLMChain.new!()
         |> LLMChain.apply_prompt_templates([prompt], %{product: "colorful socks"})
@@ -247,22 +253,24 @@ defmodule LangChain.Chains.LLMChainTest do
           "Suggest one good name for a company that makes <%= @product %>?"
         )
 
-      callback = fn
-        %MessageDelta{} = delta ->
+      handler = %{
+        on_llm_new_delta: fn _chain, delta ->
           send(self(), {:test_stream_deltas, delta})
-
-        %Message{} = message ->
+        end,
+        on_message_processed: fn _chain, message ->
           send(self(), {:test_stream_message, message})
-      end
+        end
+      }
 
-      model = ChatOpenAI.new!(%{temperature: 1, seed: 0, stream: true})
+      model = ChatOpenAI.new!(%{temperature: 1, seed: 0, stream: true, callbacks: [handler]})
 
       # We can construct an LLMChain from a PromptTemplate and an LLM.
-      {:ok, updated_chain, response} =
+      {:ok, updated_chain, [response]} =
         %{llm: model, verbose: true}
         |> LLMChain.new!()
+        |> LLMChain.add_callback(handler)
         |> LLMChain.apply_prompt_templates([prompt], %{product: "colorful socks"})
-        |> LLMChain.run(callback_fn: callback)
+        |> LLMChain.run()
 
       assert %Message{role: :assistant} = response
       assert updated_chain.last_message == response
@@ -295,7 +303,7 @@ defmodule LangChain.Chains.LLMChainTest do
       end)
 
       # We can construct an LLMChain from a PromptTemplate and an LLM.
-      {:ok, %LLMChain{} = updated_chain, message} =
+      {:ok, %LLMChain{} = updated_chain, [exchanged_message]} =
         %{llm: ChatOpenAI.new!(%{stream: false})}
         |> LLMChain.new!()
         |> LLMChain.apply_prompt_templates([prompt], %{product: "colorful socks"})
@@ -303,7 +311,7 @@ defmodule LangChain.Chains.LLMChainTest do
         |> LLMChain.run()
 
       assert updated_chain.needs_response == false
-      assert updated_chain.last_message == message
+      assert updated_chain.last_message == exchanged_message
       assert updated_chain.last_message == fake_message
     end
 
@@ -344,7 +352,7 @@ defmodule LangChain.Chains.LLMChainTest do
       end)
 
       # We can construct an LLMChain from a PromptTemplate and an LLM.
-      {:ok, updated_chain, response} =
+      {:ok, updated_chain, [response]} =
         %{llm: model, verbose: false, callbacks: [chain_handler]}
         |> LLMChain.new!()
         |> LLMChain.apply_prompt_templates([prompt], %{product: "colorful socks"})
@@ -902,7 +910,7 @@ defmodule LangChain.Chains.LLMChainTest do
         })
 
       # create and run the chain
-      {:ok, updated_chain, %Message{} = message} =
+      {:ok, updated_chain, exchanged_messages} =
         LLMChain.new!(%{
           llm: ChatOpenAI.new!(%{seed: 0}),
           custom_context: custom_context,
@@ -912,9 +920,11 @@ defmodule LangChain.Chains.LLMChainTest do
         |> LLMChain.add_message(Message.new_user!("Where is the hairbrush located?"))
         |> LLMChain.run(mode: :while_needs_response)
 
-      assert updated_chain.last_message == message
-      assert message.role == :assistant
-      assert message.content == "The hairbrush is located in the drawer."
+      [_tool_call, _tool_result, %Message{} = final_message] = exchanged_messages
+
+      assert updated_chain.last_message == final_message
+      assert final_message.role == :assistant
+      assert final_message.content == "The hairbrush is located in the drawer."
 
       # assert our custom function was executed with custom_context supplied
       assert_received {:function_run, arguments, context}
@@ -987,7 +997,7 @@ defmodule LangChain.Chains.LLMChainTest do
           end
         })
 
-      {:ok, _updated_chain, %Message{} = response} =
+      {:ok, _updated_chain, exchanged_messages} =
         LLMChain.new!(%{
           llm: ChatOpenAI.new!(%{seed: 0, stream: false}),
           custom_context: nil,
@@ -997,10 +1007,12 @@ defmodule LangChain.Chains.LLMChainTest do
         |> LLMChain.add_message(message)
         |> LLMChain.run(mode: :while_needs_response)
 
-      # the response should contain data returned from the function
-      assert response.content =~ "Germany"
-      assert response.content =~ "fra"
-      assert response.role == :assistant
+      [_tool_call, _tool_result, %Message{} = final_response] = exchanged_messages
+
+      # the final_response should contain data returned from the function
+      assert final_response.content =~ "Germany"
+      assert final_response.content =~ "fra"
+      assert final_response.role == :assistant
       assert_received {:function_called, "fly_regions"}
     end
 
@@ -1044,7 +1056,9 @@ defmodule LangChain.Chains.LLMChainTest do
       assert reason =~ ~r/PromptTemplates must be/
     end
 
-    test "increments current_failure_count on parse failure", %{chain: chain} do
+    test "mode: :while_needs_response - increments current_failure_count on parse failure", %{
+      chain: chain
+    } do
       # Made NOT LIVE here
       fake_messages = [
         Message.new_assistant!(%{content: "Not what you wanted"})
@@ -1096,7 +1110,7 @@ defmodule LangChain.Chains.LLMChainTest do
       assert m7.content == "ERROR: Invalid JSON data: unexpected byte at position 0: 0x4E (\"N\")"
     end
 
-    test "fires callbacks for failed messages correctly" do
+    test "mode: :while_needs_response - fires callbacks for failed messages correctly" do
       handler = %{
         on_message_processing_error: fn _chain, data ->
           send(self(), {:processing_error_callback, data})
@@ -1177,7 +1191,7 @@ defmodule LangChain.Chains.LLMChainTest do
         {:ok, fake_messages}
       end)
 
-      {:ok, _updated_chain, last_message} =
+      {:ok, _updated_chain, [last_message]} =
         chain
         |> LLMChain.message_processors([JsonProcessor.new!()])
         |> LLMChain.add_message(Message.new_system!())
@@ -1202,13 +1216,15 @@ defmodule LangChain.Chains.LLMChainTest do
          ]}
       end)
 
-      {:ok, _updated_chain, last_message} =
+      {:ok, _updated_chain, exchanged_messages} =
         %{llm: chat}
         |> LLMChain.new!()
         |> LLMChain.message_processors([JsonProcessor.new!()])
         |> LLMChain.add_message(Message.new_system!())
         |> LLMChain.add_message(Message.new_user!("What's the value in JSON?"))
         |> LLMChain.run(mode: :until_success)
+
+      [_invalid_msg, _error_response, last_message] = exchanged_messages
 
       # stopped after processing a successful assistant response
       assert last_message.role == :assistant
@@ -1225,11 +1241,11 @@ defmodule LangChain.Chains.LLMChainTest do
         ])
       ]
 
-      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+      expect(ChatOpenAI, :call, 2, fn _model, _messages, _tools ->
         {:ok, fake_messages}
       end)
 
-      {:ok, updated_chain, last_message} =
+      {:ok, updated_chain, exchanged_messages} =
         %{llm: ChatOpenAI.new!(%{stream: false}), verbose: false}
         |> LLMChain.new!()
         |> LLMChain.add_tools([fail_once])
@@ -1237,8 +1253,60 @@ defmodule LangChain.Chains.LLMChainTest do
         |> LLMChain.add_message(Message.new_user!("Execute the fail_once tool."))
         |> LLMChain.run(mode: :until_success)
 
-      assert last_message.role == :tool
-      assert [%ToolResult{is_error: false}] = last_message.tool_results
+      [tool_call_1, tool_result_1, tool_call_2, tool_result_2] = exchanged_messages
+
+      assert %Message{
+               tool_calls: [
+                 %LangChain.Message.ToolCall{
+                   status: :complete,
+                   type: :function,
+                   call_id: "call_fake123",
+                   name: "fail_once"
+                 }
+               ]
+             } = tool_call_1
+
+      assert %Message{
+               tool_results: [
+                 %LangChain.Message.ToolResult{
+                   type: :function,
+                   tool_call_id: "call_fake123",
+                   name: "fail_once",
+                   content: "Not what I wanted",
+                   # failed
+                   is_error: true
+                 }
+               ]
+             } = tool_result_1
+
+      assert %Message{
+               tool_calls: [
+                 %LangChain.Message.ToolCall{
+                   status: :complete,
+                   type: :function,
+                   call_id: "call_fake123",
+                   name: "fail_once"
+                 }
+               ]
+             } = tool_call_2
+
+      assert %Message{
+               status: :complete,
+               role: :tool,
+               tool_results: [
+                 %LangChain.Message.ToolResult{
+                   type: :function,
+                   tool_call_id: "call_fake123",
+                   name: "fail_once",
+                   content: "It worked this time",
+                   # passed
+                   is_error: false
+                 }
+               ]
+             } = tool_result_2
+
+      assert updated_chain.last_message.role == :tool
+      assert [%ToolResult{is_error: false}] = updated_chain.last_message.tool_results
       assert updated_chain.current_failure_count == 0
     end
 
@@ -1255,17 +1323,19 @@ defmodule LangChain.Chains.LLMChainTest do
         ])
       ]
 
-      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+      expect(ChatOpenAI, :call, 2, fn _model, _messages, _tools ->
         {:ok, fake_messages}
       end)
 
-      {:ok, updated_chain, last_message} =
+      {:ok, updated_chain, exchanged_messages} =
         %{llm: ChatOpenAI.new!(%{stream: false}), verbose: false}
         |> LLMChain.new!()
         |> LLMChain.add_tools([hello_world, fail_once])
         |> LLMChain.add_message(Message.new_system!())
         |> LLMChain.add_message(Message.new_user!("Execute the fail_once tool."))
         |> LLMChain.run(mode: :until_success)
+
+      [_tool_call_1, _failed_result_1, _tool_call_2, last_message] = exchanged_messages
 
       assert last_message.role == :tool
 

--- a/test/chains/routing_chain_test.exs
+++ b/test/chains/routing_chain_test.exs
@@ -133,7 +133,7 @@ defmodule LangChain.Chains.RoutingChainTest do
         {:ok, [fake_message]}
       end)
 
-      assert {:ok, updated_chain, last_msg} = RoutingChain.run(routing_chain)
+      assert {:ok, updated_chain, [last_msg]} = RoutingChain.run(routing_chain)
       assert %LLMChain{} = updated_chain
       assert last_msg == fake_message
     end

--- a/test/chains/routing_chain_test.exs
+++ b/test/chains/routing_chain_test.exs
@@ -133,9 +133,9 @@ defmodule LangChain.Chains.RoutingChainTest do
         {:ok, [fake_message]}
       end)
 
-      assert {:ok, updated_chain, [last_msg]} = RoutingChain.run(routing_chain)
+      assert {:ok, updated_chain} = RoutingChain.run(routing_chain)
       assert %LLMChain{} = updated_chain
-      assert last_msg == fake_message
+      assert updated_chain.last_message == fake_message
     end
   end
 

--- a/test/chains/text_to_title_chain_test.exs
+++ b/test/chains/text_to_title_chain_test.exs
@@ -67,7 +67,7 @@ defmodule LangChain.Chains.TextToTitleChainTest do
         {:ok, [fake_message]}
       end)
 
-      assert {:ok, updated_chain, last_msg} = TextToTitleChain.run(title_chain)
+      assert {:ok, updated_chain, [last_msg]} = TextToTitleChain.run(title_chain)
       assert %LLMChain{} = updated_chain
       assert last_msg == fake_message
     end

--- a/test/chains/text_to_title_chain_test.exs
+++ b/test/chains/text_to_title_chain_test.exs
@@ -67,9 +67,9 @@ defmodule LangChain.Chains.TextToTitleChainTest do
         {:ok, [fake_message]}
       end)
 
-      assert {:ok, updated_chain, [last_msg]} = TextToTitleChain.run(title_chain)
+      assert {:ok, updated_chain} = TextToTitleChain.run(title_chain)
       assert %LLMChain{} = updated_chain
-      assert last_msg == fake_message
+      assert updated_chain.last_message == fake_message
     end
   end
 

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -1223,14 +1223,14 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
         })
 
       # verbose: true
-      {:ok, _result_chain, last_message} =
+      {:ok, updated_chain} =
         LLMChain.new!(%{llm: chat, verbose: false})
         |> LLMChain.add_message(user_message)
         |> LLMChain.add_tools(tool)
         |> LLMChain.run(mode: :until_success)
 
       # has the result from the function execution
-      [tool_result] = last_message.tool_results
+      [tool_result] = updated_chain.last_message.tool_results
       assert tool_result.content == "SUCCESS"
     end
   end
@@ -1246,14 +1246,14 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
         end
       }
 
-      {:ok, _result_chain, last_message} =
+      {:ok, updated_chain} =
         LLMChain.new!(%{llm: %ChatAnthropic{stream: true, callbacks: [handler]}})
         |> LLMChain.add_message(Message.new_user!("Say, 'Hi!'!"))
         |> LLMChain.run()
 
-      assert last_message.content == "Hi!"
-      assert last_message.status == :complete
-      assert last_message.role == :assistant
+      assert updated_chain.last_message.content == "Hi!"
+      assert updated_chain.last_message.status == :complete
+      assert updated_chain.last_message.role == :assistant
 
       assert_received {:streamed_fn, data}
       assert %MessageDelta{role: :assistant} = data
@@ -1275,14 +1275,14 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
         end
       }
 
-      {:ok, _result_chain, last_message} =
+      {:ok, updated_chain} =
         LLMChain.new!(%{llm: %ChatAnthropic{stream: false, callbacks: [handler]}})
         |> LLMChain.add_message(Message.new_user!("Say, 'Hi!'!"))
         |> LLMChain.run()
 
-      assert last_message.content == "Hi!"
-      assert last_message.status == :complete
-      assert last_message.role == :assistant
+      assert updated_chain.last_message.content == "Hi!"
+      assert updated_chain.last_message.status == :complete
+      assert updated_chain.last_message.role == :assistant
 
       assert_received {:received_msg, data}
       assert %Message{role: :assistant} = data
@@ -1316,7 +1316,7 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
         end
       }
 
-      {:ok, _result_chain, last_message} =
+      {:ok, updated_chain} =
         LLMChain.new!(%{
           llm: %ChatAnthropic{model: @test_model, stream: true, callbacks: [handler]}
         })
@@ -1326,9 +1326,9 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
         |> LLMChain.add_message(Message.new_user!("What's the capitol of Norway?"))
         |> LLMChain.run()
 
-      assert last_message.content =~ "Oslo"
-      assert last_message.status == :complete
-      assert last_message.role == :assistant
+      assert updated_chain.last_message.content =~ "Oslo"
+      assert updated_chain.last_message.status == :complete
+      assert updated_chain.last_message.role == :assistant
 
       assert_received {:streamed_fn, data}
       assert %MessageDelta{role: :assistant} = data

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -587,7 +587,7 @@ defmodule ChatModels.ChatGoogleAITest do
 
       model = ChatGoogleAI.new!(%{temperature: 0, stream: false, callbacks: [llm_handler]})
 
-      {:ok, updated_chain, %Message{} = message} =
+      {:ok, updated_chain} =
         LLMChain.new!(%{
           llm: model,
           verbose: false,
@@ -600,8 +600,8 @@ defmodule ChatModels.ChatGoogleAITest do
         |> LLMChain.add_tools(Calculator.new!())
         |> LLMChain.run(mode: :while_needs_response)
 
-      assert updated_chain.last_message == message
-      assert message.role == :assistant
+      assert %Message{} = updated_chain.last_message
+      assert updated_chain.last_message.role == :assistant
 
       answer = LangChain.Utils.ChainResult.to_string!(updated_chain)
       assert answer =~ "is 200"
@@ -609,7 +609,9 @@ defmodule ChatModels.ChatGoogleAITest do
       # assert received multiple messages as callbacks
       assert_received {:callback_msg, message}
       assert message.role == :assistant
-      assert [%ToolCall{name: "calculator", arguments: %{"expression" => _}}] = message.tool_calls
+
+      assert [%ToolCall{name: "calculator", arguments: %{"expression" => _}}] =
+               message.tool_calls
 
       # the function result message
       assert_received {:callback_tool_msg, message}

--- a/test/utils/chain_result_test.exs
+++ b/test/utils/chain_result_test.exs
@@ -52,7 +52,7 @@ defmodule LangChain.Utils.ChainResultTest do
     test "handles an LLMChain.run/2 success result" do
       message = Message.new_assistant!("the answer")
       chain = %LLMChain{last_message: message}
-      assert {:ok, "the answer"} == ChainResult.to_string({:ok, chain, message})
+      assert {:ok, "the answer"} == ChainResult.to_string({:ok, chain})
     end
   end
 


### PR DESCRIPTION
- Remove the "last_message" from the return tuple of `LLMChain.run/2`
- Data is still available in `%LLMChain{last_message: last_message}`
- Adds `%LLMChain{exchanged_messages: exchanged_messages}`.

This is a breaking change. Let's cover why this is being done and how to adapt to it.

## Why the change

Before this change, an `LLMChain`'s `run` function returned `{:ok, updated_chain, last_message}`. 

When an assistant (ie LLM) issues a ToolCall and when `run` is in the mode `:until_success` or `:while_need_response`, the `LLMChain` will automatically execute the function and return the result as a new Message back to the LLM. This works great!

The problem comes when an application needs to keep track of all the messages being exchanged during a run operation. That can be done by using callbacks and sending and receiving messages, but that's far from ideal. It makes more sense to have access to that information directly after the `run` operation completes.

## What this change does

This PR changes the returned type to `{:ok, updated_chain}`.

The `last_message` is available in `updated_chain.last_message`. This cleans up the return API.

This change also adds `%LLMChain{exchanged_messages: exchanged_messages}`,or `updated_chain.exchanged_messages` which is a list of all the messages exchanged between the application and the LLM during the execution of the `run` function.

This breaks the return contract for the `run` function.

## How to adapt to this change

To adapt to this, if the application isn't using the `last_message` in `{:ok, updated_chain, _last_message}`, then delete the third position in the tuple. Ex: `{:ok, updated_chain}`.

Access to the `last_message` is available on the `updated_chain`.

```elixir
{:ok, updated_chain} =
  %{llm: model}
  |> LLMChain.new!()
  |> LLMChain.run()

last_message = updated_chain.last_message
```

NOTE: that the `updated_chain` now includes `updated_chain.exchanged_messages` which can also be used.