### PR TITLE
Make api keys optional when running tests.

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,31 @@
-# Load the ENV key for running live OpenAI tests.
-Application.put_env(:langchain, :openai_key, System.fetch_env("OPENAI_API_KEY"))
-Application.put_env(:langchain, :anthropic_key, System.fetch_env("ANTHROPIC_API_KEY"))
-Application.put_env(:langchain, :google_ai_key, System.fetch_env("GOOGLE_API_KEY"))
+defmodule LangChain.TestHelpers do
+  def load_env(key) do
+    try do
+      System.fetch_env!(key)
+    rescue
+      _e ->
+        ""
+    end
+  end
+end
+
+Application.put_env(
+  :langchain,
+  :openai_key,
+  LangChain.TestHelpers.load_env("OPENAI_API_KEY")
+)
+
+Application.put_env(
+  :langchain,
+  :anthropic_key,
+  LangChain.TestHelpers.load_env("ANTHROPIC_API_KEY")
+)
+
+Application.put_env(
+  :langchain,
+  :google_ai_key,
+  LangChain.TestHelpers.load_env("GOOGLE_API_KEY")
+)
 
 Mimic.copy(LangChain.ChatModels.ChatOpenAI)
 Mimic.copy(LangChain.ChatModels.ChatAnthropic)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,7 @@
 # Load the ENV key for running live OpenAI tests.
-Application.put_env(:langchain, :openai_key, System.fetch_env!("OPENAI_API_KEY"))
-Application.put_env(:langchain, :anthropic_key, System.fetch_env!("ANTHROPIC_API_KEY"))
-Application.put_env(:langchain, :google_ai_key, System.fetch_env!("GOOGLE_API_KEY"))
+Application.put_env(:langchain, :openai_key, System.fetch_env("OPENAI_API_KEY"))
+Application.put_env(:langchain, :anthropic_key, System.fetch_env("ANTHROPIC_API_KEY"))
+Application.put_env(:langchain, :google_ai_key, System.fetch_env("GOOGLE_API_KEY"))
 
 Mimic.copy(LangChain.ChatModels.ChatOpenAI)
 Mimic.copy(LangChain.ChatModels.ChatAnthropic)


### PR DESCRIPTION
When running the test without having all the API keys set this would blow up even if you are not testing that api.  This will just try to load them and continue.