### PR TITLE
Do not duplicate tool call parameters if they are identical

### DIFF
--- a/lib/message/tool_call.ex
+++ b/lib/message/tool_call.ex
@@ -152,6 +152,11 @@ defmodule LangChain.Message.ToolCall do
     |> update_status(call_part)
   end
 
+  defp append_tool_name(%ToolCall{name: primary_name} = primary, %ToolCall{name: new_name})
+       when primary_name == new_name do
+    primary
+  end
+
   defp append_tool_name(%ToolCall{} = primary, %ToolCall{name: new_name})
        when is_binary(new_name) do
     %ToolCall{primary | name: (primary.name || "") <> new_name}

--- a/lib/message/tool_call.ex
+++ b/lib/message/tool_call.ex
@@ -139,6 +139,8 @@ defmodule LangChain.Message.ToolCall do
     raise LangChainError, "Can only merge tool calls with the same index"
   end
 
+  def merge(%ToolCall{} = t1, %ToolCall{} = t2) when t1 == t2, do: t1
+
   def merge(%ToolCall{} = primary, %ToolCall{} = call_part) do
     # merge the "part" into the primary.
     primary

--- a/test/message/tool_call_test.exs
+++ b/test/message/tool_call_test.exs
@@ -121,6 +121,20 @@ defmodule LangChain.Message.ToolCallTest do
       assert result == received
     end
 
+    test "does not duplicate incomplete call" do
+      received = %ToolCall{
+        status: :incomplete,
+        type: :function,
+        call_id: nil,
+        name: "get_weather",
+        arguments: nil,
+        index: 0
+      }
+
+      result = ToolCall.merge(received, received)
+      assert result == received
+    end
+
     test "updates tool name" do
       call_1 = %ToolCall{
         status: :incomplete,


### PR DESCRIPTION
When using streaming with tools in ChatGoogleAI I've noticed that the merge method in tool_calls duplicated the name of the function. 

Because of that the tool calls were not working. For some reason ChatGoogleAI sends the same message delta with tools twice.

Below you can see that the name of the function was being duplicated: `image_1__generate_image` converted into `image_1__generate_imageimage_1__generate_image`.

```
primary: %LangChain.MessageDelta{
  content: nil,
  status: :complete,
  index: 0,
  role: :assistant,
  tool_calls: [
    %LangChain.Message.ToolCall{
      status: :incomplete,
      type: :function,
      call_id: "call-image_1__generate_image",
      name: "image_1__generate_image",
      arguments: %{"prompt" => "a dog"},
      index: nil
    }
  ]
}
delta call: %LangChain.Message.ToolCall{
  status: :incomplete,
  type: :function,
  call_id: "call-image_1__generate_image",
  name: "image_1__generate_image",
  arguments: %{"prompt" => "a dog"},
  index: nil
}
merged call: %LangChain.Message.ToolCall{
  status: :incomplete,
  type: :function,
  call_id: "call-image_1__generate_image",
  name: "image_1__generate_imageimage_1__generate_image",
  arguments: %{"prompt" => "a dog"},
  index: nil
}
```

I've introduced a fix that makes same messagedelta with tool call not duplicate