### PR TITLE
🐛 cast tool_calls arguments correctly inside message_deltas

### DIFF
--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -56,7 +56,6 @@ defmodule LangChain.MessageDelta do
     %MessageDelta{}
     |> cast(attrs, @create_fields)
     |> assign_string_value(:content, attrs)
-    |> assign_string_value(:arguments, attrs)
     |> validate_required(@required_fields)
     |> apply_action(:insert)
   end

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -1233,6 +1233,31 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert parsed == [json_1, json_2]
     end
 
+    test "correctly parses when data content contains spaces such as python code with intedentation" do
+      data =
+        "data: {\"id\":\"chatcmpl-7e8yp1xBhriNXiqqZ0xJkgNrmMuGS\",\"object\":\"chat.completion.chunk\",\"created\":1689801995,\"model\":\"gpt-4-0613\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"def my_function(x):\\n    return x + 1\"},\"finish_reason\":null}]}\n\n"
+
+      {parsed, incomplete} = ChatOpenAI.decode_stream({data, ""})
+
+      assert incomplete == ""
+
+      assert parsed == [
+               %{
+                 "id" => "chatcmpl-7e8yp1xBhriNXiqqZ0xJkgNrmMuGS",
+                 "object" => "chat.completion.chunk",
+                 "created" => 1_689_801_995,
+                 "model" => "gpt-4-0613",
+                 "choices" => [
+                   %{
+                     "index" => 0,
+                     "delta" => %{"content" => "def my_function(x):\n    return x + 1"},
+                     "finish_reason" => nil
+                   }
+                 ]
+               }
+             ]
+    end
+
     test "correctly parses when data split over received messages", %{json_1: json_1} do
       # split the data over multiple messages
       data =

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -1233,7 +1233,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert parsed == [json_1, json_2]
     end
 
-    test "correctly parses when data content contains spaces such as python code with intedentation" do
+    test "correctly parses when data content contains spaces such as python code with indentation" do
       data =
         "data: {\"id\":\"chatcmpl-7e8yp1xBhriNXiqqZ0xJkgNrmMuGS\",\"object\":\"chat.completion.chunk\",\"created\":1689801995,\"model\":\"gpt-4-0613\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"def my_function(x):\\n    return x + 1\"},\"finish_reason\":null}]}\n\n"
 

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -175,6 +175,136 @@ defmodule LangChain.MessageDeltaTest do
       assert merged == expected
     end
 
+    test "correctly merge message with tool_call containing empty spaces" do
+      first_delta =
+        %LangChain.MessageDelta{
+          content: "",
+          status: :incomplete,
+          index: nil,
+          role: :assistant,
+          tool_calls: nil
+        }
+
+      deltas = [
+        %LangChain.MessageDelta{
+          content: "stu",
+          status: :incomplete,
+          index: nil,
+          role: :assistant,
+          tool_calls: nil
+        },
+        %LangChain.MessageDelta{
+          content: "ff",
+          status: :incomplete,
+          index: nil,
+          role: :assistant,
+          tool_calls: nil
+        },
+        %LangChain.MessageDelta{
+          content: nil,
+          status: :incomplete,
+          index: nil,
+          role: :assistant,
+          tool_calls: [
+            %LangChain.Message.ToolCall{
+              status: :incomplete,
+              type: :function,
+              call_id: "toolu_123",
+              name: "get_code",
+              arguments: nil,
+              index: 1
+            }
+          ]
+        },
+        %LangChain.MessageDelta{
+          content: nil,
+          status: :incomplete,
+          index: nil,
+          role: :assistant,
+          tool_calls: [
+            %LangChain.Message.ToolCall{
+              status: :incomplete,
+              type: :function,
+              call_id: "toolu_123",
+              name: "get_code",
+              arguments: "{\"code\": \"def my_function(x):\n ",
+              index: 1
+            }
+          ]
+        },
+        %LangChain.MessageDelta{
+          content: nil,
+          status: :incomplete,
+          index: nil,
+          role: :assistant,
+          tool_calls: [
+            %LangChain.Message.ToolCall{
+              status: :incomplete,
+              type: :function,
+              call_id: "toolu_123",
+              name: "get_code",
+              arguments: " ",
+              index: 1
+            }
+          ]
+        },
+        %LangChain.MessageDelta{
+          content: nil,
+          status: :incomplete,
+          index: nil,
+          role: :assistant,
+          tool_calls: [
+            %LangChain.Message.ToolCall{
+              status: :incomplete,
+              type: :function,
+              call_id: "toolu_123",
+              name: "get_code",
+              arguments: "  ",
+              index: 1
+            }
+          ]
+        },
+        %LangChain.MessageDelta{
+          content: nil,
+          status: :incomplete,
+          index: nil,
+          role: :assistant,
+          tool_calls: [
+            %LangChain.Message.ToolCall{
+              status: :incomplete,
+              type: :function,
+              call_id: "toolu_123",
+              name: "get_code",
+              arguments: "return x + 1\"}",
+              index: 1
+            }
+          ]
+        }
+      ]
+
+      merged =
+        Enum.reduce(deltas, first_delta, fn new_delta, acc ->
+          MessageDelta.merge_delta(acc, new_delta)
+        end)
+
+      assert merged == %LangChain.MessageDelta{
+               content: "stuff",
+               status: :incomplete,
+               index: nil,
+               role: :assistant,
+               tool_calls: [
+                 %LangChain.Message.ToolCall{
+                   status: :incomplete,
+                   type: :function,
+                   call_id: "toolu_123",
+                   name: "get_codeget_codeget_codeget_codeget_code",
+                   arguments: "{\"code\": \"def my_function(x):\n    return x + 1\"}",
+                   index: 1
+                 }
+               ]
+             }
+    end
+
     test "correctly merges message with tool_call split over multiple deltas and index is not by position" do
       first_delta =
         %LangChain.MessageDelta{


### PR DESCRIPTION
Before this fix, tool call arguments in deltas which contained several empty spaces were missing data when being cast.
While triaging this issue I also added some extra tests checking for correct casting of spaces. 