### PR TITLE
feat: add OpenAI's new structured output API

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -122,6 +122,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     # How many chat completion choices to generate for each input message.
     field :n, :integer, default: 1
     field :json_response, :boolean, default: false
+    field :json_schema, :map, default: nil
     field :stream, :boolean, default: false
     field :max_tokens, :integer, default: nil
     # Options for streaming response. Only set this when you set `stream: true`
@@ -153,6 +154,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     :stream,
     :receive_timeout,
     :json_response,
+    :json_schema,
     :max_tokens,
     :stream_options,
     :user,
@@ -263,11 +265,20 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     %{"include_usage" => Map.get(data, :include_usage, Map.get(data, "include_usage"))}
   end
 
-  defp set_response_format(%ChatOpenAI{json_response: true}),
-    do: %{"type" => "json_object"}
+  defp set_response_format(%ChatOpenAI{json_response: true, json_schema: json_schema}) when not is_nil(json_schema) do
+    %{
+      "type" => "json_schema",
+      "json_schema" => json_schema
+    }
+  end
 
-  defp set_response_format(%ChatOpenAI{json_response: false}),
-    do: %{"type" => "text"}
+  defp set_response_format(%ChatOpenAI{json_response: true}) do
+    %{"type" => "json_object"}
+  end
+
+  defp set_response_format(%ChatOpenAI{json_response: false}) do
+    %{"type" => "text"}
+  end
 
   @doc """
   Convert a LangChain structure to the expected map of data for the OpenAI API.
@@ -908,6 +919,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
         :seed,
         :n,
         :json_response,
+        :json_schema,
         :stream,
         :max_tokens,
         :stream_options

--- a/test/chains/data_extraction_chain_test.exs
+++ b/test/chains/data_extraction_chain_test.exs
@@ -15,8 +15,8 @@ defmodule LangChain.Chains.DataExtractionChainTest do
           FunctionParam.new!(%{name: "person_name", type: :string}),
           FunctionParam.new!(%{name: "person_age", type: :number}),
           FunctionParam.new!(%{name: "person_hair_color", type: :string}),
-          FunctionParam.new!(%{name: "dog_name", type: :string}),
-          FunctionParam.new!(%{name: "dog_breed", type: :string})
+          FunctionParam.new!(%{name: "pet_dog_name", type: :string}),
+          FunctionParam.new!(%{name: "pet_dog_breed", type: :string})
         ]
         |> FunctionParam.to_parameters_schema()
 
@@ -31,8 +31,8 @@ defmodule LangChain.Chains.DataExtractionChainTest do
                    items: %{
                      "type" => "object",
                      "properties" => %{
-                       "dog_breed" => %{"type" => "string"},
-                       "dog_name" => %{"type" => "string"},
+                       "pet_dog_breed" => %{"type" => "string"},
+                       "pet_dog_name" => %{"type" => "string"},
                        "person_age" => %{"type" => "number"},
                        "person_hair_color" => %{"type" => "string"},
                        "person_name" => %{"type" => "string"}
@@ -55,32 +55,34 @@ defmodule LangChain.Chains.DataExtractionChainTest do
         FunctionParam.new!(%{name: "person_name", type: :string}),
         FunctionParam.new!(%{name: "person_age", type: :number}),
         FunctionParam.new!(%{name: "person_hair_color", type: :string}),
-        FunctionParam.new!(%{name: "dog_name", type: :string}),
-        FunctionParam.new!(%{name: "dog_breed", type: :string})
+        FunctionParam.new!(%{name: "pet_dog_name", type: :string}),
+        FunctionParam.new!(%{name: "pet_dog_breed", type: :string})
       ]
       |> FunctionParam.to_parameters_schema()
 
     # Model setup - specify the model and seed
-    {:ok, chat} = ChatOpenAI.new(%{model: "gpt-4o", temperature: 0, seed: 0, stream: false})
+    {:ok, chat} = ChatOpenAI.new(%{model: "gpt-4o-mini-2024-07-18", temperature: 0, seed: 0, stream: false})
 
     # run the chain, chain.run(prompt to extract data from)
-    data_prompt =
-      "Alex is 5 feet tall. Claudia is 4 feet taller than Alex and jumps higher than him.
-       Claudia is a brunette and Alex is blonde. Alex's dog Frosty is a labrador and likes to play hide and seek. Identify each person and their relevant information."
+    data_prompt = """
+      Alex is 5 feet tall. Claudia is 4 feet taller than Alex and jumps higher than him.
+      Claudia is a brunette and Alex is blonde.
+      Alex's dog Frosty is a labrador and likes to play hide and seek. Identify each person and their relevant information.
+    """
 
     {:ok, result} = DataExtractionChain.run(chat, schema_parameters, data_prompt, verbose: true)
 
     assert result == [
              %{
-               "dog_breed" => "labrador",
-               "dog_name" => "Frosty",
+               "pet_dog_breed" => "labrador",
+               "pet_dog_name" => "Frosty",
                "person_age" => nil,
                "person_hair_color" => "blonde",
                "person_name" => "Alex"
              },
              %{
-               "dog_breed" => nil,
-               "dog_name" => nil,
+               "pet_dog_breed" => nil,
+               "pet_dog_name" => nil,
                "person_age" => nil,
                "person_hair_color" => "brunette",
                "person_name" => "Claudia"

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -297,7 +297,7 @@ defmodule LangChain.MessageDeltaTest do
                    status: :incomplete,
                    type: :function,
                    call_id: "toolu_123",
-                   name: "get_codeget_codeget_codeget_codeget_code",
+                   name: "get_code",
                    arguments: "{\"code\": \"def my_function(x):\n    return x + 1\"}",
                    index: 1
                  }

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -409,7 +409,7 @@ defmodule LangChain.Fixtures do
   end
 
   def too_large_user_request() do
-    Message.new_user!("Analyze the following text: \n\n" <> text_chunks(8))
+    Message.new_user!("Analyze the following text: \n\n" <> text_chunks(16))
   end
 
   def results_in_too_long_response() do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,7 @@
 # Load the ENV key for running live OpenAI tests.
 Application.put_env(:langchain, :openai_key, System.fetch_env!("OPENAI_API_KEY"))
-# Application.put_env(:langchain, :anthropic_key, System.fetch_env!("ANTHROPIC_API_KEY"))
-# Application.put_env(:langchain, :google_ai_key, System.fetch_env!("GOOGLE_API_KEY"))
+Application.put_env(:langchain, :anthropic_key, System.fetch_env!("ANTHROPIC_API_KEY"))
+Application.put_env(:langchain, :google_ai_key, System.fetch_env!("GOOGLE_API_KEY"))
 
 Mimic.copy(LangChain.ChatModels.ChatOpenAI)
 Mimic.copy(LangChain.ChatModels.ChatAnthropic)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,7 @@
 # Load the ENV key for running live OpenAI tests.
 Application.put_env(:langchain, :openai_key, System.fetch_env!("OPENAI_API_KEY"))
-Application.put_env(:langchain, :anthropic_key, System.fetch_env!("ANTHROPIC_API_KEY"))
-Application.put_env(:langchain, :google_ai_key, System.fetch_env!("GOOGLE_API_KEY"))
+# Application.put_env(:langchain, :anthropic_key, System.fetch_env!("ANTHROPIC_API_KEY"))
+# Application.put_env(:langchain, :google_ai_key, System.fetch_env!("GOOGLE_API_KEY"))
 
 Mimic.copy(LangChain.ChatModels.ChatOpenAI)
 Mimic.copy(LangChain.ChatModels.ChatAnthropic)


### PR DESCRIPTION
#### What does this PR do?:
- [x] Add `json_schema` Field to `ChatOpenAI` and Enhance Response Format Handling
- [x] Cleans up a handful of tests for `mix test --include live_open_ai`

#### Summary:
This pull request introduces a new `json_schema` field to the `ChatOpenAI` module, which enhances the response format handling capabilities by allowing for JSON Schema-based validation.

#### Changes:
1. **Field Definition**:
   - Added `field :json_schema, :map, default: nil` to the `ChatOpenAI` struct.
   - Updated the list of valid struct keys to include `:json_schema`.

2. **Response Format Handling**:
   - Modified the `set_response_format` function to account for cases when `json_response` is true and `json_schema` is provided.
     - If `json_response` is true and `json_schema` is not nil, the response format is set to include `json_schema`.
     - If `json_response` is true but `json_schema` is nil, the response format defaults to `json_object`.
     - If `json_response` is false, the response format is set to `text`.

#### Code Details:
1. **Field Addition**:
    ```elixir
    field :json_schema, :map, default: nil
    ```

2. **Response Format Modification**:
    ```elixir
    defp set_response_format(%ChatOpenAI{json_response: true, json_schema: json_schema}) when not is_nil(json_schema) do
      %{
        "type" => "json_schema",
        "json_schema" => json_schema
      }
    end

    defp set_response_format(%ChatOpenAI{json_response: true}) do
      %{"type" => "json_object"}
    end

    defp set_response_format(%ChatOpenAI{json_response: false}) do
      %{"type" => "text"}
    end
    ```