### PR TITLE
Handle empty text parts from GoogleAI responses

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -597,6 +597,16 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     end)
   end
 
+  @doc false
+  def filter_text_parts(parts) when is_list(parts) do
+    Enum.filter(parts, fn p ->
+      case p do
+        %{"text" => text} -> text && text != ""
+        _ -> false
+      end
+    end)
+  end
+
   @doc """
   Return the content parts for the message.
   """

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -426,6 +426,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     text_part =
       parts
       |> filter_parts_for_types(["text"])
+      |> filter_text_parts()
       |> Enum.map(fn part ->
         ContentPart.new!(%{type: :text, content: part["text"]})
       end)
@@ -479,6 +480,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
 
     parts
     |> filter_parts_for_types(["text"])
+    |> filter_text_parts()
     |> Enum.map(fn part ->
       ContentPart.new!(%{type: :text, content: part["text"]})
     end)

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -410,6 +410,22 @@ defmodule ChatModels.ChatGoogleAITest do
     end
   end
 
+  describe "filter_text_parts/1" do
+    test "returns only text parts that are not nil or empty" do
+      parts = [
+        %{"text" => "I have text"},
+        %{"text" => nil},
+        %{"text" => ""},
+        %{"text" => "I have more text"}
+      ]
+
+      assert ChatGoogleAI.filter_text_parts(parts) == [
+               %{"text" => "I have text"},
+               %{"text" => "I have more text"}
+             ]
+    end
+  end
+
   describe "get_message_contents/1" do
     test "returns basic text as a ContentPart" do
       message = Message.new_user!("Howdy!")

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -289,6 +289,21 @@ defmodule ChatModels.ChatGoogleAITest do
       assert struct.status == :complete
     end
 
+    test "handles receiving a message with an empty text part", %{model: model} do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{"role" => "model", "parts" => [%{"text" => ""}]},
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ]
+      }
+
+      assert [%Message{} = struct] = ChatGoogleAI.do_process_response(model, response)
+      assert struct.content == []
+    end
+
     test "error if receiving non-text content", %{model: model} do
       response = %{
         "candidates" => [
@@ -349,6 +364,26 @@ defmodule ChatModels.ChatGoogleAITest do
       assert struct.content == "This is the first part of a mes"
       assert struct.index == 0
       assert struct.status == :incomplete
+    end
+
+    test "handles receiving a MessageDelta with an empty text part", %{model: model} do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "role" => "model",
+              "parts" => [%{"text" => ""}]
+            },
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ]
+      }
+
+      assert [%MessageDelta{} = struct] =
+               ChatGoogleAI.do_process_response(model, response, MessageDelta)
+
+      assert struct.content == ""
     end
 
     test "handles API error messages", %{model: model} do


### PR DESCRIPTION
When using a newer model variant such as `gemini-1.5-pro-002`, we occasionally receive empty text parts in the response, which was causing the validation of `ContentPart`s to fail. 

This PR filters those before creating the content part.