### PR TITLE
Handle functions with no parameters for Google AI

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -250,7 +250,15 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   end
 
   def for_api(%Function{} = function) do
-    ChatOpenAI.for_api(function)
+    encoded = ChatOpenAI.for_api(function)
+
+    # For functions with no parameters, Google AI needs the parameters field removing, otherwise it will error
+    # with "* GenerateContentRequest.tools[0].function_declarations[0].parameters.properties: should be non-empty for OBJECT type\n"
+    if encoded["parameters"] == %{"properties" => %{}, "type" => "object"} do
+      Map.delete(encoded, "parameters")
+    else
+      encoded
+    end
   end
 
   @doc """

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -159,7 +159,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
         %{
           # Google AI functions use an OpenAI compatible format.
           # See: https://ai.google.dev/docs/function_calling#how_it_works
-          "functionDeclarations" => Enum.map(functions, &ChatOpenAI.for_api/1)
+          "functionDeclarations" => Enum.map(functions, &for_api/1)
         }
       ])
     else

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -249,6 +249,10 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     }
   end
 
+  def for_api(%Function{} = function) do
+    ChatOpenAI.for_api(function)
+  end
+
   @doc """
   Calls the Google AI API passing the ChatGoogleAI struct with configuration, plus
   either a simple message or the list of messages to act as the prompt.

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -323,8 +323,7 @@ defmodule ChatModels.ChatGoogleAITest do
 
       assert %{
                "description" => "Give a hello world greeting.",
-               "name" => "hello_world",
-               "parameters" => %{"properties" => %{}, "type" => "object"}
+               "name" => "hello_world"
              } == ChatGoogleAI.for_api(function)
     end
   end

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -1,4 +1,5 @@
 defmodule ChatModels.ChatGoogleAITest do
+  alias LangChain.FunctionParam
   alias LangChain.ChatModels.ChatGoogleAI
   use LangChain.BaseCase
 
@@ -267,6 +268,48 @@ defmodule ChatModels.ChatGoogleAITest do
                  }
                ]
              } = tool_call
+    end
+
+    test "handles converting functions with parameters" do
+      {:ok, weather} =
+        Function.new(%{
+          name: "get_weather",
+          description: "Get the current weather in a given US location",
+          parameters: [
+            FunctionParam.new!(%{
+              name: "city",
+              type: "string",
+              description: "The city name, e.g. San Francisco",
+              required: true
+            }),
+            FunctionParam.new!(%{
+              name: "state",
+              type: "string",
+              description: "The 2 letter US state abbreviation, e.g. CA, NY, UT",
+              required: true
+            })
+          ],
+          function: fn _args, _context -> {:ok, "75 degrees"} end
+        })
+
+      assert %{
+               "description" => "Get the current weather in a given US location",
+               "name" => "get_weather",
+               "parameters" => %{
+                 "properties" => %{
+                   "city" => %{
+                     "description" => "The city name, e.g. San Francisco",
+                     "type" => "string"
+                   },
+                   "state" => %{
+                     "description" => "The 2 letter US state abbreviation, e.g. CA, NY, UT",
+                     "type" => "string"
+                   }
+                 },
+                 "required" => ["city", "state"],
+                 "type" => "object"
+               }
+             } == ChatGoogleAI.for_api(weather)
     end
   end
 

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -263,8 +263,7 @@ defmodule ChatModels.ChatGoogleAITest do
                "functionDeclarations" => [
                  %{
                    "name" => "hello_world",
-                   "description" => "Give a hello world greeting.",
-                   "parameters" => %{"properties" => %{}, "type" => "object"}
+                   "description" => "Give a hello world greeting."
                  }
                ]
              } = tool_call

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -311,6 +311,22 @@ defmodule ChatModels.ChatGoogleAITest do
                }
              } == ChatGoogleAI.for_api(weather)
     end
+
+    test "handles functions without parameters" do
+      {:ok, function} =
+        Function.new(%{
+          name: "hello_world",
+          description: "Give a hello world greeting.",
+          parameters: [],
+          function: fn _args, _context -> {:ok, "Hello User!"} end
+        })
+
+      assert %{
+               "description" => "Give a hello world greeting.",
+               "name" => "hello_world",
+               "parameters" => %{"properties" => %{}, "type" => "object"}
+             } == ChatGoogleAI.for_api(function)
+    end
   end
 
   describe "do_process_response/2" do


### PR DESCRIPTION
If a function is defined with an empty parameter list, the API returns `* GenerateContentRequest.tools[0].function_declarations[0].parameters.properties: should be non-empty for OBJECT type\n` with the current implementation.

Removing the parameters key from the function declaration when there are no parameters resolves this.