### PR TITLE
Handle missing token usage fields for Google AI

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -660,8 +660,8 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   defp get_token_usage(%{"usageMetadata" => usage} = _response_body) do
     # extract out the reported response token usage
     TokenUsage.new!(%{
-      input: Map.get(usage, "promptTokenCount"),
-      output: Map.get(usage, "candidatesTokenCount")
+      input: Map.get(usage, "promptTokenCount", 0),
+      output: Map.get(usage, "candidatesTokenCount", 0)
     })
   end
 


### PR DESCRIPTION
Very sporadically, we see errors due to the usageMetadata map missing one of the token count fields when using the Google AI API.

This PR provides a fallback value when fetching either of the fields.