### PR TITLE
Add support for passing safety settings to Google AI

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -100,7 +100,8 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     :top_k,
     :receive_timeout,
     :stream,
-    :callbacks
+    :callbacks,
+    :safety_settings
   ]
   @required_fields [
     :endpoint,

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -75,6 +75,13 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     # goes on too long by itself, it tends to hallucinate more.
     field :receive_timeout, :integer, default: @receive_timeout
 
+    # The safety settings for the model, specified as a list of maps. Each map
+    # should contain a `category` and a `threshold` for that category.
+    # e.g. [%{"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_ONLY_HIGH"}]
+    # see https://ai.google.dev/api/generate-content#v1beta.SafetySetting
+    # for the list of categories and thresholds
+    field :safety_settings, {:array, :map}, default: []
+
     field :stream, :boolean, default: false
 
     # A list of maps for callback handlers

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -675,7 +675,8 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
         :top_p,
         :top_k,
         :receive_timeout,
-        :stream
+        :stream,
+        :safety_settings
       ],
       @current_config_version
     )

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -173,6 +173,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
         }
       }
       |> LangChain.Utils.conditionally_add_to_map("system_instruction", system_instruction)
+      |> LangChain.Utils.conditionally_add_to_map("safetySettings", google_ai.safety_settings)
 
     if functions && not Enum.empty?(functions) do
       req

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -605,7 +605,8 @@ defmodule ChatModels.ChatGoogleAITest do
                "version" => 1,
                "api_version" => "v1beta",
                "top_k" => 1.0,
-               "top_p" => 1.0
+               "top_p" => 1.0,
+               "safety_settings" => []
              }
     end
   end

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -241,6 +241,23 @@ defmodule ChatModels.ChatGoogleAITest do
       assert expected == ChatGoogleAI.for_api(tool_result)
     end
 
+    test "adds safety settings to the request if present" do
+      settings = [
+        %{"category" => "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold" => "BLOCK_ONLY_HIGH"}
+      ]
+
+      google_ai = ChatGoogleAI.new!(%{safety_settings: settings})
+      data = ChatGoogleAI.for_api(google_ai, [], [])
+
+      assert %{"safetySettings" => ^settings} = data
+    end
+
+    test "does not add safety settings to the request if list of settings is empty" do
+      google_ai = ChatGoogleAI.new!(%{safety_settings: []})
+      data = ChatGoogleAI.for_api(google_ai, [], [])
+      refute Map.has_key?(data, "safetySettings")
+    end
+
     test "adds system instruction to the request if present", %{google_ai: google_ai} do
       message = "You are a helpful assistant."
       data = ChatGoogleAI.for_api(google_ai, [Message.new_system!(message)], [])


### PR DESCRIPTION
This implements a new field on ChatGoogleAI for setting the safety settings for content filtering, following the documentation at https://ai.google.dev/gemini-api/docs/safety-settings#web and https://ai.google.dev/api/generate-content#v1beta.SafetySetting

Based on your comment at https://github.com/brainlid/langchain/pull/142#issuecomment-2183694933 I kept this as a simple list of maps, rather than introducing a struct and associated changesets, on the basis that the LLM will validate the settings.

I've added support for serializing the config, which should be backwards compatible as deserializing maps without the safety settings field will construct a model with the safety settings set to an empty list, which then wouldn't be added to the request as the list is empty.