### PR TITLE
Remove unused assignment from ChatGoogleAI

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -489,13 +489,6 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
           nil
       end
 
-    parts
-    |> filter_parts_for_types(["text"])
-    |> filter_text_parts()
-    |> Enum.map(fn part ->
-      ContentPart.new!(%{type: :text, content: part["text"]})
-    end)
-
     tool_calls_from_parts =
       parts
       |> filter_parts_for_types(["functionCall"])


### PR DESCRIPTION
This code iterated over parts in the response, but the result was never used, as text_content was captured above and used instead.