### PR TITLE
add "processed_content" to ToolResult struct and support storing Elixir data from function results

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -735,6 +735,17 @@ defmodule LangChain.Chains.LLMChain do
       if verbose, do: IO.inspect(function.name, label: "EXECUTING FUNCTION")
 
       case Function.execute(function, call.arguments, context) do
+        {:ok, llm_result, processed_result} ->
+          if verbose, do: IO.inspect(llm_result, label: "FUNCTION RESULT")
+          # successful execution and storage of processed_content.
+          ToolResult.new!(%{
+            tool_call_id: call.call_id,
+            content: llm_result,
+            processed_content: processed_result,
+            name: function.name,
+            display_text: function.display_text
+          })
+
         {:ok, result} ->
           if verbose, do: IO.inspect(result, label: "FUNCTION RESULT")
           # successful execution.

--- a/lib/message.ex
+++ b/lib/message.ex
@@ -36,6 +36,21 @@ defmodule LangChain.Message do
   support it, and they may require using specific models trained for it. See the
   documentation for the LLM or service for details on their level of support.
 
+  ## Processed Content
+
+  The `processed_content` field is a handy place to store the results of
+  processing a message and needing to hold on to the processed value and store
+  it with the message.
+
+  This is particularly helpful for a `LangChain.MessageProcessors.JsonProcessor`
+  that can process an assistant message and store the processed value on the
+  message itself.
+
+  It is intended for assistant messages when a message processor is applied.
+  This contains the results of the processing. This allows the `content` to
+  reflect what was actually returned from the LLM so it can easily be sent back
+  to the LLM as a part of the entire conversation.
+
   ## Examples
 
   A basic system message example:
@@ -71,10 +86,6 @@ defmodule LangChain.Message do
   embedded_schema do
     # Message content that the LLM sees.
     field :content, :any, virtual: true
-    # For assistant messages when message_processors are applied. This contains
-    # the results of the processing. This allows the `content` to reflect what
-    # was actually returned for when we send it back to the LLM as a historical
-    # message.
     field :processed_content, :any, virtual: true
     field :index, :integer
     field :status, Ecto.Enum, values: [:complete, :cancelled, :length], default: :complete

--- a/lib/message/tool_result.ex
+++ b/lib/message/tool_result.ex
@@ -3,6 +3,18 @@ defmodule LangChain.Message.ToolResult do
   Represents a the result of running a requested tool. The LLM's requests a tool
   use through a `ToolCall`. A `ToolResult` returns the answer or result from the
   application back to the AI.
+
+  ## Content
+  The `content` is a string that gets returned to the LLM as the result.
+
+  ## Processed Content
+  The `processed_content` field is optional. When you want to keep the results
+  of the Elixir function call as a native Elixir data structure,
+  `processed_content` can hold it.
+
+  To do this, the Elixir function's result should be a `{:ok, "String response
+  for LLM", native_elixir_data}`. See `LangChain.Function` for details and
+  examples.
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -20,6 +32,8 @@ defmodule LangChain.Message.ToolResult do
     field :name, :string
     # the content returned to the LLM/AI.
     field :content, :string
+    # optional stored results of tool result
+    field :processed_content, :any, virtual: true
     # Text to display in a UI for the result. Optional.
     field :display_text, :string
     # flag if the result is an error
@@ -28,7 +42,15 @@ defmodule LangChain.Message.ToolResult do
 
   @type t :: %ToolResult{}
 
-  @update_fields [:type, :tool_call_id, :name, :content, :display_text, :is_error]
+  @update_fields [
+    :type,
+    :tool_call_id,
+    :name,
+    :content,
+    :processed_content,
+    :display_text,
+    :is_error
+  ]
   @create_fields @update_fields
   @required_fields [:type, :tool_call_id, :content]
 

--- a/lib/message_processors/json_processor.ex
+++ b/lib/message_processors/json_processor.ex
@@ -5,7 +5,7 @@ defmodule LangChain.MessageProcessors.JsonProcessor do
 
   When successful, the assistant message's JSON contents are processed into a
   map and set on `processed_content`. No additional validation or processing of
-  the data is done in by this processor.
+  the data is done by this processor.
 
   When JSON data is expected but not received, or the received JSON is invalid
   or incomplete, a new user `Message` struct is returned with a text error


### PR DESCRIPTION
This allows an Elixir function executed by an LLM through a `LangChain.Message.ToolCall` and `LangChain.Function` definition to return and store the raw Elixir data structure in the matching `LangChain.Message.ToolResult`.

An Elixir function can return a 3-item tuple like this:

```elixir
{:ok, "llm result text", raw_result}
```

Where the `elixir_data_to_keep` is assigned to the `%ToolResult{processed_content: raw_result}`.

- documentation updates
- `LLMChain.execute_tool_call` supports Elixir functions returning a 3-item tuple with the raw result