### PR TITLE
Revamped error handling and handles Anthropic's "overload_error"

### DIFF
--- a/lib/chains/data_extraction_chain.ex
+++ b/lib/chains/data_extraction_chain.ex
@@ -73,6 +73,7 @@ defmodule LangChain.Chains.DataExtractionChain do
   alias LangChain.PromptTemplate
   alias LangChain.Message
   alias LangChain.Message.ToolCall
+  alias LangChain.LangChainError
   alias LangChain.Chains.LLMChain
   alias LangChain.ChatModels.ChatOpenAI
 
@@ -86,7 +87,7 @@ Passage:
   Run the data extraction chain.
   """
   @spec run(ChatOpenAI.t(), json_schema :: map(), prompt :: [any()], opts :: Keyword.t()) ::
-          {:ok, result :: [any()]} | {:error, String.t()}
+          {:ok, result :: [any()]} | {:error, LangChainError.t()}
   def run(llm, json_schema, prompt, opts \\ []) do
     verbose = Keyword.get(opts, :verbose, false)
 
@@ -123,7 +124,7 @@ Passage:
           {:ok, info}
 
         other ->
-          {:error, "Unexpected response. #{inspect(other)}"}
+          {:error, LangChainError.exception("Unexpected response. #{inspect(other)}")}
       end
     rescue
       exception ->
@@ -131,7 +132,7 @@ Passage:
           "Caught unexpected exception in DataExtractionChain. Error: #{inspect(exception)}"
         )
 
-        {:error, "Unexpected error in DataExtractionChain. Check logs for details."}
+        {:error, LangChainError.exception("Unexpected error in DataExtractionChain. Check logs for details.")}
     end
   end
 

--- a/lib/chains/routing_chain.ex
+++ b/lib/chains/routing_chain.ex
@@ -106,7 +106,7 @@ defmodule LangChain.Chains.RoutingChain do
   route.
   """
   @spec run(t(), Keyword.t()) ::
-          {:ok, LLMChain.t(), Message.t() | [Message.t()]} | {:error, String.t()}
+          {:ok, LLMChain.t(), Message.t() | [Message.t()]} | {:error, LangChainError.t()}
   def run(%RoutingChain{} = chain, opts \\ []) do
     default_name = chain.default_route.name
 

--- a/lib/chains/text_to_title_chain.ex
+++ b/lib/chains/text_to_title_chain.ex
@@ -124,7 +124,7 @@ defmodule LangChain.Chains.TextToTitleChain do
       |> TextToTitleChain.run()
 
   """
-  @spec run(t(), Keyword.t()) :: {:ok, LLMChain.t()} | {:error, LLMChain.t(), String.t()}
+  @spec run(t(), Keyword.t()) :: {:ok, LLMChain.t()} | {:error, LLMChain.t(), LangChainError.t()}
   def run(%TextToTitleChain{} = chain, opts \\ []) do
     messages =
       [

--- a/lib/chat_models/chat_bumblebee.ex
+++ b/lib/chat_models/chat_bumblebee.ex
@@ -179,8 +179,8 @@ defmodule LangChain.ChatModels.ChatBumblebee do
       {:ok, chain} ->
         chain
 
-      {:error, changeset} ->
-        raise LangChainError, changeset
+      {:error, %Ecto.Changeset{} = changeset} ->
+        raise LangChainError.exception(changeset)
     end
   end
 
@@ -229,7 +229,7 @@ defmodule LangChain.ChatModels.ChatBumblebee do
       end
     rescue
       err in LangChainError ->
-        {:error, err.message}
+        {:error, err}
     end
   end
 
@@ -259,10 +259,10 @@ defmodule LangChain.ChatModels.ChatBumblebee do
         # return a list of the complete message. As a list for compatibility.
         [message]
 
-      {:error, changeset} ->
+      {:error, %Ecto.Changeset{} = changeset} ->
         reason = Utils.changeset_error_to_string(changeset)
         Logger.error("Failed to create non-streamed full message: #{inspect(reason)}")
-        {:error, reason}
+        {:error, LangChainError.exception(changeset)}
     end
   end
 
@@ -296,14 +296,14 @@ defmodule LangChain.ChatModels.ChatBumblebee do
             Callbacks.fire(model.callbacks, :on_llm_new_delta, [model, delta])
             delta
 
-          {:error, changeset} ->
+          {:error, %Ecto.Changeset{} = changeset} ->
             reason = Utils.changeset_error_to_string(changeset)
 
             Logger.error(
               "Failed to process received model's MessageDelta data: #{inspect(reason)}"
             )
 
-            raise LangChainError, reason
+            raise LangChainError.exception(changeset)
         end
     end
 

--- a/lib/chat_models/chat_model.ex
+++ b/lib/chat_models/chat_model.ex
@@ -3,10 +3,11 @@ defmodule LangChain.ChatModels.ChatModel do
   alias LangChain.Message
   alias LangChain.MessageDelta
   alias LangChain.Function
+  alias LangChain.LangChainError
   alias LangChain.Utils
 
   @type call_response ::
-          {:ok, Message.t() | [Message.t()] | [MessageDelta.t()]} | {:error, String.t()}
+          {:ok, Message.t() | [Message.t()] | [MessageDelta.t()]} | {:error, LangChainError.t()}
 
   @type tool :: Function.t()
   @type tools :: [tool()]

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -493,7 +493,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       end
     rescue
       err in LangChainError ->
-        {:error, err.message}
+        {:error, err}
     end
   end
 
@@ -517,7 +517,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   # Retries the request up to 3 times on transient errors with a 1 second delay
   @doc false
   @spec do_api_request(t(), [Message.t()], ChatModel.tools(), integer()) ::
-          list() | struct() | {:error, String.t()}
+          list() | struct() | {:error, LangChainError.t()}
   def do_api_request(openai, messages, tools, retry_count \\ 3)
 
   def do_api_request(_openai, _messages, _tools, 0) do
@@ -564,7 +564,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
         ])
 
         case do_process_response(openai, data) do
-          {:error, reason} ->
+          {:error, %LangChainError{} = reason} ->
             {:error, reason}
 
           result ->
@@ -572,8 +572,9 @@ defmodule LangChain.ChatModels.ChatOpenAI do
             result
         end
 
-      {:error, %Req.TransportError{reason: :timeout}} ->
-        {:error, "Request timed out"}
+      {:error, %Req.TransportError{reason: :timeout} = err} ->
+        {:error,
+         LangChainError.exception(type: "timeout", message: "Request timed out", original: err)}
 
       {:error, %Req.TransportError{reason: :closed}} ->
         # Force a retry by making a recursive call decrementing the counter
@@ -617,11 +618,12 @@ defmodule LangChain.ChatModels.ChatOpenAI do
 
         data
 
-      {:error, %LangChainError{message: reason}} ->
-        {:error, reason}
+      {:error, %LangChainError{} = error} ->
+        {:error, error}
 
-      {:error, %Req.TransportError{reason: :timeout}} ->
-        {:error, "Request timed out"}
+      {:error, %Req.TransportError{reason: :timeout} = err} ->
+        {:error,
+         LangChainError.exception(type: "timeout", message: "Request timed out", original: err)}
 
       {:error, %Req.TransportError{reason: :closed}} ->
         # Force a retry by making a recursive call decrementing the counter
@@ -633,7 +635,8 @@ defmodule LangChain.ChatModels.ChatOpenAI do
           "Unhandled and unexpected response from streamed post call. #{inspect(other)}"
         )
 
-        {:error, "Unexpected response"}
+        {:error,
+         LangChainError.exception(type: "unexpected_response", message: "Unexpected response")}
     end
   end
 
@@ -751,8 +754,8 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       {:ok, message} ->
         message
 
-      {:error, changeset} ->
-        {:error, Utils.changeset_error_to_string(changeset)}
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, LangChainError.exception(changeset)}
     end
   end
 
@@ -792,8 +795,8 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       {:ok, message} ->
         message
 
-      {:error, changeset} ->
-        {:error, Utils.changeset_error_to_string(changeset)}
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, LangChainError.exception(changeset)}
     end
   end
 
@@ -811,10 +814,10 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       {:ok, %ToolCall{} = call} ->
         call
 
-      {:error, changeset} ->
+      {:error, %Ecto.Changeset{} = changeset} ->
         reason = Utils.changeset_error_to_string(changeset)
         Logger.error("Failed to process ToolCall for a function. Reason: #{reason}")
-        {:error, reason}
+        {:error, LangChainError.exception(changeset)}
     end
   end
 
@@ -838,10 +841,10 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       {:ok, %ToolCall{} = call} ->
         call
 
-      {:error, changeset} ->
+      {:error, %Ecto.Changeset{} = changeset} ->
         reason = Utils.changeset_error_to_string(changeset)
         Logger.error("Failed to process ToolCall for a function. Reason: #{reason}")
-        {:error, reason}
+        {:error, LangChainError.exception(changeset)}
     end
   end
 
@@ -856,25 +859,25 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       {:ok, message} ->
         message
 
-      {:error, changeset} ->
-        {:error, Utils.changeset_error_to_string(changeset)}
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, LangChainError.exception(changeset)}
     end
   end
 
   def do_process_response(_model, %{"error" => %{"message" => reason}}) do
     Logger.error("Received error from API: #{inspect(reason)}")
-    {:error, reason}
+    {:error, LangChainError.exception(message: reason)}
   end
 
   def do_process_response(_model, {:error, %Jason.DecodeError{} = response}) do
     error_message = "Received invalid JSON: #{inspect(response)}"
     Logger.error(error_message)
-    {:error, error_message}
+    {:error, LangChainError.exception(type: "invalid_json", message: error_message, original: response)}
   end
 
   def do_process_response(_model, other) do
     Logger.error("Trying to process an unexpected response. #{inspect(other)}")
-    {:error, "Unexpected response"}
+    {:error, LangChainError.exception(message: "Unexpected response")}
   end
 
   defp finish_reason_to_status(nil), do: :incomplete

--- a/lib/langchain_error.ex
+++ b/lib/langchain_error.ex
@@ -9,13 +9,22 @@ defmodule LangChain.LangChainError do
 
       raise LangChainError, "Message text"
 
+      raise LangChainError, type: "overloaded_error", message: "Message text"
+
+  The error struct contains the following keys:
+
+  - `:type` - A string code to make detecting and responding to specific errors easier. This may have values like "length" or "overloaded_error". The specific meaning of the type is dependent on the service or model.
+
+  - `:message` - A string representation or explanation of the error.
+
+  - `:original` - If a exception was caught and wrapped into a LangChainError, this may be the original message that was encountered.
   """
   import LangChain.Utils, only: [changeset_error_to_string: 1]
   alias __MODULE__
 
   @type t :: %LangChainError{}
 
-  defexception [:message]
+  defexception [:type, :message, :original]
 
   @doc """
   Create the exception using either a message or a changeset who's errors are
@@ -28,6 +37,14 @@ defmodule LangChain.LangChainError do
 
   def exception(%Ecto.Changeset{} = changeset) do
     text_reason = changeset_error_to_string(changeset)
-    %LangChainError{message: text_reason}
+    %LangChainError{type: "changeset", message: text_reason}
+  end
+
+  def exception(opts) when is_list(opts) do
+    %LangChainError{
+      message: Keyword.fetch!(opts, :message),
+      type: Keyword.get(opts, :type),
+      original: Keyword.get(opts, :original),
+    }
   end
 end

--- a/lib/message.ex
+++ b/lib/message.ex
@@ -241,7 +241,10 @@ defmodule LangChain.Message do
                 # convert the error to text and return error tuple
                 {:error, Utils.changeset_error_to_string(changeset)}
 
-              {:error, reason} ->
+              {:error, %LangChainError{message: message}} ->
+                {:error, message}
+
+              {:error, reason} when is_binary(reason) ->
                 {:error, reason}
             end
           end)

--- a/lib/utils/chain_result.ex
+++ b/lib/utils/chain_result.ex
@@ -21,10 +21,10 @@ defmodule LangChain.Utils.ChainResult do
   @spec to_string(
           LLMChain.t()
           | {:ok, LLMChain.t()}
-          | {:error, LLMChain.t(), String.t()}
+          | {:error, LLMChain.t(), LangChainError.t()}
         ) ::
-          {:ok, String.t()} | {:error, LLMChain.t(), String.t()}
-  def to_string({:error, chain, reason}) when is_binary(reason) do
+          {:ok, String.t()} | {:error, LLMChain.t(), LangChainError.t()}
+  def to_string({:error, chain, %LangChainError{} = reason}) do
     # if an error was passed in, forward it through.
     {:error, chain, reason}
   end
@@ -34,7 +34,15 @@ defmodule LangChain.Utils.ChainResult do
   end
 
   # when received a single ContentPart
-  def to_string(%LLMChain{last_message: %Message{role: :assistant, status: :complete, content: [%ContentPart{type: :text} = part]}} = _chain) do
+  def to_string(
+        %LLMChain{
+          last_message: %Message{
+            role: :assistant,
+            status: :complete,
+            content: [%ContentPart{type: :text} = part]
+          }
+        } = _chain
+      ) do
     {:ok, part.content}
   end
 
@@ -43,15 +51,16 @@ defmodule LangChain.Utils.ChainResult do
   end
 
   def to_string(%LLMChain{last_message: %Message{role: :assistant, status: _incomplete}} = chain) do
-    {:error, chain, "Message is incomplete"}
+    {:error, chain, LangChainError.exception(type: "to_string", message: "Message is incomplete")}
   end
 
   def to_string(%LLMChain{last_message: %Message{}} = chain) do
-    {:error, chain, "Message is not from assistant"}
+    {:error, chain,
+     LangChainError.exception(type: "to_string", message: "Message is not from assistant")}
   end
 
   def to_string(%LLMChain{last_message: nil} = chain) do
-    {:error, chain, "No last message"}
+    {:error, chain, LangChainError.exception(type: "to_string", message: "No last message")}
   end
 
   @doc """
@@ -64,7 +73,7 @@ defmodule LangChain.Utils.ChainResult do
   def to_string!(%LLMChain{} = chain) do
     case ChainResult.to_string(chain) do
       {:ok, result} -> result
-      {:error, _chain, reason} -> raise LangChainError, reason
+      {:error, _chain, %LangChainError{} = exception} -> raise exception
     end
   end
 
@@ -92,8 +101,8 @@ defmodule LangChain.Utils.ChainResult do
       {:ok, updated} ->
         updated
 
-      {:error, _chain, reason} ->
-        raise LangChainError, reason
+      {:error, _chain, %LangChainError{} = exception} ->
+        raise exception
     end
   end
 end

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -402,8 +402,9 @@ defmodule ChatModels.ChatGoogleAITest do
         ]
       }
 
-      assert [{:error, error_string}] = ChatGoogleAI.do_process_response(model, response)
-      assert error_string == "role: is invalid"
+      assert [{:error, %LangChainError{} = error}] = ChatGoogleAI.do_process_response(model, response)
+      assert error.type == "changeset"
+      assert error.message == "role: is invalid"
     end
 
     test "handles receiving function calls", %{model: model} do
@@ -482,20 +483,24 @@ defmodule ChatModels.ChatGoogleAITest do
         }
       }
 
-      assert {:error, error_string} = ChatGoogleAI.do_process_response(model, response)
-      assert error_string == "Invalid request"
+      assert {:error, %LangChainError{} = error} = ChatGoogleAI.do_process_response(model, response)
+      assert error.type == nil
+      assert error.message == "Invalid request"
     end
 
     test "handles Jason.DecodeError", %{model: model} do
       response = {:error, %Jason.DecodeError{}}
 
-      assert {:error, error_string} = ChatGoogleAI.do_process_response(model, response)
-      assert "Received invalid JSON:" <> _ = error_string
+      assert {:error, %LangChainError{} = error} = ChatGoogleAI.do_process_response(model, response)
+      assert error.type == "invalid_json"
+      assert "Received invalid JSON:" <> _ = error.message
     end
 
     test "handles unexpected response with error", %{model: model} do
       response = %{}
-      assert {:error, "Unexpected response"} = ChatGoogleAI.do_process_response(model, response)
+      assert {:error, %LangChainError{} = error} = ChatGoogleAI.do_process_response(model, response)
+      assert error.type == "unexpected_response"
+      assert error.message == "Unexpected response"
     end
   end
 

--- a/test/chat_models/chat_mistral_ai_test.exs
+++ b/test/chat_models/chat_mistral_ai_test.exs
@@ -4,6 +4,7 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
   alias LangChain.ChatModels.ChatMistralAI
   alias LangChain.Message
   alias LangChain.MessageDelta
+  alias LangChain.LangChainError
 
   setup do
     model = ChatMistralAI.new!(%{"model" => "mistral-tiny"})
@@ -125,7 +126,10 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
         ]
       }
 
-      assert [{:error, "role: is invalid"}] = ChatMistralAI.do_process_response(model, response)
+      assert [{:error, %LangChainError{} = error}] =
+               ChatMistralAI.do_process_response(model, response)
+
+      assert error.message == "role: is invalid"
     end
 
     test "handles receiving MessageDeltas as well", %{model: model} do
@@ -159,20 +163,29 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
         }
       }
 
-      assert {:error, error_string} = ChatMistralAI.do_process_response(model, response)
-      assert error_string == "Invalid request"
+      assert {:error, %LangChainError{} = error} = ChatMistralAI.do_process_response(model, response)
+
+      assert error.type == nil
+      assert error.message == "Invalid request"
     end
 
     test "handles Jason.DecodeError", %{model: model} do
       response = {:error, %Jason.DecodeError{}}
 
-      assert {:error, error_string} = ChatMistralAI.do_process_response(model, response)
-      assert "Received invalid JSON:" <> _ = error_string
+      assert {:error, %LangChainError{} = error} = ChatMistralAI.do_process_response(model, response)
+
+      assert error.type == "invalid_json"
+      assert "Received invalid JSON:" <> _ = error.message
     end
 
     test "handles unexpected response with error", %{model: model} do
       response = %{}
-      assert {:error, "Unexpected response"} = ChatMistralAI.do_process_response(model, response)
+
+      assert {:error, %LangChainError{} = error} =
+               ChatMistralAI.do_process_response(model, response)
+
+      assert error.type == "unexpected_response"
+      assert error.message == "Unexpected response"
     end
   end
 

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -10,6 +10,7 @@ defmodule ChatModels.ChatVertexAITest do
   alias LangChain.Message.ToolResult
   alias LangChain.MessageDelta
   alias LangChain.Function
+  alias LangChain.LangChainError
 
   setup do
     {:ok, hello_world} =
@@ -189,8 +190,9 @@ defmodule ChatModels.ChatVertexAITest do
         ]
       }
 
-      assert [{:error, error_string}] = ChatVertexAI.do_process_response(response)
-      assert error_string == "role: is invalid"
+      assert [{:error, %LangChainError{} = error}] = ChatVertexAI.do_process_response(response)
+      assert error.type == "changeset"
+      assert error.message == "role: is invalid"
     end
 
     test "handles receiving function calls" do
@@ -254,13 +256,17 @@ defmodule ChatModels.ChatVertexAITest do
     test "handles Jason.DecodeError" do
       response = {:error, %Jason.DecodeError{}}
 
-      assert {:error, error_string} = ChatVertexAI.do_process_response(response)
-      assert "Received invalid JSON:" <> _ = error_string
+      assert {:error, %LangChainError{} = error} = ChatVertexAI.do_process_response(response)
+
+      assert error.type == "invalid_json"
+      assert "Received invalid JSON:" <> _ = error.message
     end
 
     test "handles unexpected response with error" do
       response = %{}
-      assert {:error, "Unexpected response"} = ChatVertexAI.do_process_response(response)
+      assert {:error, %LangChainError{} = error} = ChatVertexAI.do_process_response(response)
+      assert error.type == "unexpected_response"
+      assert error.message == "Unexpected response"
     end
   end
 

--- a/test/langchain_error_test.exs
+++ b/test/langchain_error_test.exs
@@ -1,0 +1,18 @@
+defmodule LangChain.LangChainErrorTest do
+  use ExUnit.Case
+  doctest LangChain.LangChainError
+
+  alias LangChain.LangChainError
+
+  describe "exception/1" do
+    test "supports creating with keyword list" do
+      original = RuntimeError.exception("testing")
+
+      error = LangChainError.exception(type: "test", message: "A test error", original: original)
+
+      assert error.type == "test"
+      assert error.message == "A test error"
+      assert error.original == original
+    end
+  end
+end


### PR DESCRIPTION
This is a major change to how errors are handled. Instead of `LLMChain.run` returning `{:error, updated_chain, string_error}`, it now returns `{:error, updated_chain, %LangChainError{}}`.

LangChainError has a `message`, which is the original string message being returned before. However, it now also has a `type` which is a string code like "invalid_json", "overload_error", "changeset", "unexpected_response", "timeout", "retries_exceeded", etc.

This makes it easier to detect an error type and take corrective action.

This is a big change that touches all the Chat models. I tested all I could. 

**What is incomplete:**
- I'm sure I missed some documentation updates
- Some Chat models either don't have live tests, or I'm not setup for testing them.

**What you need to do:**
- Check you application code for how it is responding to and handling error responses.

Impacting:
- Closes #193 
- Closes #159
- References #177 - makes it easier to detect and handle a retry in application code.