### PR TITLE
implement initial support for fallbacks

### DIFF
--- a/lib/langchain_error.ex
+++ b/lib/langchain_error.ex
@@ -30,7 +30,7 @@ defmodule LangChain.LangChainError do
   Create the exception using either a message or a changeset who's errors are
   converted to a message.
   """
-  @spec exception(message :: String.t() | Ecto.Changeset.t()) :: t()
+  @spec exception(message :: String.t() | Ecto.Changeset.t()) :: t() | no_return()
   def exception(message) when is_binary(message) do
     %LangChainError{message: message}
   end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -305,4 +305,15 @@ defmodule LangChain.Utils do
 
     {List.first(system), other}
   end
+
+  @doc """
+  Replace the system message with a new system message. This retains all other
+  messages as-is. An error is raised if there are more than 1 system messages.
+  """
+  @spec replace_system_message!([Message.t()], Message.t()) :: [Message.t()] | no_return()
+  def replace_system_message!(messages, new_system_message) do
+    {_old_system, rest} = split_system_message(messages)
+    # return the new system message along with the rest
+    [new_system_message | rest]
+  end
 end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -204,4 +204,37 @@ defmodule LangChain.UtilsTest do
                    end
     end
   end
+
+  describe "replace_system_message!/2" do
+    test "returns list with new system message" do
+      non_system = [
+        Message.new_user!("User 1"),
+        Message.new_assistant!("Assistant 1")
+      ]
+
+      [new_system | rest] =
+        Utils.replace_system_message!(
+          [Message.new_system!("System A") | non_system],
+          Message.new_system!("System B")
+        )
+
+      assert rest == non_system
+      assert new_system.role == :system
+      assert new_system.content == "System B"
+    end
+
+    test "handles when no existing system message" do
+      non_system = [
+        Message.new_user!("User 1"),
+        Message.new_assistant!("Assistant 1")
+      ]
+
+      [new_system | rest] =
+        Utils.replace_system_message!(non_system, Message.new_system!("System B"))
+
+      assert rest == non_system
+      assert new_system.role == :system
+      assert new_system.content == "System B"
+    end
+  end
 end


### PR DESCRIPTION
- adds :with_fallbacks option to LLMChain.run/2 options
- adds :before_fallback function for chain modification

Fallbacks is a feature inspired by [fallbacks in the OG LangChain](https://python.langchain.com/docs/how_to/fallbacks/). 

It's an important feature for taking an LLM system into production. When a system like OpenAI goes down or rate limits your usage, this enables you to automatically fallback to a different LLM.

I think it works best going from OpenAI -> Azure OpenAI, or Anthropic -> Bedrock Anthropic. That's where the most similar behavior can be found.

Provides an alternate recovery option for Anthropic "overloaded" errors. Issue #193 