### PR TITLE
Fix specs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 Elixir LangChain enables Elixir applications to integrate AI services and self-hosted models into an application.
 
 Currently supported AI services:
+
 - OpenAI ChatGPT
 - OpenAI DALL-e 2 - image generation
 - Anthropic Claude
-- Google AI - https://generativelanguage.googleapis.com
+- Google AI - <https://generativelanguage.googleapis.com>
 - Google Vertex AI - Gemini
 - Ollama
 - Mistral
@@ -114,6 +115,7 @@ fly secrets set ANTHROPIC_API_KEY=MyAnthropicApiKey
 ```
 
 A list of models to use:
+
 - [Anthropic Claude models](https://docs.anthropic.com/en/docs/about-claude/models)
 - [OpenAI models](https://platform.openai.com/docs/models)
 - [Gemini AI models](https://ai.google.dev/gemini-api/docs/models/gemini)
@@ -139,6 +141,7 @@ alias LangChain.Function
 alias LangChain.Message
 alias LangChain.Chains.LLMChain
 alias LangChain.ChatModels.ChatOpenAI
+alias LangChain.Utils.ChainResult
 
 # map of data we want to be passed as `context` to the function when
 # executed.
@@ -171,7 +174,7 @@ custom_fn =
   })
 
 # create and run the chain
-{:ok, updated_chain, %Message{} = message} =
+{:ok, updated_chain}} =
   LLMChain.new!(%{
     llm: ChatOpenAI.new!(),
     custom_context: custom_context,
@@ -182,8 +185,11 @@ custom_fn =
   |> LLMChain.run(mode: :while_needs_response)
 
 # print the LLM's answer
-IO.puts(message.content)
-#=> "The hairbrush is located in the drawer."
+IO.puts(update |> ChainResult.to_string())
+```
+
+# => "The hairbrush is located in the drawer."
+
 ```
 
 ### Alternative OpenAI compatible APIs
@@ -193,7 +199,7 @@ There are several services or self-hosted applications that provide an OpenAI co
 For example, if a locally running service provided that feature, the following code could connect to the service:
 
 ```elixir
-{:ok, updated_chain, %Message{} = message} =
+{:ok, updated_chain} = message} =
   LLMChain.new!(%{
     llm: ChatOpenAI.new!(%{endpoint: "http://localhost:1234/v1/chat/completions"}),
   })
@@ -243,4 +249,3 @@ Executing a specific test, whether it is a `live_call` or not, will execute it c
 When doing local development on the `LangChain` library itself, rename the `.envrc_template` to `.envrc` and populate it with your private API values. This is only used when running live test when explicitly requested.
 
 Use a tool like [Direnv](https://direnv.net/) or [Dotenv](https://github.com/motdotla/dotenv) to load the API values into the ENV when using the library locally.
-

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Currently supported AI services:
 - OpenAI ChatGPT
 - OpenAI DALL-e 2 - image generation
 - Anthropic Claude
-- Google AI - <https://generativelanguage.googleapis.com>
-- Google Vertex AI - Gemini
+- Google Gemini
+- Google Vertex AI (Google's enterprise offering)
 - Ollama
 - Mistral
 - Bumblebee self-hosted models - including Llama, Mistral and Zephyr

--- a/README.md
+++ b/README.md
@@ -186,10 +186,7 @@ custom_fn =
 
 # print the LLM's answer
 IO.puts(update |> ChainResult.to_string())
-```
-
 # => "The hairbrush is located in the drawer."
-
 ```
 
 ### Alternative OpenAI compatible APIs

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ There are several services or self-hosted applications that provide an OpenAI co
 For example, if a locally running service provided that feature, the following code could connect to the service:
 
 ```elixir
-{:ok, updated_chain} = message} =
+{:ok, updated_chain} =
   LLMChain.new!(%{
     llm: ChatOpenAI.new!(%{endpoint: "http://localhost:1234/v1/chat/completions"}),
   })

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -289,7 +289,7 @@ defmodule LangChain.Chains.LLMChain do
   Run the chain on the LLM using messages and any registered functions. This
   formats the request for a ChatLLMChain where messages are passed to the API.
 
-  When successful, it returns `{:ok, updated_chain, message_or_messages}`
+  When successful, it returns `{:ok, updated_chain}`
 
   ## Options
 

--- a/lib/chains/routing_chain.ex
+++ b/lib/chains/routing_chain.ex
@@ -106,7 +106,7 @@ defmodule LangChain.Chains.RoutingChain do
   route.
   """
   @spec run(t(), Keyword.t()) ::
-          {:ok, LLMChain.t(), Message.t() | [Message.t()]} | {:error, LangChainError.t()}
+          {:ok, LLMChain.t()} | {:error, LLMChain.t(), LangChainError.t()}
   def run(%RoutingChain{} = chain, opts \\ []) do
     default_name = chain.default_route.name
 

--- a/lib/langchain_error.ex
+++ b/lib/langchain_error.ex
@@ -30,7 +30,7 @@ defmodule LangChain.LangChainError do
   Create the exception using either a message or a changeset who's errors are
   converted to a message.
   """
-  @spec exception(message :: String.t() | Ecto.Changeset.t()) :: t() | no_return()
+  @spec exception(message :: String.t() | Ecto.Changeset.t() | keyword()) :: t() | no_return()
   def exception(message) when is_binary(message) do
     %LangChainError{message: message}
   end
@@ -44,7 +44,7 @@ defmodule LangChain.LangChainError do
     %LangChainError{
       message: Keyword.fetch!(opts, :message),
       type: Keyword.get(opts, :type),
-      original: Keyword.get(opts, :original),
+      original: Keyword.get(opts, :original)
     }
   end
 end

--- a/lib/prompt_template.ex
+++ b/lib/prompt_template.ex
@@ -323,7 +323,7 @@ defmodule LangChain.PromptTemplate do
   content. Raises an exception if invalid.
   """
   @spec to_content_part!(t(), input :: %{atom() => any()}) ::
-          {:ok, Message.t()} | {:error, Ecto.Changeset.t()}
+          ContentPart.t() | no_return()
   def to_content_part!(%PromptTemplate{} = template, %{} = inputs \\ %{}) do
     content = PromptTemplate.format(template, inputs)
     ContentPart.new!(%{type: :text, content: content})

--- a/lib/utils/chain_result.ex
+++ b/lib/utils/chain_result.ex
@@ -80,7 +80,8 @@ defmodule LangChain.Utils.ChainResult do
   @doc """
   Write the result to the given map as the value of the given key.
   """
-  @spec to_map(LLMChain.t(), map(), any()) :: {:ok, map()} | {:error, String.t()}
+  @spec to_map(LLMChain.t(), map(), any()) ::
+          {:ok, map()} | {:error, LLMChain.t(), LangChainError.t()}
   def to_map(%LLMChain{} = chain, map, key) do
     case ChainResult.to_string(chain) do
       {:ok, value} ->

--- a/lib/utils/chat_templates.ex
+++ b/lib/utils/chat_templates.ex
@@ -108,7 +108,7 @@ defmodule LangChain.Utils.ChatTemplates do
   - Alternates message roles between: user, assistant, user, assistant, etc.
   """
   @spec prep_and_validate_messages([Message.t()]) ::
-          {Message.t(), Message.t(), [Message.t()]} | no_return()
+          {Message.t() | nil, Message.t(), [Message.t()]} | no_return()
   def prep_and_validate_messages(messages) do
     {system, first_user, rest} =
       case messages do


### PR DESCRIPTION
Hi, and thanks for creating LangChain - it's a very useful library!

Apologies for unsolicited PR, but I decided to fix some low-hanging spec errors that dialyzer was complaining about, and also fixed `README.md` to use the new return type for `LLMChain.run()`. 

There are still a few dialyzer errors left but they are a bit more cryptic.

Hope that works!