### PR TITLE
Fix content-part encoding and decoding for Google API.

### DIFF
--- a/lib/message_processors/json_processor.ex
+++ b/lib/message_processors/json_processor.ex
@@ -110,7 +110,7 @@ defmodule LangChain.MessageProcessors.JsonProcessor do
   @spec run(LLMChain.t(), Message.t()) ::
           {:cont, Message.t()} | {:halt, Message.t()}
   def run(%LLMChain{} = chain, %Message{} = message) do
-    case Jason.decode(message.processed_content) do
+    case Jason.decode(content_to_string(message.processed_content)) do
       {:ok, parsed} ->
         if chain.verbose, do: IO.puts("Parsed JSON text to a map")
         {:cont, %Message{message | processed_content: parsed}}
@@ -132,4 +132,11 @@ defmodule LangChain.MessageProcessors.JsonProcessor do
         {:halt, Message.new_user!("ERROR: No JSON found")}
     end
   end
+
+  defp content_to_string([
+         %LangChain.Message.ContentPart{type: :text, content: content}
+       ]),
+       do: content
+
+  defp content_to_string(content), do: content
 end

--- a/lib/message_processors/json_processor.ex
+++ b/lib/message_processors/json_processor.ex
@@ -122,7 +122,9 @@ defmodule LangChain.MessageProcessors.JsonProcessor do
   end
 
   def run(%LLMChain{} = chain, %Message{} = message, regex_pattern) do
-    case Regex.run(regex_pattern, message.processed_content, capture: :all_but_first) do
+    case Regex.run(regex_pattern, content_to_string(message.processed_content),
+           capture: :all_but_first
+         ) do
       [json] ->
         if chain.verbose, do: IO.puts("Extracted JSON text from message")
         # run recursive call on just the extracted JSON

--- a/notebooks/context-specific-image-descriptions.livemd
+++ b/notebooks/context-specific-image-descriptions.livemd
@@ -181,7 +181,7 @@ image_data_from_other_system = "image of urban art mural on underpass at 507 Kin
   %{llm: openai_chat_model, verbose: true}
   |> LLMChain.new!()
   |> LLMChain.apply_prompt_templates(messages, %{extra_image_info: image_data_from_other_system})
-  |> LLMChain.message_processors([JsonProcessor.new!()])
+  |> LLMChain.message_processors([JsonProcessor.new!(~r/```json(.*?)```/s)])
   |> LLMChain.run(mode: :until_success)
 
 updated_chain.last_message.processed_content
@@ -242,7 +242,7 @@ image_data_from_other_system = "image of urban art mural on underpass at 507 Kin
   %{llm: anthropic_chat_model, verbose: true}
   |> LLMChain.new!()
   |> LLMChain.apply_prompt_templates(messages, %{extra_image_info: image_data_from_other_system})
-  |> LLMChain.message_processors([JsonProcessor.new!(~r/```json(.*?)```/s))])
+  |> LLMChain.message_processors([JsonProcessor.new!(~r/```json(.*?)```/s)])
   |> LLMChain.run(mode: :until_success)
 
 updated_chain.last_message.processed_content

--- a/notebooks/context-specific-image-descriptions.livemd
+++ b/notebooks/context-specific-image-descriptions.livemd
@@ -4,7 +4,7 @@
 
 ```elixir
 Mix.install([
-  {:langchain, "~> 0.3.0-rc.0"},
+  {:langchain, github: "brainlid/langchain"},
   {:kino, "~> 0.12.0"}
 ])
 ```
@@ -242,7 +242,7 @@ image_data_from_other_system = "image of urban art mural on underpass at 507 Kin
   %{llm: anthropic_chat_model, verbose: true}
   |> LLMChain.new!()
   |> LLMChain.apply_prompt_templates(messages, %{extra_image_info: image_data_from_other_system})
-  |> LLMChain.message_processors([JsonProcessor.new!()])
+  |> LLMChain.message_processors([JsonProcessor.new!(~r/```json(.*?)```/s))])
   |> LLMChain.run(mode: :until_success)
 
 updated_chain.last_message.processed_content
@@ -262,5 +262,3 @@ Here's what I got from it:
 ```
 
 We would want to run multiple tests on a small sampling of images and tweak our prompt until we are happy with the result. Then, we can process full batch and save our work as a template for future projects as well.
-
-<!-- livebook:{"offset":12761,"stamp":{"token":"XCP.W16VHoMa17Ik5HZEODX4xG_3efAZOoT53nwCTV0ILJBlJPOfjaoVorequscNTIpjctd5Dd_rFjn2mYnQ3HBs-HEgL3Ndv-JDxG2NMRBdcbJi_vREiaEJT2lrNKafOvhP9ZvW698i28G9jhon35Zc","version":2}} -->

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -194,8 +194,6 @@ defmodule ChatModels.ChatGoogleAITest do
                  }
                ]
              } = msg1
-
-      IO.inspect(msg1)
     end
 
     test "translates a Message with function results to the expected structure" do


### PR DESCRIPTION
It also makes the JSON response parsing in the image processing notebook more robust by including explicit regex to strip json-with-trip-quotes from the beginning and the end of the model output, which seems to be a popular way across different LLMs to return a requested JSON.

Fix #209, fix #208.