### PR TITLE
add explicit message support in summarizer

### DIFF
--- a/lib/chains/summarize_conversation_chain.ex
+++ b/lib/chains/summarize_conversation_chain.ex
@@ -286,7 +286,7 @@ defmodule LangChain.Chains.SummarizeConversationChain do
 
   def create_summary_messages(summary_text) when is_binary(summary_text) do
     [
-      Message.new_user!("Summarize our conversation to this point for future reference."),
+      Message.new_user!("Summarize our entire conversation up to this point for future reference."),
       Message.new_assistant!(summary_text)
     ]
   end


### PR DESCRIPTION
Adds support for greater customization of behavior with `LangChain.Chains.SummarizeConversationChain` by allowing the set of messages used by the summarizing chain to be completely controlled.

Some LLM's behavior may greatly improve with this level of explicit control.