### PR TITLE
Remove constraint of alternating user, assistant

### DIFF
--- a/lib/utils/chat_templates.ex
+++ b/lib/utils/chat_templates.ex
@@ -104,8 +104,11 @@ defmodule LangChain.Utils.ChatTemplates do
   If there is an issue, an exception is raised. Reasons for an exception:
 
   - Only 1 system message is allowed and, if included, it is the first message.
-  - Non-system messages must begin with a user message
-  - Alternates message roles between: user, assistant, user, assistant, etc.
+  - Non-system messages must begin with a user message or assitant message.
+
+  Recent change:
+  - Alternating messages between user / assistant / user / assistant are no longer enforced as not every model has issues.
+  - It is up to the programmer to enforce this if this is something they need.
   """
   @spec prep_and_validate_messages([Message.t()]) ::
           {Message.t() | nil, Message.t(), [Message.t()]} | no_return()
@@ -138,17 +141,16 @@ defmodule LangChain.Utils.ChatTemplates do
     # must alternate user, assistant, user, etc. Put the first user message back
     # on the list for checking it.
     [first_user | rest]
-    |> Enum.with_index()
     |> Enum.each(fn
-      {%Message{role: :user}, index} when is_even(index) ->
+      %Message{role: :user} ->
         :ok
 
-      {%Message{role: :assistant}, index} when is_odd(index) ->
+      %Message{role: :assistant} ->
         :ok
 
       _other ->
         raise LangChainError,
-              "Conversation roles must alternate user/assistant/user/assistant/..."
+              "Conversation roles must be either user or assistant."
     end)
 
     # return 3 element tuple of critical message pieces

--- a/test/utils/chat_templates_test.exs
+++ b/test/utils/chat_templates_test.exs
@@ -72,18 +72,29 @@ defmodule LangChain.Utils.ChatTemplatesTest do
                    end
     end
 
-    test "raises exception when not alternating user/assistant" do
-      assert_raise LangChainError,
-                   "Conversation roles must alternate user/assistant/user/assistant/...",
-                   fn ->
-                     ChatTemplates.prep_and_validate_messages([
-                       Message.new_system!("system_message"),
-                       Message.new_user!("user_1"),
-                       Message.new_user!("user_2"),
-                       Message.new_assistant!("assistant_response"),
-                       Message.new_user!("user_3")
-                     ])
-                   end
+    test "raises no exception when alternating user/assistant not one for one" do
+      system = Message.new_system!("system_message")
+
+      first = Message.new_user!("user_1")
+
+      rest = [
+        Message.new_user!("user_2"),
+        Message.new_assistant!("assistant_response"),
+        Message.new_user!("user_3")
+      ]
+
+      {s, u, r} =
+        ChatTemplates.prep_and_validate_messages([
+          Message.new_system!("system_message"),
+          Message.new_user!("user_1"),
+          Message.new_user!("user_2"),
+          Message.new_assistant!("assistant_response"),
+          Message.new_user!("user_3")
+        ])
+
+      assert s == system
+      assert u == first
+      assert r == rest
     end
 
     # test "removes special tokens from the message content"


### PR DESCRIPTION
I'm doing something a bit funky and I need to be able to have messages in whatever order. 
eg system/user/assistant/user1/user2/assistant/user2/user1/assistant/etc.
The LLM (Ollama) doesn't seem to mind.