### PR TITLE
Change abacus to optional dep

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule LangChain.MixProject do
       {:ecto, "~> 3.10 or ~> 3.11"},
       {:gettext, "~> 0.20"},
       {:req, ">= 0.5.2"},
-      {:abacus, "~> 2.1.0"},
+      {:abacus, "~> 2.1.0", optional: true},
       {:nx, ">= 0.7.0", optional: true},
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},
       {:mimic, "~> 1.8", only: :test}


### PR DESCRIPTION
This PR resolves #24.

`abacus` can't be compiled in livebook.

```
==> abacus
warning: in order to compile .yrl files, you must add "compilers: [:yecc] ++ Mix.compilers()" to the "def project" section of abacus's mix.exs
warning: in order to compile .xrl files, you must add "compilers: [:leex] ++ Mix.compilers()" to the "def project" section of abacus's mix.exs
Compiling 3 files (.erl)
src/new_parser.yrl:54:7: syntax error before: 'else'
%   54|       {'else', '$5'}
%     |       ^

src/new_parser.erl:819:13: function yeccpars2_46_/1 undefined
%  819|  NewStack = yeccpars2_46_(Stack),
%     |             ^

src/new_parser.yrl:71:2: inlined function yeccpars2_46_/1 undefined
%   71| expr -> expr '/' expr : {'/', [], ['$1', '$3']}.
%     |  ^

could not compile dependency :abacus, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile abacus --force", update it with "mix deps.update abacus" or clean it with "mix deps.clean abacus"
```