### PR TITLE
feat: Enable :inet6 for Req.new for Ollama

### DIFF
--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -299,6 +299,7 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
         receive_timeout: ollama_ai.receive_timeout,
         retry: :transient,
         max_retries: 3,
+        inet6: true,
         retry_delay: fn attempt -> 300 * attempt end
       )
 
@@ -337,6 +338,7 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
     Req.new(
       url: ollama_ai.endpoint,
       json: for_api(ollama_ai, messages, functions),
+      inet6: true,
       receive_timeout: ollama_ai.receive_timeout
     )
     |> Req.post(


### PR DESCRIPTION
Tried to use this with fly.io. I was unable to connection to Ollama hosted on a private flycast address. Enabling ipv6 fixed the issue.