### PR TITLE
Add Bumblebee Phi-4

### DIFF
--- a/lib/chat_models/chat_bumblebee.ex
+++ b/lib/chat_models/chat_bumblebee.ex
@@ -123,7 +123,14 @@ defmodule LangChain.ChatModels.ChatBumblebee do
     # # more focused and deterministic.
     # field :temperature, :float, default: 1.0
 
-    field :template_format, Ecto.Enum, values: [:inst, :im_start, :zephyr, :llama_2, :llama_3]
+    field :template_format, Ecto.Enum, values: [
+      :inst,
+      :im_start,
+      :zephyr,
+      :phi_4,
+      :llama_2,
+      :llama_3
+    ]
 
     # The bumblebee model may compile differently based on the stream true/false
     # option on the serving. Therefore, streaming should be enabled on the


### PR DESCRIPTION
This commit adds the Prompt template for the Phi-4 model.

Tested with quantized Phi-4 on 40GB A100. (17.7 GB vram and 100GB ram to quantize)

template_format: :phi_4

If I should add the livebook let me know?