### PR TITLE
support for o1 OpenAI model

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -300,7 +300,12 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   end
 
   def for_api(%Function{} = function) do
-    encoded = ChatOpenAI.for_api(function)
+    encoded =
+      %{
+        "name" => function.name,
+        "parameters" => ChatOpenAI.get_parameters(function)
+      }
+      |> Utils.conditionally_add_to_map("description", function.description)
 
     # For functions with no parameters, Google AI needs the parameters field removing, otherwise it will error
     # with "* GenerateContentRequest.tools[0].function_declarations[0].parameters.properties: should be non-empty for OBJECT type\n"

--- a/lib/chat_models/chat_mistral_ai.ex
+++ b/lib/chat_models/chat_mistral_ai.ex
@@ -125,7 +125,7 @@ defmodule LangChain.ChatModels.ChatMistralAI do
       top_p: mistral.top_p,
       safe_prompt: mistral.safe_prompt,
       stream: mistral.stream,
-      messages: Enum.map(messages, &ChatOpenAI.for_api/1)
+      messages: Enum.map(messages, &ChatOpenAI.for_api(mistral, &1))
     }
     |> Utils.conditionally_add_to_map(:random_seed, mistral.random_seed)
     |> Utils.conditionally_add_to_map(:max_tokens, mistral.max_tokens)

--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -192,7 +192,7 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
     %{
       model: model.model,
       temperature: model.temperature,
-      messages: messages |> Enum.map(&ChatOpenAI.for_api/1),
+      messages: messages |> Enum.map(&ChatOpenAI.for_api(model, &1)),
       stream: model.stream,
       seed: model.seed,
       num_ctx: model.num_ctx,

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -108,6 +108,18 @@ defmodule LangChain.ChatModels.ChatOpenAI do
 
   `https://some-subdomain.cognitiveservices.azure.com/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-08-01-preview"`
 
+  ## Reasoning Model Support
+
+  OpenAI made some significant API changes with the introduction of their "reasoning" models. This includes the `o1` and `o1-mini` models.
+
+  To enable this mode, set `:reasoning_mode` to `true`:
+
+      model = ChatOpenAI.new!(%{reasoning_mode: true})
+
+  Setting `reasoning_mode` to `true` does at least the two following things:
+
+  - Set `:developer` as the `role` for system messages. The OpenAI documentation says API calls to `o1` and newer models must use the `role: :developer` instead of `role: :system` and errors if not set correctly.
+  - The `:reasoning_effort` option included in LLM requests. This setting is only permitted on a reasoning model. The `:reasoning_effort` values support the "low", "medium" (default), and "high" options specified in the OpenAI documentation. This instructs the LLM on how much time, and tokens, should be spent on thinking through and reasoning about the request and the response.
   """
   use Ecto.Schema
   require Logger
@@ -115,6 +127,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   alias __MODULE__
   alias LangChain.Config
   alias LangChain.ChatModels.ChatModel
+  alias LangChain.PromptTemplate
   alias LangChain.Message
   alias LangChain.Message.ContentPart
   alias LangChain.Message.ToolCall
@@ -155,6 +168,19 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     # their existing frequency in the text so far, decreasing the model's
     # likelihood to repeat the same line verbatim.
     field :frequency_penalty, :float, default: 0.0
+
+    # Used when working with a reasoning model like `o1` and newer. This setting
+    # is required when working with those models as the API behavior needs to
+    # change.
+    field :reasoning_mode, :boolean, default: false
+
+    # o1 models only
+    #
+    # Constrains effort on reasoning for reasoning models. Currently supported
+    # values are `low`, `medium`, and `high`. Reducing reasoning effort can result in
+    # faster responses and fewer tokens used on reasoning in a response.
+    field :reasoning_effort, :string, default: "medium"
+
     # Duration in seconds for the response to be received. When streaming a very
     # lengthy response, a longer time limit may be required. However, when it
     # goes on too long by itself, it tends to hallucinate more.
@@ -198,6 +224,8 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     :seed,
     :n,
     :stream,
+    :reasoning_mode,
+    :reasoning_effort,
     :receive_timeout,
     :json_response,
     :json_schema,
@@ -275,7 +303,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       messages:
         messages
         |> Enum.reduce([], fn m, acc ->
-          case for_api(m) do
+          case for_api(openai, m) do
             %{} = data ->
               [data | acc]
 
@@ -287,22 +315,26 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       response_format: set_response_format(openai),
       user: openai.user
     }
+    |> Utils.conditionally_add_to_map(
+      :reasoning_effort,
+      if(openai.reasoning_mode, do: openai.reasoning_effort, else: nil)
+    )
     |> Utils.conditionally_add_to_map(:max_tokens, openai.max_tokens)
     |> Utils.conditionally_add_to_map(:seed, openai.seed)
     |> Utils.conditionally_add_to_map(
       :stream_options,
       get_stream_options_for_api(openai.stream_options)
     )
-    |> Utils.conditionally_add_to_map(:tools, get_tools_for_api(tools))
+    |> Utils.conditionally_add_to_map(:tools, get_tools_for_api(openai, tools))
     |> Utils.conditionally_add_to_map(:tool_choice, get_tool_choice(openai))
   end
 
-  defp get_tools_for_api(nil), do: []
+  defp get_tools_for_api(%_{} = _model, nil), do: []
 
-  defp get_tools_for_api(tools) do
+  defp get_tools_for_api(%_{} = model, tools) do
     Enum.map(tools, fn
       %Function{} = function ->
-        %{"type" => "function", "function" => for_api(function)}
+        %{"type" => "function", "function" => for_api(model, function)}
     end)
   end
 
@@ -341,20 +373,62 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   defp get_tool_choice(%ChatOpenAI{}), do: nil
 
   @doc """
-  Convert a LangChain structure to the expected map of data for the OpenAI API.
+  Convert a LangChain Message-based structure to the expected map of data for
+  the OpenAI API. This happens within the context of the model configuration as
+  well. The additional context is needed to correctly convert a role to either
+  `:system` or `:developer`.
+
+  NOTE: The `ChatOpenAI` model's functions are reused in other modules. For this
+  reason, model is more generally defined as a struct.
   """
-  @spec for_api(Message.t() | ContentPart.t() | Function.t()) ::
+  @spec for_api(
+          struct(),
+          Message.t()
+          | PromptTemplate.t()
+          | ToolCall.t()
+          | ToolResult.t()
+          | ContentPart.t()
+          | Function.t()
+        ) ::
           %{String.t() => any()} | [%{String.t() => any()}]
-  def for_api(%Message{role: :assistant, tool_calls: tool_calls} = msg)
+  def for_api(%_{} = model, %Message{content: content} = msg) when is_binary(content) do
+    role = get_message_role(model, msg.role)
+
+    %{
+      "role" => role,
+      "content" => msg.content
+    }
+    |> Utils.conditionally_add_to_map("name", msg.name)
+  end
+
+  def for_api(%_{} = model, %Message{role: :user, content: content} = msg)
+      when is_list(content) do
+    %{
+      "role" => msg.role,
+      "content" => Enum.map(content, &for_api(model, &1))
+    }
+    |> Utils.conditionally_add_to_map("name", msg.name)
+  end
+
+  def for_api(%_{} = _model, %ToolResult{type: :function} = result) do
+    # a ToolResult becomes a stand-alone %Message{role: :tool} response.
+    %{
+      "role" => :tool,
+      "tool_call_id" => result.tool_call_id,
+      "content" => result.content
+    }
+  end
+
+  def for_api(%_{} = model, %Message{role: :assistant, tool_calls: tool_calls} = msg)
       when is_list(tool_calls) do
     %{
       "role" => :assistant,
       "content" => msg.content
     }
-    |> Utils.conditionally_add_to_map("tool_calls", Enum.map(tool_calls, &for_api(&1)))
+    |> Utils.conditionally_add_to_map("tool_calls", Enum.map(tool_calls, &for_api(model, &1)))
   end
 
-  def for_api(%Message{role: :tool, tool_results: tool_results} = _msg)
+  def for_api(%_{} = _model, %Message{role: :tool, tool_results: tool_results} = _msg)
       when is_list(tool_results) do
     # ToolResults turn into a list of tool messages for OpenAI
     Enum.map(tool_results, fn result ->
@@ -366,40 +440,12 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     end)
   end
 
-  def for_api(%Message{content: content} = msg) when is_binary(content) do
-    %{
-      "role" => msg.role,
-      "content" => msg.content
-    }
-    |> Utils.conditionally_add_to_map("name", msg.name)
-  end
-
-  def for_api(%Message{role: :user, content: content} = msg) when is_list(content) do
-    %{
-      "role" => msg.role,
-      "content" => Enum.map(content, &for_api(&1))
-    }
-    |> Utils.conditionally_add_to_map("name", msg.name)
-  end
-
-  def for_api(%ToolResult{type: :function} = result) do
-    # a ToolResult becomes a stand-alone %Message{role: :tool} response.
-    %{
-      "role" => :tool,
-      "tool_call_id" => result.tool_call_id,
-      "content" => result.content
-    }
-  end
-
-  def for_api(%LangChain.PromptTemplate{} = _template) do
-    raise LangChain.LangChainError, "PromptTemplates must be converted to messages."
-  end
-
-  def for_api(%ContentPart{type: :text} = part) do
+  def for_api(%_{} = _model, %ContentPart{type: :text} = part) do
     %{"type" => "text", "text" => part.content}
   end
 
-  def for_api(%ContentPart{type: image} = part) when image in [:image, :image_url] do
+  def for_api(%_{} = _model, %ContentPart{type: image} = part)
+      when image in [:image, :image_url] do
     media_prefix =
       case Keyword.get(part.options || [], :media, nil) do
         nil ->
@@ -437,7 +483,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   end
 
   # ToolCall support
-  def for_api(%ToolCall{type: :function} = fun) do
+  def for_api(%_{} = _model, %ToolCall{type: :function} = fun) do
     %{
       "id" => fun.call_id,
       "type" => "function",
@@ -449,7 +495,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   end
 
   # Function support
-  def for_api(%Function{} = fun) do
+  def for_api(%_{} = _model, %Function{} = fun) do
     %{
       "name" => fun.name,
       "parameters" => get_parameters(fun)
@@ -457,21 +503,32 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     |> Utils.conditionally_add_to_map("description", fun.description)
   end
 
-  defp get_parameters(%Function{parameters: [], parameters_schema: nil} = _fun) do
+  def for_api(%_{} = _model, %PromptTemplate{} = _template) do
+    raise LangChain.LangChainError, "PromptTemplates must be converted to messages."
+  end
+
+  @doc false
+  def get_parameters(%Function{parameters: [], parameters_schema: nil} = _fun) do
     %{
       "type" => "object",
       "properties" => %{}
     }
   end
 
-  defp get_parameters(%Function{parameters: [], parameters_schema: schema} = _fun)
-       when is_map(schema) do
+  def get_parameters(%Function{parameters: [], parameters_schema: schema} = _fun)
+      when is_map(schema) do
     schema
   end
 
-  defp get_parameters(%Function{parameters: params} = _fun) do
+  def get_parameters(%Function{parameters: params} = _fun) do
     FunctionParam.to_parameters_schema(params)
   end
+
+  # Convert a message role into either `:system` or :developer` based on the
+  # message role and the system config.
+  defp get_message_role(%ChatOpenAI{reasoning_mode: true}, :system), do: :developer
+  defp get_message_role(%ChatOpenAI{}, role), do: role
+  defp get_message_role(_model, role), do: role
 
   @doc """
   Calls the OpenAI API passing the ChatOpenAI struct with configuration, plus
@@ -889,11 +946,23 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   # MS Azure returns numeric error codes. Interpret them when possible to give a computer-friendly reason
   #
   # https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/create-upgrade-delete/429-too-many-requests-errors
-  def do_process_response(_model, %{"error" => %{"code" => code, "message" => reason}}) do
+  def do_process_response(_model, %{
+        "error" => %{"code" => code, "message" => reason} = error_data
+      }) do
     type =
       case code do
         "429" ->
           "rate_limit_exceeded"
+
+        "unsupported_value" ->
+          if String.contains?(reason, "does not support 'system' with this model") do
+            Logger.error(
+              "This model requires 'reasoning_mode' to be enabled. Reason: #{inspect(reason)}"
+            )
+
+            # return the API error type as the exception type information
+            error_data["type"]
+          end
 
         _other ->
           nil
@@ -996,6 +1065,8 @@ defmodule LangChain.ChatModels.ChatOpenAI do
         :model,
         :temperature,
         :frequency_penalty,
+        :reasoning_mode,
+        :reasoning_effort,
         :receive_timeout,
         :seed,
         :n,

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -152,7 +152,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
         %{
           # Google AI functions use an OpenAI compatible format.
           # See: https://ai.google.dev/docs/function_calling#how_it_works
-          "functionDeclarations" => Enum.map(functions, &ChatOpenAI.for_api/1)
+          "functionDeclarations" => Enum.map(functions, &ChatOpenAI.for_api(vertex_ai, &1))
         }
       ])
     else

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -94,6 +94,16 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert openai.json_response == true
       assert openai.json_schema == json_schema
     end
+
+    test "supports overriding reasoning_effort" do
+      # defaults to "medium"
+      %ChatOpenAI{} = openai = ChatOpenAI.new!()
+      assert openai.reasoning_effort == "medium"
+
+      # can override the default to "high"
+      %ChatOpenAI{} = openai = ChatOpenAI.new!(%{"reasoning_effort" => "high"})
+      assert openai.reasoning_effort == "high"
+    end
   end
 
   describe "for_api/3" do
@@ -212,54 +222,15 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
   end
 
   describe "for_api/1" do
-    test "turns a basic user message into the expected JSON format" do
-      expected = %{"role" => :user, "content" => "Hi."}
-      result = ChatOpenAI.for_api(Message.new_user!("Hi."))
-      assert result == expected
-    end
-
-    test "includes 'name' when set" do
-      expected = %{"role" => :user, "content" => "Hi.", "name" => "Harold"}
-      result = ChatOpenAI.for_api(Message.new!(%{role: :user, content: "Hi.", name: "Harold"}))
-      assert result == expected
-    end
-
-    test "turns an assistant message into expected JSON format" do
-      # NOTE: Does not include tool_calls if empty
-      expected = %{"role" => :assistant, "content" => "Hi."}
-      result = ChatOpenAI.for_api(Message.new_assistant!(%{content: "Hi.", tool_calls: []}))
-      assert result == expected
-    end
-
-    test "turns a multi-modal user message into the expected JSON format" do
-      expected = %{
-        "role" => :user,
-        "content" => [
-          %{"type" => "text", "text" => "Tell me about this image:"},
-          %{"type" => "image_url", "image_url" => %{"url" => "url-to-image"}}
-        ]
-      }
-
-      result =
-        ChatOpenAI.for_api(
-          Message.new_user!([
-            ContentPart.text!("Tell me about this image:"),
-            ContentPart.image_url!("url-to-image")
-          ])
-        )
-
-      assert result == expected
-    end
-
     test "turns a text ContentPart into the expected JSON format" do
       expected = %{"type" => "text", "text" => "Tell me about this image:"}
-      result = ChatOpenAI.for_api(ContentPart.text!("Tell me about this image:"))
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), ContentPart.text!("Tell me about this image:"))
       assert result == expected
     end
 
     test "turns an image ContentPart into the expected JSON format" do
       expected = %{"type" => "image_url", "image_url" => %{"url" => "image_base64_data"}}
-      result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data"))
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), ContentPart.image!("image_base64_data"))
       assert result == expected
     end
 
@@ -269,40 +240,40 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
         "image_url" => %{"url" => "image_base64_data", "detail" => "low"}
       }
 
-      result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", detail: "low"))
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), ContentPart.image!("image_base64_data", detail: "low"))
       assert result == expected
     end
 
     test "turns ContentPart's media type the expected JSON values" do
       expected = "data:image/jpg;base64,image_base64_data"
-      result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", media: :jpg))
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), ContentPart.image!("image_base64_data", media: :jpg))
       assert %{"image_url" => %{"url" => ^expected}} = result
 
       expected = "data:image/jpg;base64,image_base64_data"
-      result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", media: :jpeg))
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), ContentPart.image!("image_base64_data", media: :jpeg))
       assert %{"image_url" => %{"url" => ^expected}} = result
 
       expected = "data:image/gif;base64,image_base64_data"
-      result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", media: :gif))
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), ContentPart.image!("image_base64_data", media: :gif))
       assert %{"image_url" => %{"url" => ^expected}} = result
 
       expected = "data:image/webp;base64,image_base64_data"
-      result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", media: :webp))
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), ContentPart.image!("image_base64_data", media: :webp))
       assert %{"image_url" => %{"url" => ^expected}} = result
 
       expected = "data:image/png;base64,image_base64_data"
-      result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", media: :png))
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), ContentPart.image!("image_base64_data", media: :png))
       assert %{"image_url" => %{"url" => ^expected}} = result
 
       # an string value is passed through
       expected = "data:file/pdf;base64,image_base64_data"
-      result = ChatOpenAI.for_api(ContentPart.image!("image_base64_data", media: "file/pdf"))
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), ContentPart.image!("image_base64_data", media: "file/pdf"))
       assert %{"image_url" => %{"url" => ^expected}} = result
     end
 
     test "turns an image_url ContentPart into the expected JSON format" do
       expected = %{"type" => "image_url", "image_url" => %{"url" => "url-to-image"}}
-      result = ChatOpenAI.for_api(ContentPart.image_url!("url-to-image"))
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), ContentPart.image_url!("url-to-image"))
       assert result == expected
     end
 
@@ -312,7 +283,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
         "image_url" => %{"url" => "url-to-image", "detail" => "low"}
       }
 
-      result = ChatOpenAI.for_api(ContentPart.image_url!("url-to-image", detail: "low"))
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), ContentPart.image_url!("url-to-image", detail: "low"))
       assert result == expected
     end
 
@@ -320,7 +291,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       tool_call =
         ToolCall.new!(%{call_id: "call_abc123", name: "hello_world", arguments: "{}"})
 
-      json = ChatOpenAI.for_api(tool_call)
+      json = ChatOpenAI.for_api(ChatOpenAI.new!(), tool_call)
 
       assert json ==
                %{
@@ -347,7 +318,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
           ]
         })
 
-      json = ChatOpenAI.for_api(msg)
+      json = ChatOpenAI.for_api(ChatOpenAI.new!(), msg)
 
       assert json == %{
                "role" => :assistant,
@@ -365,18 +336,6 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
              }
     end
 
-    test "turns a ToolResult into the expected JSON format" do
-      result = ToolResult.new!(%{tool_call_id: "tool_abc123", content: "Hello World!"})
-
-      json = ChatOpenAI.for_api(result)
-
-      assert json == %{
-               "content" => "Hello World!",
-               "tool_call_id" => "tool_abc123",
-               "role" => :tool
-             }
-    end
-
     test "turns a tool message into expected JSON format" do
       msg =
         Message.new_tool_result!(%{
@@ -385,7 +344,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
           ]
         })
 
-      [json] = ChatOpenAI.for_api(msg)
+      [json] = ChatOpenAI.for_api(ChatOpenAI.new!(), msg)
 
       assert json == %{
                "content" => "Hello World!",
@@ -411,7 +370,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
 
       # ChatGPT expects each tool response to stand alone. This splits them out
       # and returns them individually.
-      list = ChatOpenAI.for_api(message)
+      list = ChatOpenAI.for_api(ChatOpenAI.new!(), message)
 
       assert is_list(list)
 
@@ -437,7 +396,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
     end
 
     test "tools work with minimal definition and no parameters", %{hello_world: hello_world} do
-      result = ChatOpenAI.for_api(hello_world)
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), hello_world)
 
       assert result == %{
                "name" => "hello_world",
@@ -474,7 +433,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
         })
 
       # result = Function.for_api(fun)
-      result = ChatOpenAI.for_api(fun)
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), fun)
 
       assert result == %{
                "name" => "say_hi",
@@ -507,7 +466,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
         })
 
       # result = Function.for_api(fun)
-      result = ChatOpenAI.for_api(fun)
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), fun)
 
       assert result == %{
                "name" => "say_hi",
@@ -534,8 +493,88 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       # don't try and send an Elixir function ref through to the API
       {:ok, fun} = Function.new(%{"name" => "hello_world", "function" => &hello_world/2})
       # result = Function.for_api(fun)
-      result = ChatOpenAI.for_api(fun)
+      result = ChatOpenAI.for_api(ChatOpenAI.new!(), fun)
       refute Map.has_key?(result, "function")
+    end
+  end
+
+  describe "for_api/2" do
+    test "turns a basic user message into the expected JSON format" do
+      openai = ChatOpenAI.new!()
+
+      expected = %{"role" => :user, "content" => "Hi."}
+      result = ChatOpenAI.for_api(openai, Message.new_user!("Hi."))
+      assert result == expected
+    end
+
+    test "includes 'name' when set" do
+      openai = ChatOpenAI.new!()
+
+      expected = %{"role" => :user, "content" => "Hi.", "name" => "Harold"}
+
+      result =
+        ChatOpenAI.for_api(openai, Message.new!(%{role: :user, content: "Hi.", name: "Harold"}))
+
+      assert result == expected
+    end
+
+    test "turns an assistant message into expected JSON format" do
+      openai = ChatOpenAI.new!()
+
+      # NOTE: Does not include tool_calls if empty
+      expected = %{"role" => :assistant, "content" => "Hi."}
+
+      result =
+        ChatOpenAI.for_api(openai, Message.new_assistant!(%{content: "Hi.", tool_calls: []}))
+
+      assert result == expected
+    end
+
+    test "turns a ToolResult into the expected JSON format" do
+      openai = ChatOpenAI.new!()
+      result = ToolResult.new!(%{tool_call_id: "tool_abc123", content: "Hello World!"})
+
+      json = ChatOpenAI.for_api(openai, result)
+
+      assert json == %{
+               "content" => "Hello World!",
+               "tool_call_id" => "tool_abc123",
+               "role" => :tool
+             }
+    end
+
+    test "turns a multi-modal user message into the expected JSON format" do
+      openai = ChatOpenAI.new!()
+
+      expected = %{
+        "role" => :user,
+        "content" => [
+          %{"type" => "text", "text" => "Tell me about this image:"},
+          %{"type" => "image_url", "image_url" => %{"url" => "url-to-image"}}
+        ]
+      }
+
+      result =
+        ChatOpenAI.for_api(
+          openai,
+          Message.new_user!([
+            ContentPart.text!("Tell me about this image:"),
+            ContentPart.image_url!("url-to-image")
+          ])
+        )
+
+      assert result == expected
+    end
+
+    test "turns system role in to developer role based on flag" do
+      openai = ChatOpenAI.new!()
+      openai_dev = ChatOpenAI.new!(%{reasoning_mode: true})
+
+      assert %{"role" => :system} =
+               ChatOpenAI.for_api(openai, Message.new_system!("System prompt!"))
+
+      assert %{"role" => :developer} =
+               ChatOpenAI.for_api(openai_dev, Message.new_system!("System prompt!"))
     end
   end
 
@@ -2066,6 +2105,8 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
                "max_tokens" => 1234,
                "model" => "gpt-4o",
                "n" => 1,
+               "reasoning_mode" => false,
+               "reasoning_effort" => "medium",
                "receive_timeout" => 60000,
                "seed" => 123,
                "stream" => false,


### PR DESCRIPTION
- adds new "reasoning_mode". Sends "developer" role instead of "system" role.
- adds support for "reasoning_effort" API option
- refactors many of the for_api functions to include the model. The reasoning model changes how things are sent

Resolves issue https://github.com/brainlid/langchain/issues/232

I don't have [Tier 5](https://platform.openai.com/docs/guides/rate-limits#usage-tiers) usage so I can't live-test this on an `o1` model. It _should_ work as far as I can tell.