### PR TITLE
feat: Support for Ollama keep_alive API parameter

### DIFF
--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -49,6 +49,7 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
 
   @create_fields [
     :endpoint,
+    :keep_alive,
     :mirostat,
     :mirostat_eta,
     :mirostat_tau,
@@ -77,6 +78,10 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
   @primary_key false
   embedded_schema do
     field :endpoint, :string, default: "http://localhost:11434/api/chat"
+
+    # Change Keep Alive setting for unloading the model from memory.
+    # (Default: "5m", set to a negative interval to disable)
+    field :keep_alive, :string, default: "5m"
 
     # Enable Mirostat sampling for controlling perplexity.
     # (default: 0, 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0)
@@ -199,6 +204,7 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
       num_predict: model.num_predict,
       repeat_last_n: model.repeat_last_n,
       repeat_penalty: model.repeat_penalty,
+      keep_alive: model.keep_alive,
       mirostat: model.mirostat,
       mirostat_eta: model.mirostat_eta,
       mirostat_tau: model.mirostat_tau,
@@ -411,6 +417,7 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
       model,
       [
         :endpoint,
+        :keep_alive,
         :model,
         :mirostat,
         :mirostat_eta,

--- a/test/chat_models/chat_ollama_ai_test.exs
+++ b/test/chat_models/chat_ollama_ai_test.exs
@@ -257,6 +257,7 @@ defmodule ChatModels.ChatOllamaAITest do
 
       assert result == %{
                "endpoint" => "http://localhost:11434/api/chat",
+               "keep_alive" => "5m",
                "mirostat" => 0,
                "mirostat_eta" => 0.1,
                "mirostat_tau" => 5.0,


### PR DESCRIPTION
This API parameter should keep the model "warm" in memory. Otherwise after 5 minutes it is unloaded, and can be expensive to re-load.

Relevant docs: https://github.com/ollama/ollama/blob/main/docs/faq.md#how-do-i-keep-a-model-loaded-in-memory-or-make-it-unload-immediately