### PR TITLE
Include stacktrace context in messages for caught exceptions from LLM functions & function callbacks.

### DIFF
--- a/lib/callbacks.ex
+++ b/lib/callbacks.ex
@@ -42,7 +42,7 @@ defmodule LangChain.Callbacks do
           rescue
             err ->
               msg =
-                "Callback handler for #{inspect(callback_name)} raised an exception: #{inspect(err)}"
+                "Callback handler for #{inspect(callback_name)} raised an exception: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"
 
               Logger.error(msg)
               raise LangChainError, msg

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -978,7 +978,9 @@ defmodule LangChain.Chains.LLMChain do
       end
     rescue
       err ->
-        Logger.error("Function #{function.name} failed in execution. Exception: #{inspect(err)}")
+        Logger.error(
+          "Function #{function.name} failed in execution. Exception: #{LangChainError.format_exception(err, __STACKTRACE__)}"
+        )
 
         ToolResult.new!(%{
           tool_call_id: call.call_id,

--- a/lib/function.ex
+++ b/lib/function.ex
@@ -281,8 +281,11 @@ defmodule LangChain.Function do
       end
     rescue
       err ->
-        Logger.error("Function #{function.name} failed in execution. Exception: #{inspect(err)}")
-        {:error, "ERROR: #{inspect(err)}"}
+        Logger.error(
+          "Function! #{function.name} failed in execution. Exception: #{LangChainError.format_exception(err, __STACKTRACE__)}"
+        )
+
+        {:error, "ERROR: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"}
     end
   end
 

--- a/lib/langchain_error.ex
+++ b/lib/langchain_error.ex
@@ -47,4 +47,19 @@ defmodule LangChain.LangChainError do
       original: Keyword.get(opts, :original)
     }
   end
+
+  @doc """
+  Formats the exception as a string using a stacktrace to provide context.
+  """
+  @spec format_exception(exception :: struct(), trace :: Exception.stacktrace(), format :: atom()) ::
+          String.t()
+  def format_exception(exception, trace, format \\ :full_stacktrace) do
+    case format do
+      :short ->
+        "(#{inspect(exception.__struct__)}) #{Exception.message(exception)} at #{Enum.at(trace, 0) |> Exception.format_stacktrace_entry()}"
+
+      _ ->
+        Exception.format(:error, exception, trace)
+    end
+  end
 end

--- a/test/callbacks_test.exs
+++ b/test/callbacks_test.exs
@@ -34,7 +34,7 @@ defmodule LangChain.CallbacksTest do
       handlers = %{custom: fn _value -> raise ArgumentError, "BOOM!" end}
 
       assert_raise LangChainError,
-                   "Callback handler for :custom raised an exception: %ArgumentError{message: \"BOOM!\"}",
+                   "Callback handler for :custom raised an exception: (ArgumentError) BOOM! at test/callbacks_test.exs:#{__ENV__.line - 3}: anonymous fn/1 in LangChain.CallbacksTest.\"test fire/3 handles when a handler errors\"/1",
                    fn ->
                      Callbacks.fire([handlers], :custom, ["123"])
                    end

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -1756,7 +1756,10 @@ defmodule LangChain.Chains.LLMChainTest do
 
       assert updated_chain.last_message.role == :tool
       [%ToolResult{} = result] = updated_chain.last_message.tool_results
-      assert result.content == "ERROR: %RuntimeError{message: \"Stuff went boom!\"}"
+
+      assert result.content ==
+               "ERROR: (RuntimeError) Stuff went boom! at test/chains/llm_chain_test.exs:#{__ENV__.line - 19}: anonymous fn/2 in LangChain.Chains.LLMChainTest.\"test execute_tool_calls/2 catches exceptions from executed function and returns Tool result with error message\"/1"
+
       assert result.is_error == true
     end
 

--- a/test/function_test.exs
+++ b/test/function_test.exs
@@ -136,7 +136,10 @@ defmodule LangChain.FunctionTest do
 
       # rescues an exception and returns as string text
       result = Function.execute(function, %{}, %{result: :exception})
-      assert result == {:error, "ERROR: %RuntimeError{message: \"fake exception\"}"}
+
+      assert result ==
+               {:error,
+                "ERROR: (RuntimeError) fake exception at test/function_test.exs:13: LangChain.FunctionTest.returns_context/2"}
 
       # returns an error when anything else is returned
       result = Function.execute(function, %{}, %{result: 123})


### PR DESCRIPTION
Hi! In upgrading some code to 0.3.0 I had a few exceptions to track down and found the lack of context in the caught error messages slowed things down.

This change adds context  to the error messages logged and kept in the chain for LLM functions and function callbacks. I took an initial stab at the places this seems most valuable while avoiding putting full stack traces in the chain. 

The details:
 - caught exceptions were logging their type and message, however, without a stack trace or location for the exception debugging was required to locate some issues. 
 - added format_exception/3 to LangChain.LangChainError to format exceptions with context from the stacktrace. The third argument is the format - :short only includes the location and the default gives a full stack trace at the end of the message.
 - I updated the most obvious places where a lack of context could slow down fixing issues, however there are other rescue blocks where this may be useful.