### PR TITLE
add on_message_processed callback when tool response is created

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -925,7 +925,9 @@ defmodule LangChain.Chains.LLMChain do
       # fire the callbacks
       if chain.verbose, do: IO.inspect(result_message, label: "TOOL RESULTS")
 
-      fire_callback_and_return(updated_chain, :on_tool_response_created, [result_message])
+      updated_chain
+      |> fire_callback_and_return(:on_message_processed, [result_message])
+      |> fire_callback_and_return(:on_tool_response_created, [result_message])
     else
       # Not a complete tool call
       chain

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -1655,8 +1655,11 @@ defmodule LangChain.Chains.LLMChainTest do
       test_pid = self()
 
       handler = %{
+        on_message_processed: fn _chain, tool_msg ->
+          send(test_pid, {:message_processed_callback_fired, tool_msg})
+        end,
         on_tool_response_created: fn _chain, tool_msg ->
-          send(test_pid, {:message_callback_fired, tool_msg})
+          send(test_pid, {:response_created_callback_fired, tool_msg})
         end
       }
 
@@ -1694,7 +1697,10 @@ defmodule LangChain.Chains.LLMChainTest do
 
       [tool1, tool2, tool3] = tool_message.tool_results
 
-      assert_receive {:message_callback_fired, callback_message}
+      assert_receive {:message_processed_callback_fired, callback_message}
+      assert %Message{role: :tool} = callback_message
+
+      assert_receive {:response_created_callback_fired, callback_message}
       assert %Message{role: :tool} = callback_message
       assert [tool1, tool2, tool3] == callback_message.tool_results
 


### PR DESCRIPTION
When a Tool response message is created, it already fired an `on_tool_response_created`, but it now also fires the more general `on_message_processed`, because a tool result can certainly be considered being processed.

Related to discussion in #244