### PR TITLE
typos: Update Example for Syntax Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,9 @@ custom_fn =
   |> LLMChain.add_tools(custom_fn)
   |> LLMChain.add_message(Message.new_user!("Where is the hairbrush located?"))
   |> LLMChain.run(mode: :while_needs_response)
-  |> ChainResult.to_string()
 
 # print the LLM's answer
-IO.puts(updated_chain)
+IO.puts(ChainResult.to_string(updated_chain))
 # => "The hairbrush is located in the drawer."
 ```
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ custom_fn =
   |> LLMChain.run(mode: :while_needs_response)
 
 # print the LLM's answer
-IO.puts(ChainResult.to_string(updated_chain))
+IO.puts(ChainResult.to_string!(updated_chain))
 # => "The hairbrush is located in the drawer."
 ```
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ custom_fn =
   })
 
 # create and run the chain
-{:ok, updated_chain}} =
+{:ok, updated_chain} =
   LLMChain.new!(%{
     llm: ChatOpenAI.new!(),
     custom_context: custom_context,
@@ -194,9 +194,10 @@ custom_fn =
   |> LLMChain.add_tools(custom_fn)
   |> LLMChain.add_message(Message.new_user!("Where is the hairbrush located?"))
   |> LLMChain.run(mode: :while_needs_response)
+  |> ChainResult.to_string()
 
 # print the LLM's answer
-IO.puts(update |> ChainResult.to_string())
+IO.puts(updated_chain)
 # => "The hairbrush is located in the drawer."
 ```
 


### PR DESCRIPTION
Move the `to_string` call into the pipeline as it returns a Tuple which IO.puts can't handle:

```log
** (Protocol.UndefinedError) protocol String.Chars not implemented for {:ok, "The hairbrush is located in the drawer."} of type Tuple
```

Renamed the variable for consistency/compilation.