### PR TITLE
Feat/add text splitter

### DIFF
--- a/lib/text_splitter.ex
+++ b/lib/text_splitter.ex
@@ -13,10 +13,10 @@ defmodule LangChain.TextSplitter do
   @type t :: %TextSplitter{}
 
   @update_fields [
-   :separator,
-   :chunk_size,
-   :chunk_overlap
-   ]
+    :separator,
+    :chunk_size,
+    :chunk_overlap
+  ]
   @create_fields @update_fields
 
   def new(attrs \\ %{}) do
@@ -24,7 +24,7 @@ defmodule LangChain.TextSplitter do
     |> cast(attrs, @create_fields)
     |> apply_action(:insert)
   end
-  
+
   def split_text(%TextSplitter{} = text_splitter, text) do
     text
     |> split_text_with_regex(text_splitter)
@@ -33,7 +33,8 @@ defmodule LangChain.TextSplitter do
 
   defp split_text_with_regex(
          text,
-         %TextSplitter{} = text_splitter) do
+         %TextSplitter{} = text_splitter
+       ) do
     text
     |> String.split(text_splitter.separator)
     |> Enum.filter(fn x -> x != "" end)
@@ -44,23 +45,28 @@ defmodule LangChain.TextSplitter do
   defp merge_split_helper(d, acc, text_splitter) do
     total = acc.total
     len = String.length(d)
-    if (total <= text_splitter.chunk_overlap) or
-         (total + len + String.length(text_splitter.separator)
-         <= text_splitter.chunk_size) and
-         (total <= 0) do
+
+    if total <= text_splitter.chunk_overlap or
+         (total + len + String.length(text_splitter.separator) <=
+            text_splitter.chunk_size and
+            total <= 0) do
       acc
     else
-      new_total = acc.total - (acc.current_doc
-      |> Enum.at(0, "")
-      |> String.length) - String.length(text_splitter.separator)
+      new_total =
+        acc.total -
+          (acc.current_doc
+           |> Enum.at(0, "")
+           |> String.length()) - String.length(text_splitter.separator)
 
       new_current_doc =
         acc.current_doc
         |> Enum.drop(1)
+
       merge_split_helper(
         d,
         %{acc | total: new_total, current_doc: new_current_doc},
-        text_splitter)
+        text_splitter
+      )
     end
   end
 
@@ -68,35 +74,38 @@ defmodule LangChain.TextSplitter do
     separator_len = String.length(text_splitter.separator)
     first_split = List.first(splits)
     acc = %{current_doc: [first_split], docs: [], total: String.length(first_split)}
-    output_acc = splits
-    |> Enum.drop(1)
-    |> Enum.reduce(
-      acc,
-      fn d, acc ->
-        len = String.length(d)
-        separator_length =
-          if Enum.count(acc.current_doc) > 0,
-             do: String.length(text_splitter.separator), else: 0
-        
-        acc =
-          if (acc.total + len + separator_length) >
-               text_splitter.chunk_size do
-                if Enum.count(acc.current_doc) do
-                  doc = join_docs(acc.current_doc, text_splitter.separator)
-                  acc = %{acc | docs: acc.docs ++ [doc]}
-                  merge_split_helper(d, acc, text_splitter)
-                else
-                  acc
-                end
+
+    output_acc =
+      splits
+      |> Enum.drop(1)
+      |> Enum.reduce(
+        acc,
+        fn d, acc ->
+          len = String.length(d)
+
+          separator_length =
+            if Enum.count(acc.current_doc) > 0,
+              do: String.length(text_splitter.separator),
+              else: 0
+
+          acc =
+            if acc.total + len + separator_length >
+                 text_splitter.chunk_size do
+              if Enum.count(acc.current_doc) do
+                doc = join_docs(acc.current_doc, text_splitter.separator)
+                acc = %{acc | docs: acc.docs ++ [doc]}
+                merge_split_helper(d, acc, text_splitter)
               else
                 acc
+              end
+            else
+              acc
+            end
+
+          %{acc | current_doc: acc.current_doc ++ [d], total: acc.total + separator_len + len}
         end
-        %{acc |
-          current_doc: acc.current_doc ++ [d],
-          total: acc.total + separator_len + len
-        }
-      end
-    )
+      )
+
     output_acc.docs ++ [join_docs(output_acc.current_doc, text_splitter.separator)]
   end
 end

--- a/lib/text_splitter.ex
+++ b/lib/text_splitter.ex
@@ -1,45 +1,71 @@
 defmodule LangChain.TextSplitter do
-  @separator " "
-  @chunk_size 7
-  @chunk_overlap 3
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias __MODULE__
+
+  @primary_key false
+  embedded_schema do
+    field :separator, :string, default: " "
+    field :chunk_size, :integer
+    field :chunk_overlap, :integer
+  end
+
+  @type t :: %TextSplitter{}
+
+  @update_fields [
+   :separator,
+   :chunk_size,
+   :chunk_overlap
+   ]
+  @create_fields @update_fields
+
+  def new(attrs \\ %{}) do
+    %TextSplitter{}
+    |> cast(attrs, @create_fields)
+    |> apply_action(:insert)
+  end
   
-  def split_text(text) do
+  def split_text(%TextSplitter{} = text_splitter, text) do
     text
-    |> split_text_with_regex
-    |> merge_splits
+    |> split_text_with_regex(text_splitter)
+    |> merge_splits(text_splitter)
   end
 
-  defp split_text_with_regex(text) do
-    String.split(text, @separator)
+  defp split_text_with_regex(
+         text,
+         %TextSplitter{} = text_splitter) do
+    text
+    |> String.split(text_splitter.separator)
+    |> Enum.filter(fn x -> x != "" end)
   end
 
-  defp join_docs(docs), do: Enum.join(docs, @separator)
+  defp join_docs(docs, separator), do: Enum.join(docs, separator)
 
-  defp merge_split_helper(d, acc) do
-    IO.puts("RECURSION!!!!!!!!!!!!!!!!!!!")
-    IO.inspect(acc)
+  defp merge_split_helper(d, acc, text_splitter) do
     total = acc.total
     len = String.length(d)
-    if (total <= @chunk_overlap) or
-         (total + len + String.length(@separator) <= @chunk_size) and
+    if (total <= text_splitter.chunk_overlap) or
+         (total + len + String.length(text_splitter.separator)
+         <= text_splitter.chunk_size) and
          (total <= 0) do
       acc
     else
       new_total = acc.total - (acc.current_doc
       |> Enum.at(0, "")
-      |> String.length) - String.length(@separator)
+      |> String.length) - String.length(text_splitter.separator)
 
       new_current_doc =
         acc.current_doc
         |> Enum.drop(1)
       merge_split_helper(
         d,
-        %{acc | total: new_total, current_doc: new_current_doc})
+        %{acc | total: new_total, current_doc: new_current_doc},
+        text_splitter)
     end
   end
 
-  defp merge_splits(splits) do
-    separator_len = String.length(@separator)
+  defp merge_splits(splits, %TextSplitter{} = text_splitter) do
+    separator_len = String.length(text_splitter.separator)
     first_split = List.first(splits)
     acc = %{current_doc: [first_split], docs: [], total: String.length(first_split)}
     output_acc = splits
@@ -47,19 +73,18 @@ defmodule LangChain.TextSplitter do
     |> Enum.reduce(
       acc,
       fn d, acc ->
-        IO.puts("REDUCTION!!!!!")
-        IO.inspect(acc)
         len = String.length(d)
         separator_length =
           if Enum.count(acc.current_doc) > 0,
-             do: String.length(@separator), else: 0
+             do: String.length(text_splitter.separator), else: 0
         
         acc =
-          if (acc.total + len + separator_length) > @chunk_size do
+          if (acc.total + len + separator_length) >
+               text_splitter.chunk_size do
                 if Enum.count(acc.current_doc) do
-                  doc = join_docs(acc.current_doc)
+                  doc = join_docs(acc.current_doc, text_splitter.separator)
                   acc = %{acc | docs: acc.docs ++ [doc]}
-                  merge_split_helper(d, acc)
+                  merge_split_helper(d, acc, text_splitter)
                 else
                   acc
                 end
@@ -72,6 +97,6 @@ defmodule LangChain.TextSplitter do
         }
       end
     )
-    output_acc.docs ++ [join_docs(output_acc.current_doc)]
+    output_acc.docs ++ [join_docs(output_acc.current_doc, text_splitter.separator)]
   end
 end

--- a/lib/text_splitter.ex
+++ b/lib/text_splitter.ex
@@ -1,5 +1,6 @@
 defmodule LangChain.TextSplitter do
   @moduledoc false
+
   defp join_docs(docs, separator) do
     text =
       docs

--- a/lib/text_splitter.ex
+++ b/lib/text_splitter.ex
@@ -9,6 +9,7 @@ defmodule LangChain.TextSplitter do
     field :chunk_size, :integer
     field :chunk_overlap, :integer
     field :keep_separator, Ecto.Enum, values: [:start, :end]
+    field :is_separator_regex, :boolean, default: false
   end
 
   @type t :: %TextSplitter{}
@@ -17,7 +18,8 @@ defmodule LangChain.TextSplitter do
     :separator,
     :chunk_size,
     :chunk_overlap,
-    :keep_separator
+    :keep_separator,
+    :is_separator_regex
   ]
   @create_fields @update_fields
 
@@ -38,9 +40,13 @@ defmodule LangChain.TextSplitter do
          %TextSplitter{} = text_splitter
        ) do
     {:ok, separator} =
-      text_splitter.separator
-      |> Regex.escape()
-      |> Regex.compile()
+      if text_splitter.is_separator_regex do
+        text_splitter.separator |> Regex.compile()
+      else
+        text_splitter.separator
+        |> Regex.escape()
+        |> Regex.compile()
+      end
 
     chunk_and_join = fn x ->
       x

--- a/lib/text_splitter.ex
+++ b/lib/text_splitter.ex
@@ -35,7 +35,7 @@ defmodule LangChain.TextSplitter do
   end
 
   @doc false
-  def merge_splits(splits,  text_splitter) do
+  def merge_splits(splits, text_splitter) do
     acc = %{current_doc: [], docs: [], total: 0}
 
     output_acc =

--- a/lib/text_splitter.ex
+++ b/lib/text_splitter.ex
@@ -1,9 +1,13 @@
 defmodule LangChain.TextSplitter do
   @moduledoc false
-  defp join_docs(docs, separator),
-       do: docs
-       |> Enum.join(separator)
-       |> String.trim()
+  defp join_docs(docs, separator) do
+    text =
+      docs
+      |> Enum.join(separator)
+      |> String.trim()
+
+    if text != "", do: text
+  end
 
   defp merge_split_helper(d, acc, text_splitter, separator) do
     separator_len = String.length(separator)
@@ -41,6 +45,7 @@ defmodule LangChain.TextSplitter do
   @doc false
   def merge_splits(splits, text_splitter, separator) do
     acc = %{current_doc: [], docs: [], total: 0}
+
     plain_separator =
       if text_splitter.is_separator_regex do
         Macro.unescape_string(separator)
@@ -84,6 +89,7 @@ defmodule LangChain.TextSplitter do
           %{acc | total: acc.total + separator_length + len}
         end
       )
+
     output_acc.docs ++ [join_docs(output_acc.current_doc, plain_separator)]
   end
 end

--- a/lib/text_splitter.ex
+++ b/lib/text_splitter.ex
@@ -1,4 +1,14 @@
 defmodule LangChain.TextSplitter do
+  @moduledoc """
+  The `TextSplitter` is a basic text splitter that divides text based on specified characters. It operates as follows:
+  
+  - It takes a `chunk_size` parameter that determines the maximum number of characters in each chunk.
+  - It splits the text at specified separator characters.
+  - If no separator is found within the `chunk_size`, it will create a chunk larger than the specified size.
+
+  The purpose is to prepare text for processing by large language models with limited context windows, or where a shorter context window is desired.
+  """
+
   defp join_docs(docs, separator), do: Enum.join(docs, separator)
 
   defp merge_split_helper(d, acc, text_splitter) do

--- a/lib/text_splitter.ex
+++ b/lib/text_splitter.ex
@@ -1,14 +1,5 @@
 defmodule LangChain.TextSplitter do
-  @moduledoc """
-  The `TextSplitter` is a basic text splitter that divides text based on specified characters. It operates as follows:
-  
-  - It takes a `chunk_size` parameter that determines the maximum number of characters in each chunk.
-  - It splits the text at specified separator characters.
-  - If no separator is found within the `chunk_size`, it will create a chunk larger than the specified size.
-
-  The purpose is to prepare text for processing by large language models with limited context windows, or where a shorter context window is desired.
-  """
-
+  @moduledoc false
   defp join_docs(docs, separator), do: Enum.join(docs, separator)
 
   defp merge_split_helper(d, acc, text_splitter) do

--- a/lib/text_splitter.ex
+++ b/lib/text_splitter.ex
@@ -1,10 +1,12 @@
 defmodule LangChain.TextSplitter do
   @moduledoc false
   defp join_docs(docs, separator),
-       do: Enum.join(docs, separator)
+       do: docs
+       |> Enum.join(separator)
+       |> String.trim()
 
-  defp merge_split_helper(d, acc, text_splitter) do
-    separator_len = String.length(text_splitter.separator)
+  defp merge_split_helper(d, acc, text_splitter, separator) do
+    separator_len = String.length(separator)
     len = String.length(d)
 
     test_separator_length =
@@ -30,17 +32,18 @@ defmodule LangChain.TextSplitter do
       merge_split_helper(
         d,
         %{acc | total: new_total, current_doc: new_current_doc},
-        text_splitter
+        text_splitter,
+        separator
       )
     end
   end
 
   @doc false
-  def merge_splits(splits, text_splitter) do
+  def merge_splits(splits, text_splitter, separator) do
     acc = %{current_doc: [], docs: [], total: 0}
     plain_separator =
       if text_splitter.is_separator_regex do
-        Macro.unescape_string(text_splitter.separator)
+        Macro.unescape_string(separator)
       else
         text_splitter.separator
       end
@@ -63,7 +66,7 @@ defmodule LangChain.TextSplitter do
               if Enum.count(acc.current_doc) > 0 do
                 doc = join_docs(acc.current_doc, plain_separator)
                 acc = %{acc | docs: acc.docs ++ [doc]}
-                merge_split_helper(d, acc, text_splitter)
+                merge_split_helper(d, acc, text_splitter, plain_separator)
               else
                 acc
               end

--- a/lib/text_splitter.ex
+++ b/lib/text_splitter.ex
@@ -1,0 +1,71 @@
+defmodule LangChain.TextSplitter do
+  @separator " "
+  @chunk_size 7
+  @chunk_overlap 3
+  
+  def split_text(text) do
+    splits = split_text_with_regex(text)
+    merge_splits(splits)
+  end
+
+  defp split_text_with_regex(text) do
+    String.split(text, @separator)
+  end
+
+  defp join_docs(docs), do: Enum.join(docs, @separator)
+
+  defp merge_split_helper(d, acc) do
+    IO.puts("RECURSION!!!!!!!!!!!!!!!!!!!")
+    IO.inspect(acc)
+    total = acc.total
+    len = String.length(d)
+    if (total < @chunk_overlap) or
+         (total + len + String.length(@separator) < @chunk_size) and
+         (total < 0) do
+      acc
+    else
+      new_total = acc.total - (acc.current_doc
+      |> Enum.at(0, "")
+      |> String.length) - String.length(@separator)
+
+      new_current_doc =
+        acc.current_doc
+        |> Enum.drop(1)
+      merge_split_helper(
+        d,
+        %{acc | total: new_total, current_doc: new_current_doc})
+    end
+  end
+
+  defp merge_splits(splits) do
+    separator_len = String.length(@separator)
+    first_split = List.first(splits)
+    acc = %{current_doc: [first_split], docs: [], total: String.length(first_split)}
+    splits
+    |> Enum.drop(1)
+    |> Enum.reduce(
+      acc,
+      fn d, acc ->
+        IO.puts("REDUCTION!!!!!")
+        IO.inspect(acc)
+        len = String.length(d)
+        doc = join_docs(acc.current_doc)
+        acc =
+          if (acc.total + len) > @chunk_size do
+                if Enum.count(acc.current_doc) do
+                  acc = %{acc | docs: acc.docs ++ [doc]}
+                  merge_split_helper(d, acc)
+                else
+                  acc
+                end
+              else
+                acc
+        end
+        %{acc |
+          current_doc: acc.current_doc ++ [d],
+          total: acc.total + separator_len + len
+        }
+      end
+    )
+  end
+end

--- a/lib/text_splitter/character_text_splitter.ex
+++ b/lib/text_splitter/character_text_splitter.ex
@@ -33,9 +33,11 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
     field :separator, :string, default: " "
     field :chunk_size, :integer
     field :chunk_overlap, :integer
+
     field :keep_separator, Ecto.Enum,
-          values: [:discard_separator, :start, :end],
-          default: :discard_separator
+      values: [:discard_separator, :start, :end],
+      default: :discard_separator
+
     field :is_separator_regex, :boolean, default: false
   end
 

--- a/lib/text_splitter/character_text_splitter.ex
+++ b/lib/text_splitter/character_text_splitter.ex
@@ -49,7 +49,7 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
   @create_fields @update_fields
 
   @doc """
-  Build a new ChracterTextSplitter and return an `:ok`/`:error` tuple with the result.
+  Build a new CharacterTextSplitter and return an `:ok`/`:error` tuple with the result.
   """
   def new(attrs \\ %{}) do
     %TextSplitter.CharacterTextSplitter{}

--- a/lib/text_splitter/character_text_splitter.ex
+++ b/lib/text_splitter/character_text_splitter.ex
@@ -1,4 +1,13 @@
 defmodule LangChain.TextSplitter.CharacterTextSplitter do
+  @moduledoc """
+  The `TextSplitter` is a basic text splitter that divides text based on specified characters. It operates as follows:
+  
+  - It takes a `chunk_size` parameter that determines the maximum number of characters in each chunk.
+  - It splits the text at specified separator characters.
+  - If no separator is found within the `chunk_size`, it will create a chunk larger than the specified size.
+
+  The purpose is to prepare text for processing by large language models with limited context windows, or where a shorter context window is desired.
+  """
   use Ecto.Schema
   import Ecto.Changeset
   alias LangChain.LangChainError

--- a/lib/text_splitter/character_text_splitter.ex
+++ b/lib/text_splitter/character_text_splitter.ex
@@ -53,7 +53,7 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
   """
   def new(attrs \\ %{}) do
     %TextSplitter.CharacterTextSplitter{}
-    |> cast(attrs, @create_fields)
+    |> cast(attrs, @create_fields, empty_values: [nil])
     |> apply_action(:insert)
   end
 
@@ -113,7 +113,8 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
     |> TextSplitter.merge_splits(text_splitter)
   end
 
-  defp split_text_with_regex(
+  @doc false
+  def split_text_with_regex(
          text,
          %CharacterTextSplitter{} = text_splitter
        ) do

--- a/lib/text_splitter/character_text_splitter.ex
+++ b/lib/text_splitter/character_text_splitter.ex
@@ -52,7 +52,7 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
   Build a new ChracterTextSplitter and return an `:ok`/`:error` tuple with the result.
   """
   def new(attrs \\ %{}) do
-    %TextSplitter.CharacterTextSplitter{} 
+    %TextSplitter.CharacterTextSplitter{}
     |> cast(attrs, @create_fields)
     |> apply_action(:insert)
   end
@@ -84,7 +84,7 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
       iex> text = "foo.bar.baz"
       iex> CharacterTextSplitter.split_text(text_splitter, text)
       ["foo.", "bar.", "baz"]
-  
+
   In order to keep the separator at the beginning of a chunk, provide the
   `keep_separator: :start` option:
       iex> text_splitter = CharacterTextSplitter.new!(%{separator: ".", chunk_size: 3, chunk_overlap: 0, keep_separator: :start})

--- a/lib/text_splitter/character_text_splitter.ex
+++ b/lib/text_splitter/character_text_splitter.ex
@@ -110,14 +110,14 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
   def split_text(%CharacterTextSplitter{} = text_splitter, text) do
     text
     |> split_text_with_regex(text_splitter)
-    |> TextSplitter.merge_splits(text_splitter)
+    |> TextSplitter.merge_splits(text_splitter, text_splitter.separator)
   end
 
   @doc false
   def split_text_with_regex(
-         text,
-         %CharacterTextSplitter{} = text_splitter
-       ) do
+        text,
+        %CharacterTextSplitter{} = text_splitter
+      ) do
     {:ok, separator} =
       if text_splitter.is_separator_regex do
         text_splitter.separator |> Regex.compile()

--- a/lib/text_splitter/character_text_splitter.ex
+++ b/lib/text_splitter/character_text_splitter.ex
@@ -1,12 +1,26 @@
 defmodule LangChain.TextSplitter.CharacterTextSplitter do
   @moduledoc """
-  The `TextSplitter` is a basic text splitter that divides text based on specified characters. It operates as follows:
-  
-  - It takes a `chunk_size` parameter that determines the maximum number of characters in each chunk.
-  - It splits the text at specified separator characters.
-  - If no separator is found within the `chunk_size`, it will create a chunk larger than the specified size.
+  The `CharacterTextSplitter` is a length based text splitter
+  that divides text based on specified characters.
+  This splitter provides consistent chunk sizes.
+  It operates as follows:
 
-  The purpose is to prepare text for processing by large language models with limited context windows, or where a shorter context window is desired.
+  - It splits the text at specified `separator` characters.  
+  - It takes a `chunk_size` parameter that determines the maximum number of characters
+    in each chunk.
+  - If no separator is found within the `chunk_size`,
+    it will create a chunk larger than the specified size.
+
+  The purpose is to prepare text for processing
+  by large language models with limited context windows,
+  or where a shorter context window is desired.
+
+  A CharacterTextSplitter is defined using a schema.
+  * `separator` - String that splits a given text.
+  * `chunk_size` - Integer number of characters that a chunk should have.
+  * `chunk_overlap` - Integer number of characters that two consecutive chunks should share.
+  * `keep_separator` - Either `nil`, `:start` or `:end`. If `nil`, the separator is discarded from the output chunks. `:start` and `:end` keep the separator at the start or end of the output chunks.
+  * `is_separator_regex` - Boolean default false. If true, the `separator` string is not escaped.
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -34,12 +48,18 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
   ]
   @create_fields @update_fields
 
+  @doc """
+  Build a new ChracterTextSplitter and return an `:ok`/`:error` tuple with the result.
+  """
   def new(attrs \\ %{}) do
     %TextSplitter.CharacterTextSplitter{} 
     |> cast(attrs, @create_fields)
     |> apply_action(:insert)
   end
 
+  @doc """
+  Build a new CharacterTextSplitter and return it or raise an error if invalid.
+  """
   def new!(attrs \\ %{}) do
     case new(attrs) do
       {:ok, character_text_spliiter} ->
@@ -50,6 +70,43 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
     end
   end
 
+  @doc """
+  Splits text based on a given character.
+  By default, the `separator` character is discarded
+      iex> text_splitter = CharacterTextSplitter.new!(%{separator: " ", chunk_size: 3, chunk_overlap: 0})
+      iex> text = "foo bar baz"
+      iex> CharacterTextSplitter.split_text(text_splitter, text)
+      ["foo", "bar", "baz"]
+
+  We can keep the separator at the end of a chunk, providing the
+  `keep_separator: :end` option:
+      iex> text_splitter = CharacterTextSplitter.new!(%{separator: ".", chunk_size: 3, chunk_overlap: 0, keep_separator: :end})
+      iex> text = "foo.bar.baz"
+      iex> CharacterTextSplitter.split_text(text_splitter, text)
+      ["foo.", "bar.", "baz"]
+  
+  In order to keep the separator at the beginning of a chunk, provide the
+  `keep_separator: :start` option:
+      iex> text_splitter = CharacterTextSplitter.new!(%{separator: ".", chunk_size: 3, chunk_overlap: 0, keep_separator: :start})
+      iex> text = "foo.bar.baz"
+      iex> CharacterTextSplitter.split_text(text_splitter, text)
+      ["foo", ".bar", ".baz"]
+
+  The last two examples used a regex special character as a `separator`.
+  Plain strings are escaped and parsed as regex before splitting.
+  If you want to use a complex regex as `separator` you can,
+  but make sure to pass the `is_separator_regex: true` option:
+      iex> text_splitter = CharacterTextSplitter.new!(%{separator: Regex.escape("."), chunk_size: 3, chunk_overlap: 0, keep_separator: :start, is_separator_regex: true})
+      iex> text = "foo.bar.baz"
+      iex> CharacterTextSplitter.split_text(text_splitter, text)
+      ["foo", ".bar", ".baz"]
+
+  You can control the overlap of chunks trhough the `chunk_overlap` parameter:
+      iex> text_splitter = CharacterTextSplitter.new!(%{separator: " ", chunk_size: 7, chunk_overlap: 3})
+      iex> text = "foo bar baz"
+      iex> CharacterTextSplitter.split_text(text_splitter, text)
+      ["foo bar", "bar baz"]
+  """
   def split_text(%CharacterTextSplitter{} = text_splitter, text) do
     text
     |> split_text_with_regex(text_splitter)

--- a/lib/text_splitter/character_text_splitter.ex
+++ b/lib/text_splitter/character_text_splitter.ex
@@ -15,12 +15,12 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
   by large language models with limited context windows,
   or where a shorter context window is desired.
 
-  A CharacterTextSplitter is defined using a schema.
+  A `CharacterTextSplitter` is defined using a schema.
   * `separator` - String that splits a given text.
   * `chunk_size` - Integer number of characters that a chunk should have.
   * `chunk_overlap` - Integer number of characters that two consecutive chunks should share.
-  * `keep_separator` - Either `nil`, `:start` or `:end`. If `nil`, the separator is discarded from the output chunks. `:start` and `:end` keep the separator at the start or end of the output chunks.
-  * `is_separator_regex` - Boolean defaulting to `false`. If `true`, the `separator` string is not escaped.
+  * `keep_separator` - Either `:discard_separator`, `:start` or `:end`. If `:discard_separator`, the separator is discarded from the output chunks. `:start` and `:end` keep the separator at the start or end of the output chunks. Defaults to `:discard_separator`.
+  * `is_separator_regex` - Boolean defaulting to `false`. If `true`, the `separator` string is not escaped. Defaults to `false`
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -33,7 +33,9 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
     field :separator, :string, default: " "
     field :chunk_size, :integer
     field :chunk_overlap, :integer
-    field :keep_separator, Ecto.Enum, values: [:start, :end]
+    field :keep_separator, Ecto.Enum,
+          values: [:discard_separator, :start, :end],
+          default: :discard_separator
     field :is_separator_regex, :boolean, default: false
   end
 

--- a/lib/text_splitter/character_text_splitter.ex
+++ b/lib/text_splitter/character_text_splitter.ex
@@ -20,7 +20,7 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
   * `chunk_size` - Integer number of characters that a chunk should have.
   * `chunk_overlap` - Integer number of characters that two consecutive chunks should share.
   * `keep_separator` - Either `nil`, `:start` or `:end`. If `nil`, the separator is discarded from the output chunks. `:start` and `:end` keep the separator at the start or end of the output chunks.
-  * `is_separator_regex` - Boolean default false. If true, the `separator` string is not escaped.
+  * `is_separator_regex` - Boolean defaulting to `false`. If `true`, the `separator` string is not escaped.
   """
   use Ecto.Schema
   import Ecto.Changeset

--- a/lib/text_splitter/language_separators.ex
+++ b/lib/text_splitter/language_separators.ex
@@ -1,4 +1,8 @@
 defmodule LangChain.TextSplitter.LanguageSeparators do
+  @moduledoc """
+  Separators lists for programming and markdown languages.
+  Useful to use with `LangChain.TextSplitter.RecursiveCharacterTextSplitter`.
+  """
   @cpp [
     # Split along class definitions
     "\nclass ",

--- a/lib/text_splitter/language_separators.ex
+++ b/lib/text_splitter/language_separators.ex
@@ -1,4 +1,32 @@
 defmodule LangChain.TextSplitter.LanguageSeparators do
+  @cpp [
+    # Split along class definitions
+    "\nclass ",
+    # Split along function definitions
+    "\nvoid ",
+    "\nint ",
+    "\nfloat ",
+    "\ndouble ",
+    # Split along control flow statements
+    "\nif ",
+    "\nfor ",
+    "\nwhile ",
+    "\nswitch ",
+    "\ncase ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def cpp() do
+    @cpp
+  end
+
+  def c() do
+    @cpp
+  end
+
   @python [
     # First, try to split along class definitions
     "\nclass ",

--- a/lib/text_splitter/language_separators.ex
+++ b/lib/text_splitter/language_separators.ex
@@ -192,7 +192,7 @@ defmodule LangChain.TextSplitter.LanguageSeparators do
     "\n-+\n",
     "\n\\*+\n",
     # Split along directive markers
-    "\n\n.. *\n\n",
+    "\n\n.. \*\n\n",
     # Split by the normal type of lines
     "\n\n",
     "\n",

--- a/lib/text_splitter/language_separators.ex
+++ b/lib/text_splitter/language_separators.ex
@@ -1,0 +1,606 @@
+defmodule LangChain.TextSplitter.LanguageSeparators do
+  @python [
+    # First, try to split along class definitions
+    "\nclass ",
+    "\ndef ",
+    "\n\tdef ",
+    # Now split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def python() do
+    @python
+  end
+
+  @go [
+    # Split along function definitions
+    "\nfunc ",
+    "\nvar ",
+    "\nconst ",
+    "\ntype ",
+    # Split along control flow statements
+    "\nif ",
+    "\nfor ",
+    "\nswitch ",
+    "\ncase ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def go() do
+    @go
+  end
+
+  @java [
+    # Split along class definitions
+    "\nclass ",
+    # Split along method definitions
+    "\npublic ",
+    "\nprotected ",
+    "\nprivate ",
+    "\nstatic ",
+    # Split along control flow statements
+    "\nif ",
+    "\nfor ",
+    "\nwhile ",
+    "\nswitch ",
+    "\ncase ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def java() do
+    @java
+  end
+
+  @kotlin [
+    # Split along class definitions
+    "\nclass ",
+    # Split along method definitions
+    "\npublic ",
+    "\nprotected ",
+    "\nprivate ",
+    "\ninternal ",
+    "\ncompanion ",
+    "\nfun ",
+    "\nval ",
+    "\nvar ",
+    # Split along control flow statements
+    "\nif ",
+    "\nfor ",
+    "\nwhile ",
+    "\nwhen ",
+    "\ncase ",
+    "\nelse ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def kotlin() do
+    @kotlin
+  end
+
+  @js [
+    # Split along function definitions
+    "\nfunction ",
+    "\nconst ",
+    "\nlet ",
+    "\nvar ",
+    "\nclass ",
+    # Split along control flow statements
+    "\nif ",
+    "\nfor ",
+    "\nwhile ",
+    "\nswitch ",
+    "\ncase ",
+    "\ndefault ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def js() do
+    @js
+  end
+
+  @ts [
+    "\nenum ",
+    "\ninterface ",
+    "\nnamespace ",
+    "\ntype ",
+    # Split along class definitions
+    "\nclass ",
+    # Split along function definitions
+    "\nfunction ",
+    "\nconst ",
+    "\nlet ",
+    "\nvar ",
+    # Split along control flow statements
+    "\nif ",
+    "\nfor ",
+    "\nwhile ",
+    "\nswitch ",
+    "\ncase ",
+    "\ndefault ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def ts() do
+    @ts
+  end
+
+  @php [
+    # Split along function definitions
+    "\nfunction ",
+    # Split along class definitions
+    "\nclass ",
+    # Split along control flow statements
+    "\nif ",
+    "\nforeach ",
+    "\nwhile ",
+    "\ndo ",
+    "\nswitch ",
+    "\ncase ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def php() do
+    @php
+  end
+
+  @proto [
+    # Split along message definitions
+    "\nmessage ",
+    # Split along service definitions
+    "\nservice ",
+    # Split along enum definitions
+    "\nenum ",
+    # Split along option definitions
+    "\noption ",
+    # Split along import statements
+    "\nimport ",
+    # Split along syntax declarations
+    "\nsyntax ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def proto() do
+    @proto
+  end
+
+  @rst [
+    # Split along section titles
+    "\n=+\n",
+    "\n-+\n",
+    "\n\\*+\n",
+    # Split along directive markers
+    "\n\n.. *\n\n",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def rst() do
+    @rst
+  end
+
+  @ruby [
+    # Split along method definitions
+    "\ndef ",
+    "\nclass ",
+    # Split along control flow statements
+    "\nif ",
+    "\nunless ",
+    "\nwhile ",
+    "\nfor ",
+    "\ndo ",
+    "\nbegin ",
+    "\nrescue ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def ruby() do
+    @ruby
+  end
+
+  @elixir [
+    # Split along method function and module definition
+    "\ndef ",
+    "\ndefp ",
+    "\ndefmodule ",
+    "\ndefprotocol ",
+    "\ndefmacro ",
+    "\ndefmacrop ",
+    # Split along control flow statements
+    "\nif ",
+    "\nunless ",
+    "\nwhile ",
+    "\ncase ",
+    "\ncond ",
+    "\nwith ",
+    "\nfor ",
+    "\ndo ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def elixir() do
+    @elixir
+  end
+
+  @rust [
+    # Split along function definitions
+    "\nfn ",
+    "\nconst ",
+    "\nlet ",
+    # Split along control flow statements
+    "\nif ",
+    "\nwhile ",
+    "\nfor ",
+    "\nloop ",
+    "\nmatch ",
+    "\nconst ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def rust() do
+    @rust
+  end
+
+  @scala [
+    # Split along class definitions
+    "\nclass ",
+    "\nobject ",
+    # Split along method definitions
+    "\ndef ",
+    "\nval ",
+    "\nvar ",
+    # Split along control flow statements
+    "\nif ",
+    "\nfor ",
+    "\nwhile ",
+    "\nmatch ",
+    "\ncase ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def scala() do
+    @scala
+  end
+
+  @swift [
+    # Split along function definitions
+    "\nfunc ",
+    # Split along class definitions
+    "\nclass ",
+    "\nstruct ",
+    "\nenum ",
+    # Split along control flow statements
+    "\nif ",
+    "\nfor ",
+    "\nwhile ",
+    "\ndo ",
+    "\nswitch ",
+    "\ncase ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def swift() do
+    @swift
+  end
+
+  @markdown [
+    # First, try to split along Markdown headings (starting with level 2)
+    "\n#\{1,6\} ",
+    # Note the alternative syntax for headings (below) is not handled here
+    # Heading level 2
+    # ---------------
+    # End of code block
+    "```\n",
+    # Horizontal lines
+    "\n\\*\\*\\*+\n",
+    "\n---+\n",
+    "\n___+\n",
+    # Note that this splitter doesn't handle horizontal lines defined
+    # by *three or more* of ***, ---, or ___, but this is not handled
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def markdown() do
+    @markdown
+  end
+
+  @latex [
+    # First, try to split along Latex sections
+    "\n\\\\chapter{",
+    "\n\\\\section{",
+    "\n\\\\subsection{",
+    "\n\\\\subsubsection{",
+    # Now split by environments
+    "\n\\\\begin{enumerate}",
+    "\n\\\\begin{itemize}",
+    "\n\\\\begin{description}",
+    "\n\\\\begin{list}",
+    "\n\\\\begin{quote}",
+    "\n\\\\begin{quotation}",
+    "\n\\\\begin{verse}",
+    "\n\\\\begin{verbatim}",
+    # Now split by math environments
+    "\n\\\\begin{align}",
+    "$$",
+    "$",
+    # Now split by the normal type of lines
+    " ",
+    ""
+  ]
+  def latex() do
+    @latex
+  end
+
+  @html [
+    # First, try to split along HTML tags
+    "<body",
+    "<div",
+    "<p",
+    "<br",
+    "<li",
+    "<h1",
+    "<h2",
+    "<h3",
+    "<h4",
+    "<h5",
+    "<h6",
+    "<span",
+    "<table",
+    "<tr",
+    "<td",
+    "<th",
+    "<ul",
+    "<ol",
+    "<header",
+    "<footer",
+    "<nav",
+    # Head
+    "<head",
+    "<style",
+    "<script",
+    "<meta",
+    "<title",
+    ""
+  ]
+  def html() do
+    @html
+  end
+
+  @csharp [
+    "\ninterface ",
+    "\nenum ",
+    "\nimplements ",
+    "\ndelegate ",
+    "\nevent ",
+    # Split along class definitions
+    "\nclass ",
+    "\nabstract ",
+    # Split along method definitions
+    "\npublic ",
+    "\nprotected ",
+    "\nprivate ",
+    "\nstatic ",
+    "\nreturn ",
+    # Split along control flow statements
+    "\nif ",
+    "\ncontinue ",
+    "\nfor ",
+    "\nforeach ",
+    "\nwhile ",
+    "\nswitch ",
+    "\nbreak ",
+    "\ncase ",
+    "\nelse ",
+    # Split by exceptions
+    "\ntry ",
+    "\nthrow ",
+    "\nfinally ",
+    "\ncatch ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def csharp() do
+    @csharp
+  end
+
+  @sol [
+    # Split along compiler information definitions
+    "\npragma ",
+    "\nusing ",
+    # Split along contract definitions
+    "\ncontract ",
+    "\ninterface ",
+    "\nlibrary ",
+    # Split along method definitions
+    "\nconstructor ",
+    "\ntype ",
+    "\nfunction ",
+    "\nevent ",
+    "\nmodifier ",
+    "\nerror ",
+    "\nstruct ",
+    "\nenum ",
+    # Split along control flow statements
+    "\nif ",
+    "\nfor ",
+    "\nwhile ",
+    "\ndo while ",
+    "\nassembly ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def sol() do
+    @sol
+  end
+
+  @cobol [
+    # Split along divisions
+    "\nIDENTIFICATION DIVISION.",
+    "\nENVIRONMENT DIVISION.",
+    "\nDATA DIVISION.",
+    "\nPROCEDURE DIVISION.",
+    # Split along sections within DATA DIVISION
+    "\nWORKING-STORAGE SECTION.",
+    "\nLINKAGE SECTION.",
+    "\nFILE SECTION.",
+    # Split along sections within PROCEDURE DIVISION
+    "\nINPUT-OUTPUT SECTION.",
+    # Split along paragraphs and common statements
+    "\nOPEN ",
+    "\nCLOSE ",
+    "\nREAD ",
+    "\nWRITE ",
+    "\nIF ",
+    "\nELSE ",
+    "\nMOVE ",
+    "\nPERFORM ",
+    "\nUNTIL ",
+    "\nVARYING ",
+    "\nACCEPT ",
+    "\nDISPLAY ",
+    "\nSTOP RUN.",
+    # Split by the normal type of lines
+    "\n",
+    " ",
+    ""
+  ]
+  def cobol() do
+    @cobol
+  end
+
+  @lua [
+    # Split along variable and table definitions
+    "\nlocal ",
+    # Split along function definitions
+    "\nfunction ",
+    # Split along control flow statements
+    "\nif ",
+    "\nfor ",
+    "\nwhile ",
+    "\nrepeat ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def lua() do
+    @lua
+  end
+
+  @haskell [
+    # Split along function definitions
+    "\nmain :: ",
+    "\nmain = ",
+    "\nlet ",
+    "\nin ",
+    "\ndo ",
+    "\nwhere ",
+    "\n:: ",
+    "\n= ",
+    # Split along type declarations
+    "\ndata ",
+    "\nnewtype ",
+    "\ntype ",
+    "\n:: ",
+    # Split along module declarations
+    "\nmodule ",
+    # Split along import statements
+    "\nimport ",
+    "\nqualified ",
+    "\nimport qualified ",
+    # Split along typeclass declarations
+    "\nclass ",
+    "\ninstance ",
+    # Split along case expressions
+    "\ncase ",
+    # Split along guards in function definitions
+    "\n| ",
+    # Split along record field declarations
+    "\ndata ",
+    "\n= {",
+    "\n, ",
+    # Split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def haskell() do
+    @haskell
+  end
+
+  @powershell [
+    # Split along function definitions
+    "\nfunction ",
+    # Split along parameter declarations (escape parentheses)
+    "\nparam ",
+    # Split along control flow statements
+    "\nif ",
+    "\nforeach ",
+    "\nfor ",
+    "\nwhile ",
+    "\nswitch ",
+    # Split along class definitions (for PowerShell 5.0 and above)
+    "\nclass ",
+    # Split along try-catch-finally blocks
+    "\ntry ",
+    "\ncatch ",
+    "\nfinally ",
+    # Split by normal lines and empty spaces
+    "\n\n",
+    "\n",
+    " ",
+    ""
+  ]
+  def powershell() do
+    @powershell
+  end
+end

--- a/lib/text_splitter/recursive_character_text_splitter.ex
+++ b/lib/text_splitter/recursive_character_text_splitter.ex
@@ -1,4 +1,34 @@
 defmodule LangChain.TextSplitter.RecursiveCharacterTextSplitter do
+  @moduledoc """
+  The `RecursiveCharacterTextSplitter` is the recommended spliltter for generic text.
+  It splits the text based on a list of characters.
+  It uses each of these characters sequentially, until the text is split
+  into small enough chunks. The default list is `["\n\n", "\n", " ", ""]`.
+
+  The purpose is to prepare text for processing
+  by large language models with limited context windows,
+  or where a shorter context window is desired.
+
+  The main characterstinc of this splitter is that tries to keep
+  paragraphs, sentences or code functions together as long as possible.
+
+  `LanguageSeparators` provide separator lists for some programming and markup languages.
+
+  How it works:
+  - It splits the text at the first specified `separator` characters
+    from the given `separators` list.
+    It uses `CharacterTextSplitter` to do so.
+  - For each of the above splits, it calls itself recursively
+    using the tail of the `separators` list.
+
+  A `RecursiveCharacterTextSplitter` is defined using a schema.
+  * `separators` - List of string that split a given text.
+    The default list is `["\n\n", "\n", " ", ""]`.
+  * `chunk_size` - Integer number of characters that a chunk should have.
+  * `chunk_overlap` - Integer number of characters that two consecutive chunks should share.
+  * `keep_separator` - Either `:discard_separator`, `:start` or `:end`. If `nil`, the separator is discarded from the output chunks. `:start` and `:end` keep the separator at the start or end of the output chunks. Defaults to `start`.
+  * `is_separator_regex` - Boolean defaulting to `false`. If `true`, the `separator` string is not escaped. Defaults to `false`
+  """  
   use Ecto.Schema
   import Ecto.Changeset
   alias LangChain.LangChainError

--- a/lib/text_splitter/recursive_character_text_splitter.ex
+++ b/lib/text_splitter/recursive_character_text_splitter.ex
@@ -11,7 +11,9 @@ defmodule LangChain.TextSplitter.RecursiveCharacterTextSplitter do
     field :separators, {:array, :string}, default: ["\n\n", "\n", " ", ""]
     field :chunk_size, :integer
     field :chunk_overlap, :integer
-    field :keep_separator, Ecto.Enum, values: [:start, :end]
+    field :keep_separator, Ecto.Enum,
+          values: [:discard_separator, :start, :end],
+          default: :start
     field :is_separator_regex, :boolean, default: false
   end
 
@@ -82,7 +84,7 @@ defmodule LangChain.TextSplitter.RecursiveCharacterTextSplitter do
       |> CharacterTextSplitter.split_text_with_regex(character_text_splitter)
 
     merge_separator =
-      if not is_nil(text_splitter.keep_separator),
+      if not (text_splitter.keep_separator == :discard_separator),
         do: "",
         else: character_text_splitter.separator
 

--- a/lib/text_splitter/recursive_character_text_splitter.ex
+++ b/lib/text_splitter/recursive_character_text_splitter.ex
@@ -13,6 +13,7 @@ defmodule LangChain.TextSplitter.RecursiveCharacterTextSplitter do
   paragraphs, sentences or code functions together as long as possible.
 
   `LangChain.TextSplitter.LanguageSeparators` provide separator lists for some programming and markup languages.
+  To use these Separators, it's recommended to set the `is_separator_regex` option to `true`.
 
   How it works:
   - It splits the text at the first specified `separator` characters
@@ -105,6 +106,7 @@ defmodule LangChain.TextSplitter.RecursiveCharacterTextSplitter do
 
   `LanguageSeparators` provides `separators` for multiple
   programming and markdown languages.
+  To use these Separators, it's recommended to set the `is_separator_regex` option to `true`.
   To split Python code:
       iex> python_code = "
       ...>def hello_world():
@@ -117,6 +119,7 @@ defmodule LangChain.TextSplitter.RecursiveCharacterTextSplitter do
       ...>  RecursiveCharacterTextSplitter.new!(%{
       ...>    separators: LanguageSeparators.python(),
       ...>    keep_separator: :start,
+      ...>    is_separator_regex: :true,
       ...>    chunk_size: 16,
       ...>    chunk_overlap: 0})
       iex> splitter |> RecursiveCharacterTextSplitter.split_text(python_code)

--- a/lib/text_splitter/recursive_character_text_splitter.ex
+++ b/lib/text_splitter/recursive_character_text_splitter.ex
@@ -1,0 +1,50 @@
+defmodule LangChain.TextSplitter.RecursiveCharacterTextSplitter do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias LangChain.LangChainError
+  alias LangChain.TextSplitter
+  alias __MODULE__
+
+  @primary_key false
+  embedded_schema do
+    field :separators, {:array, :string}, default: ["\n\n", "\n", " ", ""]
+    field :chunk_size, :integer
+    field :chunk_overlap, :integer
+    field :keep_separator, Ecto.Enum, values: [:start, :end]
+    field :is_separator_regex, :boolean, default: false
+  end
+
+  @type t :: %RecursiveCharacterTextSplitter{}
+
+  @update_fields [
+    :separators,
+    :chunk_size,
+    :chunk_overlap,
+    :keep_separator,
+    :is_separator_regex
+  ]
+  @create_fields @update_fields
+
+  @doc """
+  Build a new RecursiveCharcterTextSplitter and return an `:ok`/`:error` tuple with the result.
+  """
+  def new(attrs \\ %{}) do
+    %TextSplitter.RecursiveCharacterTextSplitter{}
+    |> cast(attrs, @create_fields)
+    |> apply_action(:insert)
+  end
+
+  @doc """
+  Build a new RecursiveCharacterTextSplitter and return it or raise an error if invalid.
+  """
+  def new!(attrs \\ %{}) do
+    case new(attrs) do
+      {:ok, character_text_spliiter} ->
+        character_text_spliiter
+
+      {:error, changeset} ->
+        raise LangChainError, changeset
+    end
+  end
+  
+end

--- a/lib/text_splitter/recursive_character_text_splitter.ex
+++ b/lib/text_splitter/recursive_character_text_splitter.ex
@@ -91,7 +91,7 @@ defmodule LangChain.TextSplitter.RecursiveCharacterTextSplitter do
             acc
           end
         cond do
-          Enum.count(new_separators) == 1 ->
+          Enum.count(new_separators) <= 1 ->
             %{acc | final_chunks: acc.final_chunks ++ [split]}
           true ->
             new_recursive_splitter =

--- a/mix.exs
+++ b/mix.exs
@@ -105,6 +105,9 @@ defmodule LangChain.MixProject do
           LangChain.Images.OpenAIImage,
           LangChain.Images.GeneratedImage
         ],
+        "Text Splitter": [
+          LangChain.TextSplitter.CharacterTextSplitter
+        ],
         Tools: [
           LangChain.Tools.Calculator
         ],

--- a/mix.exs
+++ b/mix.exs
@@ -106,7 +106,9 @@ defmodule LangChain.MixProject do
           LangChain.Images.GeneratedImage
         ],
         "Text Splitter": [
-          LangChain.TextSplitter.CharacterTextSplitter
+          LangChain.TextSplitter.CharacterTextSplitter,
+          LangChain.TextSplitter.RecursiveCharacterTextSplitter,
+          LangChain.TextSplitter.LanguageSeparators
         ],
         Tools: [
           LangChain.Tools.Calculator

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -805,7 +805,7 @@ class Program
 
       assert splits == expected_splits
     end
-    
+
     test "C and C++ splitting" do
       code = "
 #include <iostream>
@@ -817,14 +817,14 @@ int main() {
     "
 
       expected_splits = [
-       "#include",
+        "#include",
         "<iostream>",
         "int main() {",
         "std::cout",
         "<< \"Hello,",
         "World!\" <<",
         "std::endl;",
-        "return 0;\n}",
+        "return 0;\n}"
       ]
 
       splitter =
@@ -841,7 +841,7 @@ int main() {
 
       assert splits == expected_splits
     end
-    
+
     test "Scala splitting" do
       code = "
 object HelloWorld {
@@ -852,7 +852,7 @@ object HelloWorld {
     "
 
       expected_splits = [
-       "object",
+        "object",
         "HelloWorld {",
         "def",
         "main(args:",
@@ -860,7 +860,7 @@ object HelloWorld {
         "Unit = {",
         "println(\"Hello,",
         "World!\")",
-        "}\n}",
+        "}\n}"
       ]
 
       splitter =
@@ -877,7 +877,7 @@ object HelloWorld {
 
       assert splits == expected_splits
     end
-    
+
     test "Ruby splitting" do
       code = "
 def hello_world
@@ -892,7 +892,7 @@ hello_world
         "puts \"Hello,",
         "World!\"",
         "end",
-        "hello_world",
+        "hello_world"
       ]
 
       splitter =
@@ -909,7 +909,7 @@ hello_world
 
       assert splits == expected_splits
     end
-    
+
     test "Php splitting" do
       code = "
 <?php
@@ -930,7 +930,7 @@ hello_world();
         "World!\";",
         "}",
         "hello_world();",
-        "?>",
+        "?>"
       ]
 
       splitter =
@@ -963,7 +963,7 @@ helloWorld()
         "print(\"Hello,",
         "World!\")",
         "}",
-        "helloWorld()",
+        "helloWorld()"
       ]
 
       splitter =
@@ -980,7 +980,7 @@ helloWorld()
 
       assert splits == expected_splits
     end
-    
+
     test "Rust splitting" do
       code = "
 fn main() {
@@ -989,7 +989,11 @@ fn main() {
     "
 
       expected_splits = [
-        "fn main() {", "println!(\"Hello", ",", "World!\");", "}"
+        "fn main() {",
+        "println!(\"Hello",
+        ",",
+        "World!\");",
+        "}"
       ]
 
       splitter =
@@ -1006,6 +1010,7 @@ fn main() {
 
       assert splits == expected_splits
     end
+
     test "Markdown splitting" do
       code = "
 # Sample Document
@@ -1037,7 +1042,7 @@ b = 2
     "
 
       expected_splits = [
-     "# Sample",
+        "# Sample",
         "Document",
         "## Section",
         "This is the",
@@ -1060,7 +1065,7 @@ b = 2
         "block",
         "# sample code",
         "a = 1\nb = 2",
-        "```",
+        "```"
       ]
 
       splitter =
@@ -1077,7 +1082,7 @@ b = 2
 
       assert splits == expected_splits
     end
-    
+
     test "Latex splitting" do
       code = "
 Hi Harrison!
@@ -1101,7 +1106,7 @@ Hi Harrison!
 
       assert splits == expected_splits
     end
-    
+
     test "Html splitting" do
       code = "
 <h1>Sample Document</h1>
@@ -1131,7 +1136,7 @@ Hi Harrison!
         "<h3>A block</h3>",
         "<div class=\"amazing\">",
         "<p>Some text</p>",
-        "<p>Some more text</p>\n            </div>",        
+        "<p>Some more text</p>\n            </div>"
       ]
 
       splitter =
@@ -1148,7 +1153,7 @@ Hi Harrison!
 
       assert splits == expected_splits
     end
-    
+
     test "Solidity splitting" do
       code = "
 pragma solidity ^0.8.20;
@@ -1171,7 +1176,7 @@ pragma solidity ^0.8.20;
         "returns(uint) {",
         "return  a",
         "+ b;",
-        "}\n  }",      
+        "}\n  }"
       ]
 
       splitter =
@@ -1188,7 +1193,7 @@ pragma solidity ^0.8.20;
 
       assert splits == expected_splits
     end
-    
+
     test "Lua splitting" do
       code = "
 local variable = 10
@@ -1229,7 +1234,7 @@ end
         "until i >=",
         "variable",
         "end",
-        "end\nend",
+        "end\nend"
       ]
 
       splitter =
@@ -1246,6 +1251,7 @@ end
 
       assert splits == expected_splits
     end
+
     test "Haskell splitting" do
       code = "
         main :: IO ()
@@ -1269,7 +1275,7 @@ end
         "add :: Int ->",
         "Int -> Int",
         "add x y = x",
-        "+ y",
+        "+ y"
       ]
 
       splitter =
@@ -1287,7 +1293,7 @@ end
 
       assert splits == expected_splits
     end
-    
+
     test "Powershell short code splitting" do
       code = "
 # Check if a file exists
@@ -1302,7 +1308,7 @@ if (Test-Path $filePath) {
       expected_splits = [
         "# Check if a file exists\n$filePath = \"C:\\temp\\file.txt\"",
         "if (Test-Path $filePath) {\n    # File exists\n} else {",
-        "# File does not exist\n}",
+        "# File does not exist\n}"
       ]
 
       splitter =
@@ -1320,7 +1326,7 @@ if (Test-Path $filePath) {
 
       assert splits == expected_splits
     end
-    
+
     test "Powershell long code splitting" do
       code = "
 # Get a list of all processes and export to CSV
@@ -1344,7 +1350,7 @@ $csvContent | ForEach-Object {
         "# Read the CSV file and display its content",
         "$csvContent = Import-Csv -Path \"C:\\temp\\processes.csv\"",
         "$csvContent | ForEach-Object {\n    $_.ProcessName\n}",
-        "# End of script",        
+        "# End of script"
       ]
 
       splitter =

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -16,7 +16,7 @@ defmodule TextSplitterTest do
                %{separator: " ", chunk_overlap: 0, chunk_size: 2}
                |> CharacterTextSplitter.new()
 
-      assert expected_splitter == output_splitter
+      assert output_splitter == expected_splitter
     end
 
     test "New TextSplitter with keep_separator" do
@@ -31,7 +31,7 @@ defmodule TextSplitterTest do
                %{separator: " ", chunk_overlap: 0, chunk_size: 2, keep_separator: :start}
                |> CharacterTextSplitter.new()
 
-      assert expected_splitter == output_splitter
+      assert output_splitter == expected_splitter
     end
 
     test "Splitting by character count" do
@@ -45,7 +45,7 @@ defmodule TextSplitterTest do
         character_splitter
         |> CharacterTextSplitter.split_text(text)
 
-      assert expected_output == output
+      assert output == expected_output
     end
 
     test "Splitting character by count doesn't create empty documents" do
@@ -59,7 +59,7 @@ defmodule TextSplitterTest do
         character_splitter
         |> CharacterTextSplitter.split_text(text)
 
-      assert expected_output == output
+      assert output ==  expected_output
     end
 
     test "Edge cases are separators" do
@@ -73,7 +73,7 @@ defmodule TextSplitterTest do
         character_splitter
         |> CharacterTextSplitter.split_text(text)
 
-      assert expected_output == output
+      assert output == expected_output
     end
 
     test "Splitting by character count on long words" do
@@ -87,7 +87,7 @@ defmodule TextSplitterTest do
         character_splitter
         |> CharacterTextSplitter.split_text(text)
 
-      assert expected_output == output
+      assert output == expected_output
     end
 
     test "Splitting by character count when shorter words are first" do
@@ -101,7 +101,7 @@ defmodule TextSplitterTest do
         character_splitter
         |> CharacterTextSplitter.split_text(text)
 
-      assert expected_output == output
+      assert output == expected_output
     end
 
     test "Splitting by characters when splits not found easily" do
@@ -115,7 +115,7 @@ defmodule TextSplitterTest do
         character_splitter
         |> CharacterTextSplitter.split_text(text)
 
-      assert expected_output == output
+      assert output == expected_output
     end
 
     test "Splitting by characters and keeping at start separator that is a regex special char" do
@@ -141,7 +141,7 @@ defmodule TextSplitterTest do
           character_splitter
           |> CharacterTextSplitter.split_text(text)
 
-        assert expected_output == output
+        assert output == expected_output
       end
     end
 
@@ -168,7 +168,7 @@ defmodule TextSplitterTest do
           character_splitter
           |> CharacterTextSplitter.split_text(text)
 
-        assert expected_output == output
+        assert output == expected_output
       end
     end
 
@@ -194,7 +194,7 @@ defmodule TextSplitterTest do
           character_splitter
           |> CharacterTextSplitter.split_text(text)
 
-        assert expected_output == output
+        assert output == expected_output
       end
     end
   end
@@ -205,55 +205,96 @@ defmodule TextSplitterTest do
       query = "Apple,banana,orange and tomato."
       expected_output_1 = ["Apple,", "banana,", "orange and tomato."]
       expected_output_2 = ["Apple", ",banana", ",orange and tomato", "."]
-      base_params = %{chunk_size: 10,
-                      chunk_overlap: 0,
-                      separators: split_tags}
+      base_params = %{chunk_size: 10, chunk_overlap: 0, separators: split_tags}
+
       test_data = [
         %{expected: expected_output_1, params: %{keep_separator: :end}},
         %{expected: expected_output_2, params: %{keep_separator: :start}}
       ]
+
       for tt <- test_data do
         splitter =
-          RecursiveCharacterTextSplitter.new!(
-            Map.merge(base_params, tt.params))
+          RecursiveCharacterTextSplitter.new!(Map.merge(base_params, tt.params))
+
         output = splitter |> RecursiveCharacterTextSplitter.split_text(query)
-        assert tt.expected == output        
+        assert tt.expected == output
       end
     end
 
-    @tag :wip
     test "Iterative splitter discard separator" do
       text = "....5X..3Y...4X....5Y..."
+
       base_params = %{
         chunk_overlap: 0,
         is_separator_regex: false,
-        separators: ["X", "Y"],
+        separators: ["X", "Y"]
       }
+
       expected_output_1 = [
         "....5",
         "..3",
         "...4",
         "....5",
-        "..."]
+        "..."
+      ]
+
       expected_output_2 = [
         "....5",
         "X..3",
         "Y...4",
         "X....5",
-        "Y..."]      
-      test_data = [
-        %{expected: expected_output_1,
-          params: %{chunk_size: 5}},
-        %{expected: expected_output_2,
-          params: %{chunk_size: 6, keep_separator: :start}},        
+        "Y..."
       ]
+
+      test_data = [
+        %{expected: expected_output_1, params: %{chunk_size: 5}},
+        %{expected: expected_output_2, params: %{chunk_size: 6, keep_separator: :start}}
+      ]
+
       for tt <- test_data do
         splitter =
-          RecursiveCharacterTextSplitter.new!(
-            Map.merge(base_params, tt.params))
+          RecursiveCharacterTextSplitter.new!(Map.merge(base_params, tt.params))
+
         output = splitter |> RecursiveCharacterTextSplitter.split_text(text)
         assert tt.expected == output
       end
+    end
+
+    @tag :wip
+    test "Iterative text splitter" do
+      text = "Hi.\n\nI'm Iglesias.\n\nHow? Are? You?\nOkay then f f f f.
+This is a weird text to write, but gotta test the splittingggg some how.
+
+Bye!\n\n-I."
+
+      expected_output = [
+        "Hi.",
+        "I'm",
+        "Iglesias.",
+        "How? Are?",
+        "You?",
+        "Okay then",
+        "f f f f.",
+        "This is a",
+        "weird",
+        "text to",
+        "write,",
+        "but gotta",
+        "test the",
+        "splitting",
+        "gggg",
+        "some how.",
+        "Bye!",
+        "-I."
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(
+          %{chunk_size: 10,
+            chunk_overlap: 1})
+
+      output = splitter |> RecursiveCharacterTextSplitter.split_text(text)
+      assert output == expected_output
     end
   end
 end

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -4,6 +4,7 @@ defmodule TextSplitterTest do
   alias LangChain.TextSplitter.RecursiveCharacterTextSplitter
   alias LangChain.TextSplitter.LanguageSeparators
   doctest CharacterTextSplitter
+  doctest RecursiveCharacterTextSplitter
 
   @chunk_size 16
 
@@ -250,8 +251,10 @@ defmodule TextSplitterTest do
       ]
 
       test_data = [
-        %{expected: expected_output_1, params: %{chunk_size: 5,
-                                                 keep_separator: :discard_separator}},
+        %{
+          expected: expected_output_1,
+          params: %{chunk_size: 5, keep_separator: :discard_separator}
+        },
         %{expected: expected_output_2, params: %{chunk_size: 6}}
       ]
 

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -209,12 +209,24 @@ defmodule TextSplitterTest do
           chunk_size: 10,
           chunk_overlap: 0,
           separators: split_tags,
+          keep_separator: :end
+        })
+
+      result = splitter
+      |> RecursiveCharacterTextSplitter.split_text(query)
+      assert ["Apple,", "banana,", "orange and tomato."] == result
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          chunk_size: 10,
+          chunk_overlap: 0,
+          separators: split_tags,
           keep_separator: :start
         })
 
       result = splitter
       |> RecursiveCharacterTextSplitter.split_text(query)
-      assert ["Apple,", "banana,", "orange and tomato."] == result 
+      assert ["Apple", ",banana", ",orange and tomato", "."] == result       
     end
   end
 end

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -416,7 +416,6 @@ func main() {
       assert splits == expected_splits
     end
 
-    @tag :wip
     test "Rst splitting" do
       code = "
 Sample Document
@@ -640,6 +639,720 @@ helloWorld();
           separators: LanguageSeparators.ts(),
           keep_separator: :start,
           chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+
+    test "Java splitting" do
+      code = "
+public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println(\"Hello, World!\");
+    }
+}
+    "
+
+      expected_splits = [
+        "public class",
+        "HelloWorld {",
+        "public",
+        "static void",
+        "main(String[]",
+        "args) {",
+        "System.out.prin",
+        "tln(\"Hello,",
+        "World!\");",
+        "}\n}"
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.java(),
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+
+    test "Kotlin splitting" do
+      code = "
+class HelloWorld {
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            println(\"Hello, World!\")
+        }
+    }
+}
+    "
+
+      expected_splits = [
+        "class",
+        "HelloWorld {",
+        "companion",
+        "object {",
+        "@JvmStatic",
+        "fun",
+        "main(args:",
+        "Array<String>)",
+        "{",
+        "println(\"Hello,",
+        "World!\")",
+        "}\n    }",
+        "}"
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.kotlin(),
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+
+    test "Csharp splitting" do
+      code = "
+using System;
+class Program
+{
+    static void Main()
+    {
+        int age = 30; // Change the age value as needed
+
+        // Categorize the age without any console output
+        if (age < 18)
+        {
+            // Age is under 18
+        }
+        else if (age >= 18 && age < 65)
+        {
+            // Age is an adult
+        }
+        else
+        {
+            // Age is a senior citizen
+        }
+    }
+}
+    "
+
+      expected_splits = [
+        "using System;",
+        "class Program\n{",
+        "static void",
+        "Main()",
+        "{",
+        "int age",
+        "= 30; // Change",
+        "the age value",
+        "as needed",
+        "//",
+        "Categorize the",
+        "age without any",
+        "console output",
+        "if (age",
+        "< 18)",
+        "{",
+        "//",
+        "Age is under 18",
+        "}",
+        "else if",
+        "(age >= 18 &&",
+        "age < 65)",
+        "{",
+        "//",
+        "Age is an adult",
+        "}",
+        "else",
+        "{",
+        "//",
+        "Age is a senior",
+        "citizen",
+        "}\n    }",
+        "}"
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.csharp(),
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    
+    test "C and C++ splitting" do
+      code = "
+#include <iostream>
+
+int main() {
+    std::cout << \"Hello, World!\" << std::endl;
+    return 0;
+}
+    "
+
+      expected_splits = [
+       "#include",
+        "<iostream>",
+        "int main() {",
+        "std::cout",
+        "<< \"Hello,",
+        "World!\" <<",
+        "std::endl;",
+        "return 0;\n}",
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.c(),
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    
+    test "Scala splitting" do
+      code = "
+object HelloWorld {
+  def main(args: Array[String]): Unit = {
+    println(\"Hello, World!\")
+  }
+}
+    "
+
+      expected_splits = [
+       "object",
+        "HelloWorld {",
+        "def",
+        "main(args:",
+        "Array[String]):",
+        "Unit = {",
+        "println(\"Hello,",
+        "World!\")",
+        "}\n}",
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.scala(),
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    
+    test "Ruby splitting" do
+      code = "
+def hello_world
+  puts \"Hello, World!\"
+end
+
+hello_world
+    "
+
+      expected_splits = [
+        "def hello_world",
+        "puts \"Hello,",
+        "World!\"",
+        "end",
+        "hello_world",
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.ruby(),
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    
+    test "Php splitting" do
+      code = "
+<?php
+function hello_world() {
+    echo \"Hello, World!\";
+}
+
+hello_world();
+?>
+    "
+
+      expected_splits = [
+        "<?php",
+        "function",
+        "hello_world() {",
+        "echo",
+        "\"Hello,",
+        "World!\";",
+        "}",
+        "hello_world();",
+        "?>",
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.php(),
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+
+    test "Swift splitting" do
+      code = "
+func helloWorld() {
+    print(\"Hello, World!\")
+}
+
+helloWorld()
+    "
+
+      expected_splits = [
+        "func",
+        "helloWorld() {",
+        "print(\"Hello,",
+        "World!\")",
+        "}",
+        "helloWorld()",
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.swift(),
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    
+    test "Rust splitting" do
+      code = "
+fn main() {
+    println!(\"Hello, World!\");
+}
+    "
+
+      expected_splits = [
+        "fn main() {", "println!(\"Hello", ",", "World!\");", "}"
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.rust(),
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    test "Markdown splitting" do
+      code = "
+# Sample Document
+
+## Section
+
+This is the content of the section.
+
+## Lists
+
+- Item 1
+- Item 2
+- Item 3
+
+### Horizontal lines
+
+***********
+____________
+-------------------
+
+#### Code blocks
+```
+This is a code block
+
+# sample code
+a = 1
+b = 2
+```
+    "
+
+      expected_splits = [
+     "# Sample",
+        "Document",
+        "## Section",
+        "This is the",
+        "content of the",
+        "section.",
+        "## Lists",
+        "- Item 1",
+        "- Item 2",
+        "- Item 3",
+        "### Horizontal",
+        "lines",
+        "***********",
+        "____________",
+        "---------------",
+        "----",
+        "#### Code",
+        "blocks",
+        "```",
+        "This is a code",
+        "block",
+        "# sample code",
+        "a = 1\nb = 2",
+        "```",
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.markdown(),
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    
+    test "Latex splitting" do
+      code = "
+Hi Harrison!
+\\chapter{1}
+    "
+
+      expected_splits = ["Hi Harrison!", "\\chapter{1}"]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.latex(),
+          is_separator_regex: true,
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    
+    test "Html splitting" do
+      code = "
+<h1>Sample Document</h1>
+    <h2>Section</h2>
+        <p id=\"1234\">Reference content.</p>
+
+    <h2>Lists</h2>
+        <ul>
+            <li>Item 1</li>
+            <li>Item 2</li>
+            <li>Item 3</li>
+        </ul>
+
+        <h3>A block</h3>
+            <div class=\"amazing\">
+                <p>Some text</p>
+                <p>Some more text</p>
+            </div>
+    "
+
+      expected_splits = [
+        "<h1>Sample Document</h1>\n    <h2>Section</h2>",
+        "<p id=\"1234\">Reference content.</p>",
+        "<h2>Lists</h2>\n        <ul>",
+        "<li>Item 1</li>\n            <li>Item 2</li>",
+        "<li>Item 3</li>\n        </ul>",
+        "<h3>A block</h3>",
+        "<div class=\"amazing\">",
+        "<p>Some text</p>",
+        "<p>Some more text</p>\n            </div>",        
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.html(),
+          keep_separator: :start,
+          chunk_size: 60,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    
+    test "Solidity splitting" do
+      code = "
+pragma solidity ^0.8.20;
+  contract HelloWorld {
+    function add(uint a, uint b) pure public returns(uint) {
+      return  a + b;
+    }
+  }
+    "
+
+      expected_splits = [
+        "pragma solidity",
+        "^0.8.20;",
+        "contract",
+        "HelloWorld {",
+        "function",
+        "add(uint a,",
+        "uint b) pure",
+        "public",
+        "returns(uint) {",
+        "return  a",
+        "+ b;",
+        "}\n  }",      
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.sol(),
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    
+    test "Lua splitting" do
+      code = "
+local variable = 10
+
+function add(a, b)
+    return a + b
+end
+
+if variable > 5 then
+    for i=1, variable do
+        while i < variable do
+            repeat
+                print(i)
+                i = i + 1
+            until i >= variable
+        end
+    end
+end
+    "
+
+      expected_splits = [
+        "local variable",
+        "= 10",
+        "function add(a,",
+        "b)",
+        "return a +",
+        "b",
+        "end",
+        "if variable > 5",
+        "then",
+        "for i=1,",
+        "variable do",
+        "while i",
+        "< variable do",
+        "repeat",
+        "print(i)",
+        "i = i + 1",
+        "until i >=",
+        "variable",
+        "end",
+        "end\nend",
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.lua(),
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    test "Haskell splitting" do
+      code = "
+        main :: IO ()
+        main = do
+          putStrLn \"Hello, World!\"
+
+        -- Some sample functions
+        add :: Int -> Int -> Int
+        add x y = x + y      
+    "
+
+      expected_splits = [
+        "main ::",
+        "IO ()",
+        "main = do",
+        "putStrLn",
+        "\"Hello, World!\"",
+        "--",
+        "Some sample",
+        "functions",
+        "add :: Int ->",
+        "Int -> Int",
+        "add x y = x",
+        "+ y",
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.haskell(),
+          is_separator_regex: true,
+          keep_separator: :start,
+          chunk_size: @chunk_size,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    
+    test "Powershell short code splitting" do
+      code = "
+# Check if a file exists
+$filePath = \"C:\\temp\\file.txt\"
+if (Test-Path $filePath) {
+    # File exists
+} else {
+    # File does not exist
+}
+    "
+
+      expected_splits = [
+        "# Check if a file exists\n$filePath = \"C:\\temp\\file.txt\"",
+        "if (Test-Path $filePath) {\n    # File exists\n} else {",
+        "# File does not exist\n}",
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.powershell(),
+          is_separator_regex: true,
+          keep_separator: :start,
+          chunk_size: 60,
+          chunk_overlap: 0
+        })
+
+      splits =
+        splitter
+        |> RecursiveCharacterTextSplitter.split_text(code)
+
+      assert splits == expected_splits
+    end
+    
+    test "Powershell long code splitting" do
+      code = "
+# Get a list of all processes and export to CSV
+$processes = Get-Process
+$processes | Export-Csv -Path \"C:\\temp\\processes.csv\" -NoTypeInformation
+
+# Read the CSV file and display its content
+$csvContent = Import-Csv -Path \"C:\\temp\\processes.csv\"
+$csvContent | ForEach-Object {
+    $_.ProcessName
+}
+
+# End of script
+    "
+
+      expected_splits = [
+        "# Get a list of all processes and export to CSV",
+        "$processes = Get-Process",
+        "$processes | Export-Csv -Path \"C:\\temp\\processes.csv\"",
+        "-NoTypeInformation",
+        "# Read the CSV file and display its content",
+        "$csvContent = Import-Csv -Path \"C:\\temp\\processes.csv\"",
+        "$csvContent | ForEach-Object {\n    $_.ProcessName\n}",
+        "# End of script",        
+      ]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: LanguageSeparators.powershell(),
+          is_separator_regex: true,
+          keep_separator: :start,
+          chunk_size: 60,
           chunk_overlap: 0
         })
 

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -4,6 +4,7 @@ defmodule TextSplitterTest do
   alias LangChain.TextSplitter
 
   describe "CharacterTextSplitter" do
+    @tag :wip
     test "text splitting by character count" do
       text = "foo bar baz 123"
       expected_output = ["foo bar", "bar baz", "baz 123"]

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -250,8 +250,9 @@ defmodule TextSplitterTest do
       ]
 
       test_data = [
-        %{expected: expected_output_1, params: %{chunk_size: 5}},
-        %{expected: expected_output_2, params: %{chunk_size: 6, keep_separator: :start}}
+        %{expected: expected_output_1, params: %{chunk_size: 5,
+                                                 keep_separator: :discard_separator}},
+        %{expected: expected_output_2, params: %{chunk_size: 6}}
       ]
 
       for tt <- test_data do

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -18,6 +18,7 @@ defmodule TextSplitterTest do
       assert expected_splitter == output_splitter
     end
 
+    @tag :wip
     test "Splitting by character count" do
       text = "foo bar baz 123"
       expected_output = ["foo bar", "bar baz", "baz 123"]
@@ -46,8 +47,9 @@ defmodule TextSplitterTest do
       assert expected_output == output
     end
 
+    @tag :wip
     test "Edge cases are separators" do
-      text = "f  b"
+      text = "f b"
       expected_output = ["f", "b"]
 
       {:ok, character_splitter} =
@@ -77,6 +79,20 @@ defmodule TextSplitterTest do
     test "Splitting by character count when shorter words are first" do
       text = "a a foo bar baz"
       expected_output = ["a a", "foo", "bar", "baz"]
+
+      {:ok, character_splitter} =
+        TextSplitter.new(%{separator: " ", chunk_size: 3, chunk_overlap: 1})
+
+      output =
+        character_splitter
+        |> TextSplitter.split_text(text)
+
+      assert expected_output == output
+    end
+
+    test "Splitting by characters when splits not found easily" do
+      text = "foo bar baz 123"
+      expected_output = ["foo", "bar", "baz", "123"]
 
       {:ok, character_splitter} =
         TextSplitter.new(%{separator: " ", chunk_size: 3, chunk_overlap: 1})

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -203,29 +203,22 @@ defmodule TextSplitterTest do
     test "recursive_character_text_splitter" do
       split_tags = [",", "."]
       query = "Apple,banana,orange and tomato."
-      splitter =
-        RecursiveCharacterTextSplitter.new!(%{
-          chunk_size: 10,
-          chunk_overlap: 0,
-          separators: split_tags,
-          keep_separator: :end
-        })
-
-      result = splitter
-      |> RecursiveCharacterTextSplitter.split_text(query)
-      assert ["Apple,", "banana,", "orange and tomato."] == result
-
-      splitter =
-        RecursiveCharacterTextSplitter.new!(%{
-          chunk_size: 10,
-          chunk_overlap: 0,
-          separators: split_tags,
-          keep_separator: :start
-        })
-
-      result = splitter
-      |> RecursiveCharacterTextSplitter.split_text(query)
-      assert ["Apple", ",banana", ",orange and tomato", "."] == result       
+      expected_output_1 = ["Apple,", "banana,", "orange and tomato."]
+      expected_output_2 = ["Apple", ",banana", ",orange and tomato", "."]
+      base_params = %{chunk_size: 10,
+                      chunk_overlap: 0,
+                      separators: split_tags}
+      test_data = [
+        %{expected: expected_output_1, params: %{keep_separator: :end}},
+        %{expected: expected_output_2, params: %{keep_separator: :start}}
+      ]
+      for tt <- test_data do
+        splitter =
+          RecursiveCharacterTextSplitter.new!(
+            Map.merge(base_params, tt.params))
+        output = splitter |> RecursiveCharacterTextSplitter.split_text(query)
+        assert tt.expected == output        
+      end
     end
 
     @tag :wip

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -73,7 +73,7 @@ defmodule TextSplitterTest do
 
       assert expected_output == output
     end
-    
+
     @tag :wip
     test "Splitting by character count when shorter words are first" do
       text = "a a foo bar baz"

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -8,35 +8,83 @@ defmodule TextSplitterTest do
       expected_splitter = %TextSplitter{
         separator: " ",
         chunk_overlap: 0,
-        chunk_size: 2,
+        chunk_size: 2
       }
+
       assert {:ok, %TextSplitter{} = output_splitter} =
-        %{separator: " ", chunk_overlap: 0, chunk_size: 2,}
-        |> TextSplitter.new()
+               %{separator: " ", chunk_overlap: 0, chunk_size: 2}
+               |> TextSplitter.new()
+
       assert expected_splitter == output_splitter
     end
-    
+
     test "Splitting by character count" do
       text = "foo bar baz 123"
       expected_output = ["foo bar", "bar baz", "baz 123"]
+
       {:ok, character_splitter} =
-        TextSplitter.new(
-           %{separator: " ", chunk_size: 7, chunk_overlap: 3})
+        TextSplitter.new(%{separator: " ", chunk_size: 7, chunk_overlap: 3})
+
       output =
         character_splitter
         |> TextSplitter.split_text(text)
+
       assert expected_output == output
     end
 
     test "Splitting character by count doesn't create empty documents" do
       text = "foo  bar"
       expected_output = ["foo", "bar"]
+
       {:ok, character_splitter} =
-        TextSplitter.new(
-           %{separator: " ", chunk_size: 2, chunk_overlap: 0})
+        TextSplitter.new(%{separator: " ", chunk_size: 2, chunk_overlap: 0})
+
       output =
         character_splitter
         |> TextSplitter.split_text(text)
+
+      assert expected_output == output
+    end
+
+    test "Edge cases are separators" do
+      text = "f  b"
+      expected_output = ["f", "b"]
+
+      {:ok, character_splitter} =
+        TextSplitter.new(%{separator: " ", chunk_size: 2, chunk_overlap: 0})
+
+      output =
+        character_splitter
+        |> TextSplitter.split_text(text)
+
+      assert expected_output == output
+    end
+
+    test "Splitting by character count on long words" do
+      text = "foo bar baz a a"
+      expected_output = ["foo", "bar", "baz", "a a"]
+
+      {:ok, character_splitter} =
+        TextSplitter.new(%{separator: " ", chunk_size: 3, chunk_overlap: 1})
+
+      output =
+        character_splitter
+        |> TextSplitter.split_text(text)
+
+      assert expected_output == output
+    end
+
+    test "Splitting by character count when shorter words are first" do
+      text = "a a foo bar baz"
+      expected_output = ["a a", "foo", "bar", "baz"]
+
+      {:ok, character_splitter} =
+        TextSplitter.new(%{separator: " ", chunk_size: 3, chunk_overlap: 1})
+
+      output =
+        character_splitter
+        |> TextSplitter.split_text(text)
+
       assert expected_output == output
     end
   end

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -38,8 +38,7 @@ defmodule TextSplitterTest do
       expected_output = ["foo bar", "bar baz", "baz 123"]
 
       character_splitter =
-        CharacterTextSplitter.new!(
-          %{separator: " ", chunk_size: 7, chunk_overlap: 3})
+        CharacterTextSplitter.new!(%{separator: " ", chunk_size: 7, chunk_overlap: 3})
 
       output =
         character_splitter
@@ -53,8 +52,7 @@ defmodule TextSplitterTest do
       expected_output = ["foo", "bar"]
 
       character_splitter =
-        CharacterTextSplitter.new!(
-          %{separator: " ", chunk_size: 2, chunk_overlap: 0})
+        CharacterTextSplitter.new!(%{separator: " ", chunk_size: 2, chunk_overlap: 0})
 
       output =
         character_splitter
@@ -188,7 +186,7 @@ defmodule TextSplitterTest do
       ]
 
       for tt <- test_params do
-         character_splitter =
+        character_splitter =
           CharacterTextSplitter.new!(Map.merge(base_params, tt))
 
         output =

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -16,7 +16,6 @@ defmodule TextSplitterTest do
       assert expected_splitter == output_splitter
     end
     
-    @tag :wip
     test "Splitting by character count" do
       text = "foo bar baz 123"
       expected_output = ["foo bar", "bar baz", "baz 123"]
@@ -29,7 +28,6 @@ defmodule TextSplitterTest do
       assert expected_output == output
     end
 
-    @tag :wip
     test "Splitting character by count doesn't create empty documents" do
       text = "foo  bar"
       expected_output = ["foo", "bar"]

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -117,25 +117,85 @@ defmodule TextSplitterTest do
       assert expected_output == output
     end
 
-    @tag :wip
-    test "Splitting by characters and keeping separator that is a regex special char" do
+    test "Splitting by characters and keeping at start separator that is a regex special char" do
       text = "foo.bar.baz.123"
       expected_output = ["foo", ".bar", ".baz", ".123"]
 
-      {:ok, character_splitter} =
-        TextSplitter.new(%{
-          separator: ".",
-          chunk_size: 1,
-          chunk_overlap: 0,
-          keep_separator: :start,
-          is_separator_regex: true
-        })
+      base_params = %{
+        chunk_size: 1,
+        chunk_overlap: 0,
+        keep_separator: :start
+      }
 
-      output =
-        character_splitter
-        |> TextSplitter.split_text(text)
+      test_params = [
+        %{separator: ".", is_separator_regex: false},
+        %{separator: Regex.escape("."), is_separator_regex: true}
+      ]
 
-      assert expected_output == output
+      for tt <- test_params do
+        {:ok, character_splitter} =
+          TextSplitter.new(Map.merge(base_params, tt))
+
+        output =
+          character_splitter
+          |> TextSplitter.split_text(text)
+
+        assert expected_output == output
+      end
+    end
+
+    test "Splitting by characters and keeping at end separator that is a regex special char" do
+      text = "foo.bar.baz.123"
+      expected_output = ["foo.", "bar.", "baz.", "123"]
+
+      base_params = %{
+        chunk_size: 1,
+        chunk_overlap: 0,
+        keep_separator: :end
+      }
+
+      test_params = [
+        %{separator: ".", is_separator_regex: false},
+        %{separator: Regex.escape("."), is_separator_regex: true}
+      ]
+
+      for tt <- test_params do
+        {:ok, character_splitter} =
+          TextSplitter.new(Map.merge(base_params, tt))
+
+        output =
+          character_splitter
+          |> TextSplitter.split_text(text)
+
+        assert expected_output == output
+      end
+    end
+
+    @tag :wip
+    test "Splitting by characters and discard separator that is a regex special char" do
+      text = "foo.bar.baz.123"
+      expected_output = ["foo", "bar", "baz", "123"]
+
+      base_params = %{
+        chunk_size: 1,
+        chunk_overlap: 0
+      }
+
+      test_params = [
+        %{separator: ".", is_separator_regex: false},
+        %{separator: Regex.escape("."), is_separator_regex: true}
+      ]
+
+      for tt <- test_params do
+        {:ok, character_splitter} =
+          TextSplitter.new(Map.merge(base_params, tt))
+
+        output =
+          character_splitter
+          |> TextSplitter.split_text(text)
+
+        assert expected_output == output
+      end
     end
   end
 end

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -18,7 +18,6 @@ defmodule TextSplitterTest do
       assert expected_splitter == output_splitter
     end
 
-    @tag :wip
     test "Splitting by character count" do
       text = "foo bar baz 123"
       expected_output = ["foo bar", "bar baz", "baz 123"]
@@ -47,7 +46,6 @@ defmodule TextSplitterTest do
       assert expected_output == output
     end
 
-    @tag :wip
     test "Edge cases are separators" do
       text = "f b"
       expected_output = ["f", "b"]
@@ -75,7 +73,8 @@ defmodule TextSplitterTest do
 
       assert expected_output == output
     end
-
+    
+    @tag :wip
     test "Splitting by character count when shorter words are first" do
       text = "a a foo bar baz"
       expected_output = ["a a", "foo", "bar", "baz"]

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -102,5 +102,16 @@ defmodule TextSplitterTest do
 
       assert expected_output == output
     end
+
+    test "Splitting by characters and keeping the separator that is regex special char" do
+      text = "foo.bar.baz.123"
+      expected_output = ["foo", ".bar", ".baz", ".123"]
+      {:ok, character_splitter} =
+        TextSplitter.new(%{separator: ".", chunk_size: 1, chunk_overlap: 0})
+      output =
+        character_splitter
+        |> TextSplitter.split_text(text)
+      assert expected_output == output
+    end
   end
 end

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -1,6 +1,7 @@
 defmodule TextSplitterTest do
   use ExUnit.Case
   alias LangChain.TextSplitter.CharacterTextSplitter
+  alias LangChain.TextSplitter.RecursiveCharacterTextSplitter
   doctest CharacterTextSplitter
 
   describe "CharacterTextSplitter" do
@@ -195,6 +196,25 @@ defmodule TextSplitterTest do
 
         assert expected_output == output
       end
+    end
+  end
+
+  describe "RecursiveCharacterTextSplitter" do
+    test "recursive_character_text_splitter" do
+      split_tags = [",", "."]
+      query = "Apple,banana,orange and tomato."
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          chunk_size: 10,
+          chunk_overlap: 0,
+          separators: split_tags,
+          keep_separator: :start
+        })
+
+      result = splitter
+      |> RecursiveCharacterTextSplitter.split_text(query)
+      assert ["Apple,", "banana,", "orange and tomato."] == result 
     end
   end
 end

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -1,0 +1,15 @@
+defmodule TextSplitterTest do
+  use ExUnit.Case
+
+  alias LangChain.TextSplitter
+
+  describe "CharacterTextSplitter" do
+    test "text splitting by character count" do
+      text = "foo bar baz 123"
+      expected_output = ["foo bar", "bar baz", "baz 123"]
+      output = TextSplitter.split_text(text)
+      assert output == expected_output
+    end
+  end
+  
+end

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -203,7 +203,6 @@ defmodule TextSplitterTest do
     test "recursive_character_text_splitter" do
       split_tags = [",", "."]
       query = "Apple,banana,orange and tomato."
-
       splitter =
         RecursiveCharacterTextSplitter.new!(%{
           chunk_size: 10,
@@ -227,6 +226,41 @@ defmodule TextSplitterTest do
       result = splitter
       |> RecursiveCharacterTextSplitter.split_text(query)
       assert ["Apple", ",banana", ",orange and tomato", "."] == result       
+    end
+
+    @tag :wip
+    test "Iterative splitter discard separator" do
+      text = "....5X..3Y...4X....5Y..."
+      base_params = %{
+        chunk_overlap: 0,
+        is_separator_regex: false,
+        separators: ["X", "Y"],
+      }
+      expected_output_1 = [
+        "....5",
+        "..3",
+        "...4",
+        "....5",
+        "..."]
+      expected_output_2 = [
+        "....5",
+        "X..3",
+        "Y...4",
+        "X....5",
+        "Y..."]      
+      test_data = [
+        %{expected: expected_output_1,
+          params: %{chunk_size: 5}},
+        %{expected: expected_output_2,
+          params: %{chunk_size: 6, keep_separator: :start}},        
+      ]
+      for tt <- test_data do
+        splitter =
+          RecursiveCharacterTextSplitter.new!(
+            Map.merge(base_params, tt.params))
+        output = splitter |> RecursiveCharacterTextSplitter.split_text(text)
+        assert tt.expected == output
+      end
     end
   end
 end

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -1,6 +1,7 @@
 defmodule TextSplitterTest do
   use ExUnit.Case
   alias LangChain.TextSplitter.CharacterTextSplitter
+  doctest CharacterTextSplitter
 
   describe "CharacterTextSplitter" do
     test "New TextSplitter" do

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -4,11 +4,28 @@ defmodule TextSplitterTest do
   alias LangChain.TextSplitter
 
   describe "CharacterTextSplitter" do
+    test "New TextSplitter" do
+      expected_splitter = %TextSplitter{
+        separator: " ",
+        chunk_overlap: 0,
+        chunk_size: 2,
+      }
+      assert {:ok, %TextSplitter{} = output_splitter} =
+        %{separator: " ", chunk_overlap: 0, chunk_size: 2,}
+        |> TextSplitter.new()
+      assert expected_splitter == output_splitter
+    end
+    
     @tag :wip
     test "Splitting by character count" do
       text = "foo bar baz 123"
       expected_output = ["foo bar", "bar baz", "baz 123"]
-      output = TextSplitter.split_text(text)
+      {:ok, character_splitter} =
+        TextSplitter.new(
+           %{separator: " ", chunk_size: 7, chunk_overlap: 3})
+      output =
+        character_splitter
+        |> TextSplitter.split_text(text)
       assert expected_output == output
     end
 
@@ -16,7 +33,12 @@ defmodule TextSplitterTest do
     test "Splitting character by count doesn't create empty documents" do
       text = "foo  bar"
       expected_output = ["foo", "bar"]
-      output = TextSplitter.split_text(text)
+      {:ok, character_splitter} =
+        TextSplitter.new(
+           %{separator: " ", chunk_size: 2, chunk_overlap: 0})
+      output =
+        character_splitter
+        |> TextSplitter.split_text(text)
       assert expected_output == output
     end
   end

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -18,6 +18,21 @@ defmodule TextSplitterTest do
       assert expected_splitter == output_splitter
     end
 
+    test "New TextSplitter with keep_separator" do
+      expected_splitter = %TextSplitter{
+        separator: " ",
+        chunk_overlap: 0,
+        chunk_size: 2,
+        keep_separator: :start
+      }
+
+      assert {:ok, %TextSplitter{} = output_splitter} =
+               %{separator: " ", chunk_overlap: 0, chunk_size: 2, keep_separator: :start}
+               |> TextSplitter.new()
+
+      assert expected_splitter == output_splitter
+    end
+
     test "Splitting by character count" do
       text = "foo bar baz 123"
       expected_output = ["foo bar", "bar baz", "baz 123"]
@@ -74,7 +89,6 @@ defmodule TextSplitterTest do
       assert expected_output == output
     end
 
-    @tag :wip
     test "Splitting by character count when shorter words are first" do
       text = "a a foo bar baz"
       expected_output = ["a a", "foo", "bar", "baz"]
@@ -103,14 +117,24 @@ defmodule TextSplitterTest do
       assert expected_output == output
     end
 
-    test "Splitting by characters and keeping the separator that is regex special char" do
+    @tag :wip
+    test "Splitting by characters and keeping separator that is a regex special char" do
       text = "foo.bar.baz.123"
       expected_output = ["foo", ".bar", ".baz", ".123"]
+
       {:ok, character_splitter} =
-        TextSplitter.new(%{separator: ".", chunk_size: 1, chunk_overlap: 0})
+        TextSplitter.new(%{
+          separator: ".",
+          chunk_size: 1,
+          chunk_overlap: 0,
+          keep_separator: :start,
+          is_separator_regex: true
+        })
+
       output =
         character_splitter
         |> TextSplitter.split_text(text)
+
       assert expected_output == output
     end
   end

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -59,7 +59,7 @@ defmodule TextSplitterTest do
         character_splitter
         |> CharacterTextSplitter.split_text(text)
 
-      assert output ==  expected_output
+      assert output == expected_output
     end
 
     test "Edge cases are separators" do
@@ -289,9 +289,11 @@ Bye!\n\n-I."
       ]
 
       splitter =
-        RecursiveCharacterTextSplitter.new!(
-          %{chunk_size: 10,
-            chunk_overlap: 1})
+        RecursiveCharacterTextSplitter.new!(%{
+          keep_separator: :start,
+          chunk_size: 10,
+          chunk_overlap: 1
+        })
 
       output = splitter |> RecursiveCharacterTextSplitter.split_text(text)
       assert output == expected_output

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -5,12 +5,19 @@ defmodule TextSplitterTest do
 
   describe "CharacterTextSplitter" do
     @tag :wip
-    test "text splitting by character count" do
+    test "Splitting by character count" do
       text = "foo bar baz 123"
       expected_output = ["foo bar", "bar baz", "baz 123"]
       output = TextSplitter.split_text(text)
-      assert output == expected_output
+      assert expected_output == output
+    end
+
+    @tag :wip
+    test "Splitting character by count doesn't create empty documents" do
+      text = "foo  bar"
+      expected_output = ["foo", "bar"]
+      output = TextSplitter.split_text(text)
+      assert expected_output == output
     end
   end
-  
 end


### PR DESCRIPTION
I've ported [CharacterTextSplitter](https://python.langchain.com/api_reference/text_splitters/character/langchain_text_splitters.character.CharacterTextSplitter.html#langchain_text_splitters.character.CharacterTextSplitter) from the Python lib. I've set up the code so [RecursiveCharacterTextSplitter](https://python.langchain.com/api_reference/text_splitters/character/langchain_text_splitters.character.RecursiveCharacterTextSplitter.html#langchain_text_splitters.character.RecursiveCharacterTextSplitter) can be added easily.

It's still missing documentation, but the code is ready for review.

The differences with the Python implementation are:
- Default Python separator is `"\n\n"` while this implementation's is `" "`. Due to [this ecto issue](https://github.com/elixir-ecto/ecto/issues/1684), if `" "` is used as a separator, the separator becomes `nil` after changeset validation. Only by setting the default to `" "`, makes `" "` a feasible separator. This also makes porting the tests easy.
- `keep_separator` option in Python is: `bool`, `"start"` or `"end"`. I've implemented with options `:start`, `:end` or `nil`. I believe this makes things more explicit without loss of functionality. Python's `True` and `"start"` map to this `:start`. Python's `False` maps to this `nil`. Python's `"end"` maps to this `:end`.

All relevant tests from the Python lib have been ported. Up to [here](https://github.com/langchain-ai/langchain/blob/1a225fad038c851b79ab8ed337b5f10551e3ac81/libs/text-splitters/tests/unit_tests/test_text_splitters.py#L169)

I believe there is an issue when it comes to implement `RecursiveCharacterTextSplitter`, as it shares a lot of options with `CharacterSplitter`. I have not found an way to share the overlapping options in the embedded Ecto schema. This will lead to some code duplication. I do not believe this to be a significant issue, as it's not user facing. However, I am happy to hear suggestions.