### PR TITLE
Redact api-key from models

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -116,7 +116,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     # API key for Anthropic. If not set, will use global api key. Allows for usage
     # of a different API key per-call if desired. For instance, allowing a
     # customer to provide their own.
-    field :api_key, :string
+    field :api_key, :string, redact: true
 
     # https://docs.anthropic.com/claude/reference/versions
     field :api_version, :string, default: "2023-06-01"

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -46,7 +46,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     # The version of the API to use.
     field :api_version, :string, default: @default_api_version
     field :model, :string, default: "gemini-pro"
-    field :api_key, :string
+    field :api_key, :string, redact: true
 
     # What sampling temperature to use, between 0 and 2. Higher values like 0.8
     # will make the output more random, while lower values like 0.2 will make it

--- a/lib/chat_models/chat_mistral_ai.ex
+++ b/lib/chat_models/chat_mistral_ai.ex
@@ -26,7 +26,7 @@ defmodule LangChain.ChatModels.ChatMistralAI do
 
     # The version of the API to use.
     field :model, :string
-    field :api_key, :string
+    field :api_key, :string, redact: true
 
     # What sampling temperature to use, between 0 and 1. Higher values like 0.8
     # will make the output more random, while lower values like 0.2 will make it

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -145,7 +145,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     # API key for OpenAI. If not set, will use global api key. Allows for usage
     # of a different API key per-call if desired. For instance, allowing a
     # customer to provide their own.
-    field :api_key, :string
+    field :api_key, :string, redact: true
 
     # What sampling temperature to use, between 0 and 2. Higher values like 0.8
     # will make the output more random, while lower values like 0.2 will make it

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -32,7 +32,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     field :endpoint, :string
 
     field :model, :string, default: "gemini-pro"
-    field :api_key, :string
+    field :api_key, :string, redact: true
 
     # What sampling temperature to use, between 0 and 2. Higher values like 0.8
     # will make the output more random, while lower values like 0.2 will make it

--- a/lib/images/open_ai_image.ex
+++ b/lib/images/open_ai_image.ex
@@ -28,7 +28,7 @@ defmodule LangChain.Images.OpenAIImage do
     # API key for OpenAI. If not set, will use global api key. Allows for usage
     # of a different API key per-call if desired. For instance, allowing a
     # customer to provide their own.
-    field :api_key, :string
+    field :api_key, :string, redact: true
     # Duration in seconds for the response to be received. When streaming a very
     # lengthy response, a longer time limit may be required. However, when it
     # goes on too long by itself, it tends to hallucinate more.

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -1673,4 +1673,15 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
              }
     end
   end
+
+  describe "inspect" do
+    test "redacts the API key" do
+      chain = ChatAnthropic.new!()
+
+      changeset = Ecto.Changeset.cast(chain, %{api_key: "1234567890"}, [:api_key])
+
+      refute inspect(changeset) =~ "1234567890"
+      assert inspect(changeset) =~ "**redacted**"
+    end
+  end
 end

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -843,4 +843,15 @@ defmodule ChatModels.ChatGoogleAITest do
     {:ok, string} = ChainResult.to_string(updated_chain)
     assert string =~ "owl"
   end
+
+  describe "inspect" do
+    test "redacts the API key" do
+      chain = ChatGoogleAI.new!()
+
+      changeset = Ecto.Changeset.cast(chain, %{api_key: "1234567890"}, [:api_key])
+
+      refute inspect(changeset) =~ "1234567890"
+      assert inspect(changeset) =~ "**redacted**"
+    end
+  end
 end

--- a/test/chat_models/chat_mistral_ai_test.exs
+++ b/test/chat_models/chat_mistral_ai_test.exs
@@ -228,4 +228,15 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
              }
     end
   end
+
+  describe "inspect" do
+    test "redacts the API key" do
+      chain = ChatMistralAI.new!(%{"model" => "mistral-tiny"})
+
+      changeset = Ecto.Changeset.cast(chain, %{api_key: "1234567890"}, [:api_key])
+
+      refute inspect(changeset) =~ "1234567890"
+      assert inspect(changeset) =~ "**redacted**"
+    end
+  end
 end

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -2127,4 +2127,15 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
              }
     end
   end
+
+  describe "inspect" do
+    test "redacts the API key" do
+      chain = ChatOpenAI.new!()
+
+      changeset = Ecto.Changeset.cast(chain, %{api_key: "1234567890"}, [:api_key])
+
+      refute inspect(changeset) =~ "1234567890"
+      assert inspect(changeset) =~ "**redacted**"
+    end
+  end
 end

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -363,4 +363,15 @@ defmodule ChatModels.ChatVertexAITest do
              }
     end
   end
+
+  describe "inspect" do
+    test "redacts the API key" do
+      chain = ChatVertexAI.new!(%{"model" => "gemini-pro", "endpoint" => "http://localhost:1000"})
+
+      changeset = Ecto.Changeset.cast(chain, %{api_key: "1234567890"}, [:api_key])
+
+      refute inspect(changeset) =~ "1234567890"
+      assert inspect(changeset) =~ "**redacted**"
+    end
+  end
 end

--- a/test/images/open_ai_image_test.exs
+++ b/test/images/open_ai_image_test.exs
@@ -134,4 +134,15 @@ defmodule LangChain.Images.OpenAIImageTest do
                OpenAIImage.do_process_response(response, request)
     end
   end
+
+  describe "inspect" do
+    test "redacts the API key" do
+      img = OpenAIImage.new!(%{prompt: "A security guard."})
+
+      changeset = Ecto.Changeset.cast(img, %{api_key: "1234567890"}, [:api_key])
+
+      refute inspect(changeset) =~ "1234567890"
+      assert inspect(changeset) =~ "**redacted**"
+    end
+  end
 end


### PR DESCRIPTION
### Summary

- **Problem:**

  If we inspect some models with API key, its possible to log and expose this sensitive data.

- **Fix:**

  Add a redact option on each sensitive field as described in [ecto doc](https://hexdocs.pm/ecto/Ecto.Schema.html#module-redacting-fields)