### PR TITLE
Support caching tool results for Anthropic calls

### DIFF
--- a/lib/message/tool_result.ex
+++ b/lib/message/tool_result.ex
@@ -38,6 +38,8 @@ defmodule LangChain.Message.ToolResult do
     field :display_text, :string
     # flag if the result is an error
     field :is_error, :boolean, default: false
+    # options potentially LLM specific (i.e. cache control for Anthropic)
+    field :options, :any, virtual: true
   end
 
   @type t :: %ToolResult{}
@@ -49,7 +51,8 @@ defmodule LangChain.Message.ToolResult do
     :content,
     :processed_content,
     :display_text,
-    :is_error
+    :is_error,
+    :options
   ]
   @create_fields @update_fields
   @required_fields [:type, :tool_call_id, :content]


### PR DESCRIPTION
Anthropic supports the `"cache_control" => %{"type" => "ephemeral"}` block for anything under the content blocks in `messages.content` (based on [docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#what-can-be-cached)).

Looks like currently only the text content in https://github.com/brainlid/langchain/blob/38e957d2985b054ce51e087b51bb1af54aee9754/lib/chat_models/chat_anthropic.ex#L872-L881 was supported

This adds the options keyword similar to how ContentPart implements it, to allow setting a tool result to be cached or not.

