### PR TITLE
feat: add support for pdf content with OpenAI model

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -457,6 +457,16 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     %{"type" => "text", "text" => part.content}
   end
 
+  def for_api(%_{} = _model, %ContentPart{type: :file, options: opts} = part) do
+    %{
+      "type" => "file",
+      "file" => %{
+        "filename" => Keyword.get(opts, :filename, "file.pdf"),
+        "file_data" => "data:application/pdf;base64," <> part.content
+      }
+    }
+  end
+
   def for_api(%_{} = _model, %ContentPart{type: image} = part)
       when image in [:image, :image_url] do
     media_prefix =

--- a/lib/message/content_part.ex
+++ b/lib/message/content_part.ex
@@ -122,8 +122,7 @@ defmodule LangChain.Message.ContentPart do
   end
 
   @doc """
-  Create a new ContentPart that contains a file encoded as base6
-  data.
+  Create a new ContentPart that contains a file encoded as base64 data.
   """
   @spec file!(String.t(), Keyword.t()) :: t() | no_return()
   def file!(content, opts \\ []) do

--- a/lib/message/content_part.ex
+++ b/lib/message/content_part.ex
@@ -9,6 +9,7 @@ defmodule LangChain.Message.ContentPart do
   - `:text` - The message part is text.
   - `:image_url` - The message part is a URL to an image.
   - `:image` - The message part is image data that is base64 encoded text.
+  - `:file` - The message part is file data that is base64 encoded text.
 
   ## Fields
 
@@ -43,7 +44,7 @@ defmodule LangChain.Message.ContentPart do
 
   @primary_key false
   embedded_schema do
-    field :type, Ecto.Enum, values: [:text, :image_url, :image], default: :text
+    field :type, Ecto.Enum, values: [:text, :image_url, :image, :file], default: :text
     field :content, :string
     field :options, :any, virtual: true
   end
@@ -118,6 +119,15 @@ defmodule LangChain.Message.ContentPart do
   @spec image!(String.t(), Keyword.t()) :: t() | no_return()
   def image!(content, opts \\ []) do
     new!(%{type: :image, content: content, options: opts})
+  end
+
+  @doc """
+  Create a new ContentPart that contains a file encoded as base6
+  data.
+  """
+  @spec file!(String.t(), Keyword.t()) :: t() | no_return()
+  def file!(content, opts \\ []) do
+    new!(%{type: :file, content: content, options: opts})
   end
 
   @doc """

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -337,6 +337,27 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert result == expected
     end
 
+    test "turns a file ContentPart into the expected JSON format" do
+      file_base64_data = "some_file_base64_data"
+      filename = "my_file.pdf"
+
+      expected = %{
+        "type" => "file",
+        "file" => %{
+          "filename" => filename,
+          "file_data" => "data:application/pdf;base64," <> file_base64_data
+        }
+      }
+
+      result =
+        ChatOpenAI.for_api(
+          ChatOpenAI.new!(),
+          ContentPart.file!(file_base64_data, media: :pdf, filename: filename)
+        )
+
+      assert result == expected
+    end
+
     test "turns a tool_call into expected JSON format" do
       tool_call =
         ToolCall.new!(%{call_id: "call_abc123", name: "hello_world", arguments: "{}"})

--- a/test/message/content_part_test.exs
+++ b/test/message/content_part_test.exs
@@ -55,6 +55,23 @@ defmodule LangChain.Message.ContentPartTest do
     end
   end
 
+  describe("file/1") do
+    test "returns a file data configured ContentPart" do
+      %ContentPart{} = part = ContentPart.file!(:base64.encode("fake_file_data"))
+      assert part.type == :file
+      assert part.content == "ZmFrZV9maWxlX2RhdGE="
+    end
+
+    test "supports 'filename' option" do
+      %ContentPart{} =
+        part = ContentPart.file!(Base.encode64("fake_file_data"), filename: "my_file.pdf")
+
+      assert part.type == :file
+      assert part.content == "ZmFrZV9maWxlX2RhdGE="
+      assert part.options == [filename: "my_file.pdf"]
+    end
+  end
+
   describe("image_url!/1") do
     test "returns a image_url configured ContentPart" do
       url =


### PR DESCRIPTION
## What does this PR do?

OpenAI [now supports PDF files as input](https://platform.openai.com/docs/guides/pdf-files?api-mode=chat&utm_source=alphasigna), either as Base64-encoded data or as file IDs obtained after uploading files to the `/v1/files` endpoint.

This PR adds support for pdf content as Base64-encoded data.