### PR TITLE
Support for file with file_id in ChatOpenAI

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -458,12 +458,23 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   end
 
   def for_api(%_{} = _model, %ContentPart{type: :file, options: opts} = part) do
+    file_params =
+      case Keyword.get(opts, :type, :base64) do
+        :file_id ->
+          %{
+            "file_id" => part.content
+          }
+
+        :base64 ->
+          %{
+            "filename" => Keyword.get(opts, :filename, "file.pdf"),
+            "file_data" => "data:application/pdf;base64," <> part.content
+          }
+      end
+
     %{
       "type" => "file",
-      "file" => %{
-        "filename" => Keyword.get(opts, :filename, "file.pdf"),
-        "file_data" => "data:application/pdf;base64," <> part.content
-      }
+      "file" => file_params
     }
   end
 

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -337,7 +337,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert result == expected
     end
 
-    test "turns a file ContentPart into the expected JSON format" do
+    test "turns a base64 file ContentPart into the expected JSON format" do
       file_base64_data = "some_file_base64_data"
       filename = "my_file.pdf"
 
@@ -352,7 +352,26 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       result =
         ChatOpenAI.for_api(
           ChatOpenAI.new!(),
-          ContentPart.file!(file_base64_data, media: :pdf, filename: filename)
+          ContentPart.file!(file_base64_data, media: :pdf, type: :base64, filename: filename)
+        )
+
+      assert result == expected
+    end
+
+    test "turns a file_id file ContentPart into the expected JSON format" do
+      file_id = "file-1234"
+
+      expected = %{
+        "type" => "file",
+        "file" => %{
+          "file_id" => file_id
+        }
+      }
+
+      result =
+        ChatOpenAI.for_api(
+          ChatOpenAI.new!(),
+          ContentPart.file!(file_id, media: :pdf, type: :file_id)
         )
 
       assert result == expected


### PR DESCRIPTION
When creating a `ContentPart`, now determine how the file is handled based on `opts[:type]`.
For backward compatibility, the default value of `opts[:type]` is set to `:base64`.