### PR TITLE
support deepseek's token usage format

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -837,7 +837,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
           | MessageDelta.t()
           | [MessageDelta.t()]
           | {:error, String.t()}
-  def do_process_response(model, %{"choices" => [], "usage" => %{} = _usage} = data) do
+  def do_process_response(model, %{"choices" => _choices, "usage" => %{} = _usage} = data) do
     case get_token_usage(data) do
       %TokenUsage{} = token_usage ->
         Callbacks.fire(model.callbacks, :on_llm_token_usage, [token_usage])
@@ -847,8 +847,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
         :ok
     end
 
-    # this stand-alone TokenUsage message is skipped and not returned
-    :skip
+    do_process_response(model, %{data | "usage" => nil})
   end
 
   def do_process_response(_model, %{"choices" => []}), do: :skip


### PR DESCRIPTION
Deepseek includes a `choice` with empty content in their token usage chunk when streaming. otherwise, their API is compatible with OpenAI's. This commit adds support for this chunk format.

Example of a token usage chunk from Deepseek:

```json
data: {
   "id":"339eade8-b499-472e-bc0d-b267b6e4bceb",
   "object":"chat.completion.chunk",
   "created":1743968719,
   "model":"deepseek-chat",
   "system_fingerprint":"fp_3d5141a69a_prod0225",
   "choices":[
      {
         "index":0,
         "delta":{
            "content":""
         },
         "logprobs":null,
         "finish_reason":"stop"
      }
   ],
   "usage":{
      "prompt_tokens":11,
      "completion_tokens":11,
      "total_tokens":22,
      "prompt_tokens_details":{
         "cached_tokens":0
      },
      "prompt_cache_hit_tokens":0,
      "prompt_cache_miss_tokens":11
   }
}
```