### PR TITLE
vertex ai file url support

### DIFF
--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -224,7 +224,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
   def for_api(%ContentPart{type: :file_url} = part) do
     %{
       "file_data" => %{
-       "mimeType" => Keyword.fetch!(part.options, :media),
+        "mimeType" => Keyword.fetch!(part.options, :media),
         "file_uri" => part.content
       }
     }

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -221,6 +221,15 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     }
   end
 
+  def for_api(%ContentPart{type: :file_url} = part) do
+    %{
+      "file_data" => %{
+       "mimeType" => Keyword.fetch!(part.options, :media),
+        "file_uri" => part.content
+      }
+    }
+  end
+
   defp for_api(%ToolCall{} = call) do
     %{
       "functionCall" => %{

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -221,7 +221,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     }
   end
 
-  def for_api(%ContentPart{type: :file_url} = part) do
+  defp for_api(%ContentPart{type: :file_url} = part) do
     %{
       "file_data" => %{
         "mimeType" => Keyword.fetch!(part.options, :media),

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -115,6 +115,33 @@ defmodule ChatModels.ChatVertexAITest do
              } = msg1
     end
 
+    test "support file_url", %{vertex_ai: google_ai} do
+      message =
+        Message.new_user!([
+          ContentPart.text!("User prompt"),
+          ContentPart.file_url!("example.com/test.pdf", media: "application/pdf")
+        ])
+
+      data = ChatVertexAI.for_api(google_ai, [message], [])
+
+      assert %{
+               "contents" => [
+                 %{
+                   "parts" => [
+                     %{"text" => "User prompt"},
+                     %{
+                       "file_data" => %{
+                         "file_uri" => "example.com/test.pdf",
+                         "mime_type" => "application/pdf"
+                       }
+                     }
+                   ],
+                   "role" => :user
+                 }
+               ]
+             } = data
+    end
+
     test "generates a map containing user and assistant messages", %{vertex_ai: vertex_ai} do
       user_message = "Hello Assistant!"
       assistant_message = "Hello User!"


### PR DESCRIPTION
Vertex AI supports file url and can work with any file url compared to google ai which only  support file url uploaded using its files api, google ai support was added recently and most of the ground work is already there in https://github.com/brainlid/langchain/pull/286  to support file _url for content part in vertex .