### PR TITLE
Fix system_instruction of ChatGoogleAI

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -184,11 +184,8 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
 
     system_instruction =
       case system do
-        nil ->
-          nil
-
-        %Message{role: :system, content: content} ->
-          %{"parts" => [%{"text" => content}]}
+        nil -> nil
+        system -> for_api(system)
       end
 
     messages_for_api =


### PR DESCRIPTION
This PR fixes the test below.

```
$ mix test test/chat_models/chat_google_ai_test.exs

Generated langchain app
Running ExUnit with seed: 266822, max_cases: 24
Excluding tags: [live_call: true]

..

  1) test for_api/3 adds system instruction to the request if present (ChatModels.ChatGoogleAITest)
     test/chat_models/chat_google_ai_test.exs:342
     match (=) failed
     The following variables were pinned:
       message = "You are a helpful assistant."
     code:  assert %{"system_instruction" => %{"parts" => [%{"text" => ^message}]}} = data
     left:  %{"system_instruction" => %{"parts" => [%{"text" => ^message}]}}
     right: %{
              "system_instruction" => %{"parts" => [%{"text" => [%LangChain.Message.ContentPart{type: :text, content: "You are a helpful assistant.", options: []}]}]},
              "contents" => [],
              "generationConfig" => %{"temperature" => 1.0, "topK" => 1.0, "topP" => 1.0}
            }
     stacktrace:
       test/chat_models/chat_google_ai_test.exs:346: (test)

....................................
Finished in 0.2 seconds (0.00s async, 0.2s sync)
44 tests, 1 failure, 5 excluded
```