### PR TITLE
Add strict to function of ChatModels.ChatOpenAI

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -527,7 +527,8 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   def for_api(%_{} = _model, %Function{} = fun) do
     %{
       "name" => fun.name,
-      "parameters" => get_parameters(fun)
+      "parameters" => get_parameters(fun),
+      "strict" => fun.strict
     }
     |> Utils.conditionally_add_to_map("description", fun.description)
   end

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -338,7 +338,8 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
                "name" => "hello_world",
                "description" => "Give a hello world greeting",
                #  NOTE: Sends the required empty parameter definition when none set
-               "parameters" => %{"properties" => %{}, "type" => "object"}
+               "parameters" => %{"properties" => %{}, "type" => "object"},
+               "strict" => false
              }
     end
 
@@ -374,7 +375,8 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert result == %{
                "name" => "say_hi",
                "description" => "Provide a friendly greeting.",
-               "parameters" => params_def
+               "parameters" => params_def,
+               "strict" => false
              }
     end
 
@@ -407,7 +409,8 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert result == %{
                "name" => "say_hi",
                "description" => "Provide a friendly greeting.",
-               "parameters" => params_def
+               "parameters" => params_def,
+               "strict" => false
              }
     end
 


### PR DESCRIPTION
The `strict` field defined in `Function` was not being reflected in the resulting schema when passed to `ChatOpenAI`.