### PR TITLE
fix exception when using jsonprocessor and mode :while_needs_response

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -888,9 +888,9 @@ defmodule LangChain.Chains.LLMChain do
           Message.t() | {:halted, Message.t(), Message.t()}
   def run_message_processors(
         %LLMChain{message_processors: processors} = chain,
-        %Message{role: :assistant} = message
+        %Message{role: :assistant, content: message_content} = message
       )
-      when is_list(processors) and processors != [] do
+      when is_list(processors) and processors != [] and is_list(message_content) and message_content != [] do
     # start `processed_content` with the message's content as a string
     message = %Message{message | processed_content: ContentPart.parts_to_string(message.content)}
 
@@ -919,7 +919,7 @@ defmodule LangChain.Chains.LLMChain do
     end)
   end
 
-  # the message is not an assistant message. Skip message processing.
+  # the message is not an assistant message or there is no content to process. Skip message processing.
   def run_message_processors(%LLMChain{} = _chain, %Message{} = message) do
     message
   end

--- a/lib/message_processors/json_processor.ex
+++ b/lib/message_processors/json_processor.ex
@@ -154,6 +154,7 @@ defmodule LangChain.MessageProcessors.JsonProcessor do
           run(chain, %Message{message | processed_content: json})
 
         _ ->
+          IO.puts("failed to find json, message.process_content=#{message.processed_content}")
           {:halt, Message.new_user!("ERROR: No JSON found")}
       end
     end)

--- a/lib/message_processors/json_processor.ex
+++ b/lib/message_processors/json_processor.ex
@@ -154,7 +154,6 @@ defmodule LangChain.MessageProcessors.JsonProcessor do
           run(chain, %Message{message | processed_content: json})
 
         _ ->
-          IO.puts("failed to find json, message.process_content=#{message.processed_content}")
           {:halt, Message.new_user!("ERROR: No JSON found")}
       end
     end)


### PR DESCRIPTION
was running into failure when using mode :while_needs_response and using message_processors with JsonProcessor. the run_while_needs_response/1 would call do_run/1 then get a single message response and call process_message/2 which calls run_message_processors/2 but the message.content is nil because its a tool call message.
we would then fail at:
message = %Message{message | processed_content: ContentPart.parts_to_string(message.content)}
when we try to call parts_to_string/1 which expects to get a list instead of nil
perhaps another solution is to add `ContentPart.parts_to_string(nil) -> nil`
