### PR TITLE
Convert Message.ContentParts to string for ollama

### DIFF
--- a/test/chat_models/chat_ollama_ai_test.exs
+++ b/test/chat_models/chat_ollama_ai_test.exs
@@ -600,7 +600,11 @@ defmodule ChatModels.ChatOllamaAITest do
 
       assert %Message{} = struct = ChatOllamaAI.do_process_response(model, response)
       assert struct.role == :assistant
-      assert struct.content == "Greetings!"
+
+      assert struct.content == [
+               %LangChain.Message.ContentPart{type: :text, content: "Greetings!", options: []}
+             ]
+
       assert struct.index == nil
     end
 


### PR DESCRIPTION
The current state of ollama is broken because Message.new* creates a list of Message.ContentParts where the ollama api expects a string.