### PR TITLE
feat: add configurable tokenizer to text splitters

### DIFF
--- a/lib/text_splitter.ex
+++ b/lib/text_splitter.ex
@@ -11,8 +11,8 @@ defmodule LangChain.TextSplitter do
   end
 
   defp merge_split_helper(d, acc, text_splitter, separator) do
-    separator_len = String.length(separator)
-    len = String.length(d)
+    separator_len = text_splitter.tokenizer.(separator)
+    len = text_splitter.tokenizer.(d)
 
     test_separator_length =
       if Enum.count(acc.current_doc) > 0, do: separator_len, else: 0
@@ -30,7 +30,7 @@ defmodule LangChain.TextSplitter do
         acc.total -
           (acc.current_doc
            |> Enum.at(0, "")
-           |> String.length()) - separator_length
+           |> text_splitter.tokenizer.()) - separator_length
 
       new_current_doc = acc.current_doc |> Enum.drop(1)
 
@@ -59,11 +59,11 @@ defmodule LangChain.TextSplitter do
       |> Enum.reduce(
         acc,
         fn d, acc ->
-          len = String.length(d)
+          len = text_splitter.tokenizer.(d)
 
           separator_length =
             if Enum.count(acc.current_doc) > 0,
-              do: String.length(plain_separator),
+              do: text_splitter.tokenizer.(plain_separator),
               else: 0
 
           acc =
@@ -84,7 +84,7 @@ defmodule LangChain.TextSplitter do
 
           separator_length =
             if Enum.count(acc.current_doc) > 1,
-              do: String.length(plain_separator),
+              do: text_splitter.tokenizer.(plain_separator),
               else: 0
 
           %{acc | total: acc.total + separator_length + len}

--- a/lib/text_splitter/character_text_splitter.ex
+++ b/lib/text_splitter/character_text_splitter.ex
@@ -5,8 +5,8 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
   This splitter provides consistent chunk sizes.
   It operates as follows:
 
-  - It splits the text at specified `separator` characters.  
-  - It takes a `chunk_size` parameter that determines the maximum number of characters
+  - It splits the text at specified `separator` characters.
+  - It takes a `chunk_size` parameter that determines the maximum number of tokens
     in each chunk.
   - If no separator is found within the `chunk_size`,
     it will create a chunk larger than the specified size.
@@ -17,10 +17,11 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
 
   A `CharacterTextSplitter` is defined using a schema.
   * `separator` - String that splits a given text.
-  * `chunk_size` - Integer number of characters that a chunk should have.
-  * `chunk_overlap` - Integer number of characters that two consecutive chunks should share.
+  * `chunk_size` - Integer number of tokens that a chunk should have.
+  * `chunk_overlap` - Integer number of tokens that two consecutive chunks should share.
   * `keep_separator` - Either `:discard_separator`, `:start` or `:end`. If `:discard_separator`, the separator is discarded from the output chunks. `:start` and `:end` keep the separator at the start or end of the output chunks. Defaults to `:discard_separator`.
   * `is_separator_regex` - Boolean defaulting to `false`. If `true`, the `separator` string is not escaped. Defaults to `false`
+  * `tokenizer` - Function that takes a string and returns the number of tokens. Defaults to `&String.length/1`.
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -39,6 +40,7 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
       default: :discard_separator
 
     field :is_separator_regex, :boolean, default: false
+    field :tokenizer, :any, virtual: true, default: &String.length/1
   end
 
   @type t :: %CharacterTextSplitter{}
@@ -48,7 +50,8 @@ defmodule LangChain.TextSplitter.CharacterTextSplitter do
     :chunk_size,
     :chunk_overlap,
     :keep_separator,
-    :is_separator_regex
+    :is_separator_regex,
+    :tokenizer
   ]
   @create_fields @update_fields
 

--- a/test/text_splitter_test.exs
+++ b/test/text_splitter_test.exs
@@ -201,6 +201,28 @@ defmodule TextSplitterTest do
         assert output == expected_output
       end
     end
+
+    test "Custom tokenizer function" do
+      text = "foo bar baz"
+      # Custom tokenizer that counts words instead of characters
+      word_tokenizer = fn text -> text |> String.split() |> length() end
+
+      expected_output = ["foo bar", "baz"]
+
+      character_splitter =
+        CharacterTextSplitter.new!(%{
+          separator: " ",
+          chunk_size: 2,
+          chunk_overlap: 0,
+          tokenizer: word_tokenizer
+        })
+
+      output =
+        character_splitter
+        |> CharacterTextSplitter.split_text(text)
+
+      assert output == expected_output
+    end
   end
 
   describe "RecursiveCharacterTextSplitter" do
@@ -299,6 +321,27 @@ Bye!\n\n-I."
           keep_separator: :start,
           chunk_size: 10,
           chunk_overlap: 1
+        })
+
+      output = splitter |> RecursiveCharacterTextSplitter.split_text(text)
+      assert output == expected_output
+    end
+  end
+
+  describe "Custom tokenizer functionality" do
+    test "RecursiveCharacterTextSplitter with word tokenizer" do
+      text = "Hello world. This is a test. Another sentence here."
+      # Custom tokenizer that counts words instead of characters
+      word_tokenizer = fn text -> text |> String.split() |> length() end
+
+      expected_output = ["Hello world", ". This is", "a test", ". Another sentence", "here."]
+
+      splitter =
+        RecursiveCharacterTextSplitter.new!(%{
+          separators: [". ", " "],
+          chunk_size: 3,
+          chunk_overlap: 0,
+          tokenizer: word_tokenizer
         })
 
       output = splitter |> RecursiveCharacterTextSplitter.split_text(text)
@@ -497,7 +540,7 @@ message Person {
     string name = 1;
     int32 age = 2;
     repeated string hobbies = 3;
-}      
+}
     "
 
       expected_splits = [
@@ -539,7 +582,7 @@ function helloWorld() {
 }
 
 // Call the function
-helloWorld();      
+helloWorld();
     "
 
       expected_splits = [
@@ -1264,7 +1307,7 @@ end
 
         -- Some sample functions
         add :: Int -> Int -> Int
-        add x y = x + y      
+        add x y = x + y
     "
 
       expected_splits = [


### PR DESCRIPTION
## Problem
The text splitters (CharacterTextSplitter and RecursiveCharacterTextSplitter) currently use character count (String.length/1) for determining chunk sizes. This is good but in most cases we would like to use tokenizers that mimic what llms use (for example https://github.com/openai/tiktoken), so it would be good to pass custom tokenizer function instead.

## Proposed solution
- Added a configurable tokenizer field to both text splitter modules:
- Backward Compatible: Default tokenizer remains &String.length/1

Example usage:
```
# Custom word tokenizer
word_tokenizer = fn text -> text |> String.split() |> length() end
splitter = CharacterTextSplitter.new!(%{
  chunk_size: 50,  # 50 words instead of characters
  tokenizer: word_tokenizer
})
```

should resolve https://github.com/brainlid/langchain/issues/311