### PR TITLE
feat: Add structured output support to ChatMistralAI 

### DIFF
--- a/lib/chat_models/chat_mistral_ai.ex
+++ b/lib/chat_models/chat_mistral_ai.ex
@@ -56,6 +56,12 @@ defmodule LangChain.ChatModels.ChatMistralAI do
     # For choosing a specific tool call (like forcing a function execution).
     field :tool_choice, :map
 
+    # JSON Schema to validate the output format (for structured JSON output)
+    field :json_schema, :map
+
+    # Whether to force a JSON response format
+    field :json_response, :boolean, default: false
+
     # A list of callback handlers
     field :callbacks, {:array, :map}, default: []
   end
@@ -73,7 +79,9 @@ defmodule LangChain.ChatModels.ChatMistralAI do
     :safe_prompt,
     :random_seed,
     :stream,
-    :tool_choice
+    :tool_choice,
+    :json_schema,
+    :json_response
   ]
   @required_fields [
     :model
@@ -126,6 +134,38 @@ defmodule LangChain.ChatModels.ChatMistralAI do
     |> Utils.conditionally_add_to_map(:max_tokens, mistral.max_tokens)
     |> Utils.conditionally_add_to_map(:tools, get_tools_for_api(mistral, tools))
     |> Utils.conditionally_add_to_map(:tool_choice, get_tool_choice(mistral))
+    |> Utils.conditionally_add_to_map(:response_format, set_response_format(mistral))
+  end
+
+  # Creates the response_format field for JSON output when json_response is true.
+  # If json_schema is provided, it will be included in the response format.
+  #
+  # For Mistral, the format is as follows:
+  # https://docs.mistral.ai/capabilities/structured-output/custom_structured_output/
+  # {
+  #   "type": "json_schema",
+  #   "json_schema": {
+  #     "schema": { ... },
+  #     "name": "output",
+  #     "strict": true
+  #   }
+  # }
+  @spec set_response_format(t()) :: map() | nil
+  defp set_response_format(%ChatMistralAI{json_response: true, json_schema: schema})
+       when is_map(schema) and map_size(schema) > 0 do
+    # The schema should already be in the correct format
+    schema
+  end
+
+  defp set_response_format(%ChatMistralAI{json_response: true}) do
+    # For Mistral, when no schema is provided, we use json_object type
+    %{
+      "type" => "json_object"
+    }
+  end
+
+  defp set_response_format(%ChatMistralAI{}) do
+    nil
   end
 
   # Add a more complete function to map tools. This mirrors ChatOpenAI approach.
@@ -676,7 +716,9 @@ defmodule LangChain.ChatModels.ChatMistralAI do
         :max_tokens,
         :safe_prompt,
         :random_seed,
-        :stream
+        :stream,
+        :json_schema,
+        :json_response
       ],
       @current_config_version
     )

--- a/test/chat_models/chat_mistral_ai_test.exs
+++ b/test/chat_models/chat_mistral_ai_test.exs
@@ -568,7 +568,8 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
 
       assert_received {:fired_token_usage, usage}
       assert %TokenUsage{input: 18} = usage
-      assert usage.output in [4, 5]  # Allow for slight variation in token count
+      # Allow for slight variation in token count
+      assert usage.output in [4, 5]
     end
 
     @tag live_call: true, live_mistral_ai: true
@@ -611,7 +612,8 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
 
       assert_received {:fired_token_usage, usage}
       assert %TokenUsage{input: 18} = usage
-      assert usage.output in [4, 5]  # Allow for slight variation in token count
+      # Allow for slight variation in token count
+      assert usage.output in [4, 5]
     end
 
     @tag live_call: true, live_mistral_ai: true

--- a/test/chat_models/chat_mistral_ai_test.exs
+++ b/test/chat_models/chat_mistral_ai_test.exs
@@ -354,7 +354,9 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
                "random_seed" => 42,
                "safe_prompt" => true,
                "top_p" => 1.0,
-               "version" => 1
+               "version" => 1,
+               "json_response" => false,
+               "json_schema" => nil
              }
     end
   end
@@ -367,6 +369,160 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
 
       refute inspect(changeset) =~ "1234567890"
       assert inspect(changeset) =~ "**redacted**"
+    end
+  end
+
+  describe "structured output support" do
+    test "new/1 accepts json_response and json_schema fields" do
+      schema = %{
+        "type" => "json_schema",
+        "json_schema" => %{
+          "schema" => %{
+            "properties" => %{
+              "name" => %{"title" => "Name", "type" => "string"},
+              "authors" => %{
+                "items" => %{"type" => "string"},
+                "title" => "Authors",
+                "type" => "array"
+              }
+            },
+            "required" => ["name", "authors"],
+            "title" => "Book",
+            "type" => "object",
+            "additionalProperties" => false
+          },
+          "name" => "book",
+          "strict" => true
+        }
+      }
+
+      assert {:ok, %ChatMistralAI{} = mistral_ai} =
+               ChatMistralAI.new(%{
+                 "model" => "ministral-8b-latest",
+                 "json_response" => true,
+                 "json_schema" => schema
+               })
+
+      assert mistral_ai.json_response == true
+      assert mistral_ai.json_schema == schema
+    end
+
+    test "for_api/3 includes response_format when json_response is true with schema" do
+      schema = %{
+        "type" => "json_schema",
+        "json_schema" => %{
+          "schema" => %{
+            "properties" => %{
+              "name" => %{"title" => "Name", "type" => "string"},
+              "authors" => %{
+                "items" => %{"type" => "string"},
+                "title" => "Authors",
+                "type" => "array"
+              }
+            },
+            "required" => ["name", "authors"],
+            "title" => "Book",
+            "type" => "object",
+            "additionalProperties" => false
+          },
+          "name" => "book",
+          "strict" => true
+        }
+      }
+
+      mistral_ai =
+        ChatMistralAI.new!(%{
+          "model" => "ministral-8b-latest",
+          "json_response" => true,
+          "json_schema" => schema
+        })
+
+      data = ChatMistralAI.for_api(mistral_ai, [], [])
+
+      assert data.response_format == schema
+    end
+
+    test "for_api/3 includes response_format when json_response is true without schema" do
+      mistral_ai =
+        ChatMistralAI.new!(%{
+          "model" => "ministral-8b-latest",
+          "json_response" => true
+        })
+
+      data = ChatMistralAI.for_api(mistral_ai, [], [])
+
+      assert data.response_format == %{"type" => "json_object"}
+    end
+
+    test "for_api/3 does not include response_format when json_response is false" do
+      mistral_ai =
+        ChatMistralAI.new!(%{
+          "model" => "ministral-8b-latest",
+          "json_response" => false
+        })
+
+      data = ChatMistralAI.for_api(mistral_ai, [], [])
+
+      refute Map.has_key?(data, :response_format)
+    end
+
+    test "serialize_config/1 includes json_response and json_schema fields" do
+      schema = %{
+        "type" => "json_schema",
+        "json_schema" => %{
+          "schema" => %{
+            "properties" => %{
+              "name" => %{"title" => "Name", "type" => "string"}
+            },
+            "required" => ["name"],
+            "title" => "Book",
+            "type" => "object"
+          },
+          "name" => "book",
+          "strict" => true
+        }
+      }
+
+      model =
+        ChatMistralAI.new!(%{
+          "model" => "ministral-8b-latest",
+          "json_response" => true,
+          "json_schema" => schema
+        })
+
+      result = ChatMistralAI.serialize_config(model)
+
+      assert result["json_response"] == true
+      assert result["json_schema"] == schema
+    end
+
+    test "restore_from_map/1 restores json_response and json_schema fields" do
+      schema = %{
+        "type" => "json_schema",
+        "json_schema" => %{
+          "schema" => %{
+            "properties" => %{
+              "name" => %{"title" => "Name", "type" => "string"}
+            },
+            "required" => ["name"],
+            "title" => "Book",
+            "type" => "object"
+          },
+          "name" => "book",
+          "strict" => true
+        }
+      }
+
+      config = %{
+        "version" => 1,
+        "model" => "ministral-8b-latest",
+        "json_response" => true,
+        "json_schema" => schema
+      }
+
+      assert {:ok, %ChatMistralAI{} = restored} = ChatMistralAI.restore_from_map(config)
+      assert restored.json_response == true
+      assert restored.json_schema == schema
     end
   end
 
@@ -402,7 +558,7 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
       # returns a list of MessageDeltas. A list of a list because it's "n" choices.
       assert result == [
                %Message{
-                 content: "Colorful Threads",
+                 content: [ContentPart.text!("Colorful Threads")],
                  status: :complete,
                  role: :assistant,
                  index: 0,
@@ -411,7 +567,8 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
              ]
 
       assert_received {:fired_token_usage, usage}
-      assert %TokenUsage{input: 18, output: 4} = usage
+      assert %TokenUsage{input: 18} = usage
+      assert usage.output in [4, 5]  # Allow for slight variation in token count
     end
 
     @tag live_call: true, live_mistral_ai: true
@@ -453,7 +610,8 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
       assert result_string == "Colorful Threads"
 
       assert_received {:fired_token_usage, usage}
-      assert %TokenUsage{input: 18, output: 4} = usage
+      assert %TokenUsage{input: 18} = usage
+      assert usage.output in [4, 5]  # Allow for slight variation in token count
     end
 
     @tag live_call: true, live_mistral_ai: true
@@ -483,6 +641,93 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
 
       tool_call_msg = Enum.find(result, fn [msg] -> msg.tool_calls != nil end)
       assert [%MessageDelta{tool_calls: [%ToolCall{name: "current_time"}]}] = tool_call_msg
+    end
+
+    @tag live_call: true, live_mistral_ai: true
+    test "structured output with JSON schema works" do
+      schema = %{
+        "type" => "json_schema",
+        "json_schema" => %{
+          "schema" => %{
+            "properties" => %{
+              "name" => %{"title" => "Name", "type" => "string"},
+              "authors" => %{
+                "items" => %{"type" => "string"},
+                "title" => "Authors",
+                "type" => "array"
+              }
+            },
+            "required" => ["name", "authors"],
+            "title" => "Book",
+            "type" => "object",
+            "additionalProperties" => false
+          },
+          "name" => "book",
+          "strict" => true
+        }
+      }
+
+      chat =
+        ChatMistralAI.new!(%{
+          temperature: 0,
+          model: "ministral-8b-latest",
+          stream: false,
+          json_response: true,
+          json_schema: schema
+        })
+
+      {:ok, result} =
+        ChatMistralAI.call(
+          chat,
+          [
+            Message.new_system!("Extract the books information."),
+            Message.new_user!("I recently read To Kill a Mockingbird by Harper Lee.")
+          ],
+          []
+        )
+
+      assert [%Message{content: content, status: :complete, role: :assistant}] = result
+
+      # The content should be a valid JSON string that matches our schema
+      assert is_list(content)
+      assert [%ContentPart{type: :text, content: json_content}] = content
+      assert is_binary(json_content)
+      {:ok, parsed_json} = Jason.decode(json_content)
+
+      # Verify the structure matches our schema
+      assert %{"name" => name, "authors" => authors} = parsed_json
+      assert is_binary(name)
+      assert is_list(authors)
+      assert Enum.all?(authors, &is_binary/1)
+    end
+
+    @tag live_call: true, live_mistral_ai: true
+    test "structured output with json_object type works" do
+      chat =
+        ChatMistralAI.new!(%{
+          temperature: 0,
+          model: "ministral-8b-latest",
+          stream: false,
+          json_response: true
+        })
+
+      {:ok, result} =
+        ChatMistralAI.call(
+          chat,
+          [
+            Message.new_system!("Extract the books information and return as JSON."),
+            Message.new_user!("I recently read To Kill a Mockingbird by Harper Lee.")
+          ],
+          []
+        )
+
+      assert [%Message{content: content, status: :complete, role: :assistant}] = result
+
+      # The content should be a valid JSON string
+      assert is_list(content)
+      assert [%ContentPart{type: :text, content: json_content}] = content
+      assert is_binary(json_content)
+      assert {:ok, _parsed_json} = Jason.decode(json_content)
     end
   end
 end


### PR DESCRIPTION
# Add Structured Output Support to ChatMistralAI

The `ChatMistralAI` module does not have  support for Mistral's structured output feature yet.

## Solution

- **New fields**: `json_response` (boolean) and `json_schema` (map)
- **Response formats**: Support for both `json_object` (free-form) and `json_schema` (strict validation)

## Example

**With JSON Schema:**
```elixir
chat = ChatMistralAI.new!(%{
  model: "ministral-8b-latest",
  json_response: true,
  json_schema: %{
    "type" => "json_schema",
    "json_schema" => %{
      "schema" => %{"properties" => %{"name" => %{"type" => "string"}}},
      "name" => "output",
      "strict" => true
    }
  }
})
```

**Free-form JSON:**
```elixir
chat = ChatMistralAI.new!(%{
  model: "ministral-8b-latest",
  json_response: true
})
```