### PR TITLE
Fix: Add token usage to ChatGoogleAI message metadata

### DIFF
--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -619,6 +619,77 @@ defmodule ChatModels.ChatGoogleAITest do
       assert error.type == "unexpected_response"
       assert error.message == "Unexpected response"
     end
+
+    test "handles receiving a message with token usage", %{model: model} do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{"role" => "model", "parts" => [%{"text" => "Hello User!"}]},
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ],
+        "usageMetadata" => %{
+          "promptTokenCount" => 10,
+          "candidatesTokenCount" => 5,
+          "totalTokenCount" => 15
+        }
+      }
+
+      assert [%Message{} = struct] = ChatGoogleAI.do_process_response(model, response)
+      assert struct.role == :assistant
+      [%ContentPart{type: :text, content: "Hello User!"}] = struct.content
+      assert struct.index == 0
+      assert struct.status == :complete
+
+      # Verify that token usage is properly included in metadata
+      assert %TokenUsage{} = struct.metadata.usage
+      assert struct.metadata.usage.input == 10
+      assert struct.metadata.usage.output == 5
+      assert struct.metadata.usage.raw == %{
+        "promptTokenCount" => 10,
+        "candidatesTokenCount" => 5,
+        "totalTokenCount" => 15
+      }
+    end
+
+    test "handles receiving MessageDelta with token usage", %{model: model} do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "role" => "model",
+              "parts" => [%{"text" => "This is a partial message"}]
+            },
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ],
+        "usageMetadata" => %{
+          "promptTokenCount" => 8,
+          "candidatesTokenCount" => 3,
+          "totalTokenCount" => 11
+        }
+      }
+
+      assert [%MessageDelta{} = struct] =
+               ChatGoogleAI.do_process_response(model, response, MessageDelta)
+
+      assert struct.role == :assistant
+      assert struct.content == "This is a partial message"
+      assert struct.index == 0
+      assert struct.status == :incomplete
+
+      # Verify that token usage is properly included in metadata
+      assert %TokenUsage{} = struct.metadata.usage
+      assert struct.metadata.usage.input == 8
+      assert struct.metadata.usage.output == 3
+      assert struct.metadata.usage.raw == %{
+        "promptTokenCount" => 8,
+        "candidatesTokenCount" => 3,
+        "totalTokenCount" => 11
+      }
+    end
   end
 
   describe "filter_parts_for_types/2" do


### PR DESCRIPTION
# Problem
ChatGoogleAI was inconsistent with other chat models in how it handled token usage information. While it extracted token usage from API responses and fired callbacks correctly, it wasn't adding the usage data to the message metadata like ChatOpenAI and ChatAnthropic do.

# Solution
- Modified do_process_response/3 in ChatGoogleAI to use TokenUsage.set/2 to add token usage to each processed message
- This follows the same pattern used by ChatOpenAI and ChatAnthropic
