### PR TITLE
Add `retry: transient` to Req for Anthropic models in stream mode

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -613,7 +613,8 @@ defmodule LangChain.ChatModels.ChatAnthropic do
       json: raw_data,
       headers: headers(anthropic),
       receive_timeout: anthropic.receive_timeout,
-      aws_sigv4: aws_sigv4_opts(anthropic.bedrock)
+      aws_sigv4: aws_sigv4_opts(anthropic.bedrock),
+      retry: :transient
     )
     |> Req.post(
       into:


### PR DESCRIPTION
If in streaming mode for Anthropic models, old connections would often close, causing an error. This leans on Req's built in retry mechanism to perform the default number of attempts to reopen the connection before throwing an error. This mechanism is in place for non streaming mode, but not streaming mode in the Anthropic Chat Model.