### PR TITLE
fix: Fixes empty list responses from models

### DIFF
--- a/.elixir-tools/next-ls.log
+++ b/.elixir-tools/next-ls.log
@@ -1,0 +1,2 @@
+
+16:10:28.495 [info] Loading 158 CA(s) from :otp store

--- a/.elixir-tools/next-ls.log
+++ b/.elixir-tools/next-ls.log
@@ -1,2 +1,0 @@
-
-16:10:28.495 [info] Loading 158 CA(s) from :otp store

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -760,11 +760,11 @@ defmodule LangChain.Chains.LLMChain do
     message_response =
       module.call(use_llm, chain.messages, chain.tools)
       |> then(fn
-        {:ok, messages} ->
+        {:ok, messages} when is_list(messages) ->
           {:ok, Enum.reject(messages, &(&1 == []))}
 
-        error ->
-          error
+        non_list_or_error ->
+          non_list_or_error
       end)
 
     # handle and output response


### PR DESCRIPTION
Observed that OpenAPI on Azure returns an empty list in responses. 

o3-mini on Azure returns `{:ok, [[], [%LangChain.MessageDelta{content: \\\"\\\", ...}`

To make this more efficient we can match on `{:ok, [[] | rest]} -> {:ok, rest}`

Fixes: https://github.com/brainlid/langchain/issues/330

