### PR TITLE
fix: Require gettext ~> 0.26

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule LangChain.MixProject do
   defp deps do
     [
       {:ecto, "~> 3.10 or ~> 3.11"},
-      {:gettext, "~> 0.20"},
+      {:gettext, "~> 0.26"},
       {:req, ">= 0.5.2"},
       {:nimble_parsec, "~> 1.4", optional: true},
       {:abacus, "~> 2.1.0", optional: true},


### PR DESCRIPTION
The change to gettext's setup in https://github.com/brainlid/langchain/pull/271 requires 0.26 or higher, so we should reflect this in mix.exs.

Note that this will expose projects using langchain to the same warning fixed in that PR.

Context: https://hexdocs.pm/gettext/changelog.html#v0-26-0