### PR TITLE
feat: Add organization ID as a parameter

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -206,6 +206,10 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     # customer to provide their own.
     field :api_key, :string, redact: true
 
+    # Organization ID for OpenAI. If not set, will use global org_id. Allows for usage
+    # of a different organization ID per-call if desired.
+    field :org_id, :string, redact: true
+
     # What sampling temperature to use, between 0 and 2. Higher values like 0.8
     # will make the output more random, while lower values like 0.2 will make it
     # more focused and deterministic.
@@ -271,6 +275,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     :temperature,
     :frequency_penalty,
     :api_key,
+    :org_id,
     :seed,
     :n,
     :stream,
@@ -293,10 +298,9 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     api_key || Config.resolve(:openai_key, "")
   end
 
-  @spec get_org_id() :: String.t() | nil
-  defp get_org_id() do
-    Config.resolve(:openai_org_id)
-  end
+  @spec get_org_id(t()) :: String.t() | nil
+  defp get_org_id(%ChatOpenAI{org_id: org_id}) when is_binary(org_id), do: org_id
+  defp get_org_id(%ChatOpenAI{}), do: Config.resolve(:openai_org_id)
 
   @spec get_proj_id() :: String.t() | nil
   defp get_proj_id() do
@@ -735,7 +739,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       )
 
     req
-    |> maybe_add_org_id_header()
+    |> maybe_add_org_id_header(openai)
     |> maybe_add_proj_id_header()
     |> Req.post()
     # parse the body and return it as parsed structs
@@ -805,7 +809,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       ],
       receive_timeout: openai.receive_timeout
     )
-    |> maybe_add_org_id_header()
+    |> maybe_add_org_id_header(openai)
     |> maybe_add_proj_id_header()
     |> Req.post(
       into: Utils.handle_stream_fn(openai, &decode_stream/1, &do_process_response(openai, &1))
@@ -1123,8 +1127,8 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     nil
   end
 
-  defp maybe_add_org_id_header(%Req.Request{} = req) do
-    org_id = get_org_id()
+  defp maybe_add_org_id_header(%Req.Request{} = req, %ChatOpenAI{} = openai) do
+    org_id = get_org_id(openai)
 
     if org_id do
       Req.Request.put_header(req, "OpenAI-Organization", org_id)

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -2323,7 +2323,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert inspect(changeset) =~ "**redacted**"
     end
 
-    test "does not redact org_id" do
+    test "redacts org_id" do
       chain = ChatOpenAI.new!()
 
       changeset = Ecto.Changeset.cast(chain, %{org_id: "test-org-123"}, [:org_id])

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -104,6 +104,16 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       %ChatOpenAI{} = openai = ChatOpenAI.new!(%{"reasoning_effort" => "high"})
       assert openai.reasoning_effort == "high"
     end
+
+    test "supports setting org_id" do
+      # defaults to nil
+      %ChatOpenAI{} = openai = ChatOpenAI.new!()
+      assert openai.org_id == nil
+
+      # can override the default to "test-org-123"
+      %ChatOpenAI{} = openai = ChatOpenAI.new!(%{"org_id" => "test-org-123"})
+      assert openai.org_id == "test-org-123"
+    end
   end
 
   describe "for_api/3" do
@@ -2214,6 +2224,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       result = ChatOpenAI.serialize_config(model)
       assert result["version"] == 1
       refute Map.has_key?(result, "api_key")
+      refute Map.has_key?(result, "org_id")
       refute Map.has_key?(result, "callbacks")
     end
 
@@ -2309,6 +2320,15 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       changeset = Ecto.Changeset.cast(chain, %{api_key: "1234567890"}, [:api_key])
 
       refute inspect(changeset) =~ "1234567890"
+      assert inspect(changeset) =~ "**redacted**"
+    end
+
+    test "does not redact org_id" do
+      chain = ChatOpenAI.new!()
+
+      changeset = Ecto.Changeset.cast(chain, %{org_id: "test-org-123"}, [:org_id])
+
+      refute inspect(changeset) =~ "test-org-123"
       assert inspect(changeset) =~ "**redacted**"
     end
   end


### PR DESCRIPTION
Add support for organization ID as a parameter in the OpenAI chat model. This allows users to specify the organization context when making requests, enabling better management of resources and access control within the OpenAI API.
The change includes updates to the `ChatOpenAI` module and its tests to ensure the organization ID is correctly passed and utilized in API calls.