### PR TITLE
feat: Add image and file template support to PromptTemplate

### DIFF
--- a/test/prompt_template_test.exs
+++ b/test/prompt_template_test.exs
@@ -430,5 +430,43 @@ What is the answer to 1 + 1?)
       assert part.content ==
                "Incorporate relevant information from the following data:\n\nmore!!\n"
     end
+
+    test "converts image template to image ContentPart" do
+      template = PromptTemplate.image_template!("<%= @image_data %>")
+      part = PromptTemplate.to_content_part!(template, %{image_data: "base64data"})
+      assert part.type == :image
+      assert part.content == "base64data"
+    end
+
+    test "converts file template to file ContentPart" do
+      template = PromptTemplate.file_template!("<%= @file_data %>")
+      part = PromptTemplate.to_content_part!(template, %{file_data: "base64data"})
+      assert part.type == :file
+      assert part.content == "base64data"
+    end
+  end
+
+  describe "to_messages!/2 with content types" do
+    test "converts image and file templates to messages" do
+      image_template = PromptTemplate.image_template!("<%= @image_data %>")
+      file_template = PromptTemplate.file_template!("<%= @file_data %>")
+
+      messages =
+        PromptTemplate.to_messages!([image_template, file_template], %{
+          image_data: "img_data",
+          file_data: "file_data"
+        })
+
+      assert length(messages) == 2
+      [image_msg, file_msg] = messages
+
+      [image_part] = image_msg.content
+      assert image_part.type == :image
+      assert image_part.content == "img_data"
+
+      [file_part] = file_msg.content
+      assert file_part.type == :file
+      assert file_part.content == "file_data"
+    end
   end
 end


### PR DESCRIPTION
Hi!

I was working on a project using AshAi and tried to send images to the AI provider. There is a snippet in AshAi:

```elixir
run prompt(
  ChatOpenAI.new!(%{model: "gpt-4o"}),
  prompt: [
    Message.new_system!("You are an expert at image analysis"),
    Message.new_user!([
      PromptTemplate.from_template!("Extra context: <%= @input.arguments.context %>"),
      ContentPart.image!("<%= @input.arguments.image_data %>", media: :jpg, detail: "low")
    ])
  ]
)
```

Since the intention of Ash is to be declarative, this is the desired way of declaring a prompt inside of an action. However, it doesn't actually work. The template in ContentPart.image! is taken as a string.

This PR adds support for `PromptTemplate.image_template!` and PromptTemplate.file_template!` so that it is possible to specify content parts with different types.

Please let me know if I should bring this up in an issue first.

Best,
MArco