### PR TITLE
Add missing verbose_api field to ChatOllamaAI for streaming compatibility

### DIFF
--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -439,10 +439,16 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
         tools,
         retry_count
       ) do
+    raw_data = for_api(ollama_ai, messages, tools)
+
+    if ollama_ai.verbose_api do
+      IO.inspect(raw_data, label: "RAW DATA BEING SUBMITTED")
+    end
+
     req =
       Req.new(
         url: ollama_ai.endpoint,
-        json: for_api(ollama_ai, messages, tools),
+        json: raw_data,
         receive_timeout: ollama_ai.receive_timeout,
         retry: :transient,
         max_retries: 3,
@@ -453,7 +459,11 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
     req
     |> Req.post()
     |> case do
-      {:ok, %Req.Response{body: data}} ->
+      {:ok, %Req.Response{body: data} = response} ->
+        if ollama_ai.verbose_api do
+          IO.inspect(response, label: "RAW REQ RESPONSE")
+        end
+
         case do_process_response(ollama_ai, data) do
           {:error, reason} ->
             {:error, reason}
@@ -492,9 +502,15 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
         tools,
         retry_count
       ) do
+    raw_data = for_api(ollama_ai, messages, tools)
+
+    if ollama_ai.verbose_api do
+      IO.inspect(raw_data, label: "RAW DATA BEING SUBMITTED")
+    end
+
     Req.new(
       url: ollama_ai.endpoint,
-      json: for_api(ollama_ai, messages, tools),
+      json: raw_data,
       inet6: true,
       receive_timeout: ollama_ai.receive_timeout
     )

--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -78,7 +78,8 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
     :temperature,
     :tfs_z,
     :top_k,
-    :top_p
+    :top_p,
+    :verbose_api
   ]
 
   @required_fields [:endpoint, :model]
@@ -166,6 +167,10 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
 
     # A list of maps for callback handlers (treat as private)
     field :callbacks, {:array, :map}, default: []
+
+    # For help with debugging. It outputs the RAW Req response received and the
+    # RAW Elixir map being submitted to the API.
+    field :verbose_api, :boolean, default: false
   end
 
   @doc """
@@ -617,7 +622,8 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
         :temperature,
         :tfs_z,
         :top_k,
-        :top_p
+        :top_p,
+        :verbose_api
       ],
       @current_config_version
     )

--- a/test/chat_models/chat_ollama_ai_test.exs
+++ b/test/chat_models/chat_ollama_ai_test.exs
@@ -43,6 +43,14 @@ defmodule ChatModels.ChatOllamaAITest do
 
       assert model.endpoint == override_url
     end
+
+    test "supports verbose_api option" do
+      model = ChatOllamaAI.new!(%{model: "llama2", verbose_api: true})
+      assert model.verbose_api == true
+
+      model = ChatOllamaAI.new!(%{model: "llama2", verbose_api: false})
+      assert model.verbose_api == false
+    end
   end
 
   describe "for_api/3" do
@@ -673,6 +681,12 @@ defmodule ChatModels.ChatOllamaAITest do
       refute Map.has_key?(result, "callbacks")
     end
 
+    test "includes verbose_api field" do
+      model = ChatOllamaAI.new!(%{model: "llama2", verbose_api: true})
+      result = ChatOllamaAI.serialize_config(model)
+      assert result["verbose_api"] == true
+    end
+
     test "creates expected map" do
       model =
         ChatOllamaAI.new!(%{
@@ -709,6 +723,7 @@ defmodule ChatModels.ChatOllamaAITest do
                "tfs_z" => 1.0,
                "top_k" => 40,
                "top_p" => 0.9,
+               "verbose_api" => false,
                "version" => 1
              }
     end


### PR DESCRIPTION
 ## Problem
  ChatOllamaAI was missing the `verbose_api` field that exists in all other chat models (OpenAI, Anthropic, GoogleAI, VertexAI). This caused streaming to fail with a `KeyError` when the streaming utilities tried to access `model.verbose_api`.

  ## Solution
  - Added `verbose_api` field to ChatOllamaAI struct with `default: false`
  - Included in `@create_fields` for proper initialization
  - Added to `serialize_config` for persistence
  - Added comprehensive test coverage

  ## Testing
  - ✅ All existing tests pass
  - ✅ New tests added for `verbose_api` functionality
  - ✅ Verified streaming now works without errors
  - ✅ Tested ContentParts v0.4.x compatibility confirmed

  ## Changes
  - `lib/chat_models/chat_ollama_ai.ex`: Added verbose_api field and configuration
  - `test/chat_models/chat_ollama_ai_test.exs`: Added tests for verbose_api

  This brings ChatOllamaAI in line with other chat model implementations and enables the same debugging capabilities.

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] This change requires a documentation update (adds new field)

  ## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have added tests that prove my fix is effective
  - [x] New and existing unit tests pass locally with my changes