### PR TITLE
feat: add run mode: step

### DIFF
--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -1541,6 +1541,265 @@ defmodule LangChain.Chains.LLMChainTest do
       assert updated_chain.current_failure_count == 3
     end
 
+    test "mode: :step - last message is user message -> returns tool calls and stops", %{
+      chain: chain,
+      hello_world: hello_world
+    } do
+      fake_messages = [
+        new_function_calls!([
+          ToolCall.new!(%{call_id: "call_fake123", name: "hello_world", arguments: nil})
+        ])
+      ]
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, fake_messages}
+      end)
+
+      {:ok, updated_chain} =
+        chain
+        |> LLMChain.add_tools([hello_world])
+        |> LLMChain.add_message(Message.new_system!())
+        |> LLMChain.add_message(Message.new_user!("Say hello!"))
+        |> LLMChain.run(mode: :step)
+
+      assert updated_chain.last_message.role == :assistant
+
+      assert [%ToolCall{name: "hello_world", call_id: "call_fake123"}] =
+               updated_chain.last_message.tool_calls
+
+      assert updated_chain.needs_response == true
+
+      assert length(updated_chain.exchanged_messages) == 1
+      assert hd(updated_chain.exchanged_messages) == updated_chain.last_message
+    end
+
+    test "mode: :step - last message is tool call -> executes tool and returns tool results", %{
+      chain: chain,
+      hello_world: hello_world
+    } do
+      tool_call_message = new_function_call!("call_fake123", "hello_world", "{}")
+
+      chain_with_tool_call =
+        chain
+        |> LLMChain.add_tools([hello_world])
+        |> LLMChain.add_message(Message.new_system!())
+        |> LLMChain.add_message(Message.new_user!("Say hello!"))
+        |> LLMChain.add_message(tool_call_message)
+
+      {:ok, updated_chain} = LLMChain.run(chain_with_tool_call, mode: :step)
+
+      assert updated_chain.last_message.role == :tool
+
+      assert [
+               %ToolResult{
+                 content: [
+                   %LangChain.Message.ContentPart{
+                     type: :text,
+                     content: "Hello world!",
+                     options: []
+                   }
+                 ],
+                 tool_call_id: "call_fake123",
+                 is_error: false
+               }
+             ] =
+               updated_chain.last_message.tool_results
+
+      assert updated_chain.needs_response == true
+
+      assert length(updated_chain.exchanged_messages) == 1
+      assert hd(updated_chain.exchanged_messages) == updated_chain.last_message
+    end
+
+    test "mode: :step - last message is tool result -> returns assistant comment", %{
+      chain: chain,
+      hello_world: hello_world
+    } do
+      tool_result = ToolResult.new!(%{tool_call_id: "call_fake123", content: "Hello world!"})
+      tool_result_message = Message.new_tool_result!(%{content: nil, tool_results: [tool_result]})
+
+      chain_with_tool_result =
+        chain
+        |> LLMChain.add_tools([hello_world])
+        |> LLMChain.add_message(Message.new_system!())
+        |> LLMChain.add_message(Message.new_user!("Say hello!"))
+        |> LLMChain.add_message(new_function_call!("call_fake123", "hello_world", "{}"))
+        |> LLMChain.add_message(tool_result_message)
+
+      fake_messages = [
+        Message.new_assistant!(%{content: "I said hello using the hello_world function!"})
+      ]
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, fake_messages}
+      end)
+
+      {:ok, updated_chain} = LLMChain.run(chain_with_tool_result, mode: :step)
+
+      assert updated_chain.last_message.role == :assistant
+
+      assert updated_chain.last_message.content == [
+               %LangChain.Message.ContentPart{
+                 type: :text,
+                 content: "I said hello using the hello_world function!",
+                 options: []
+               }
+             ]
+
+      assert updated_chain.last_message.tool_calls == []
+      assert updated_chain.needs_response == false
+
+      assert length(updated_chain.exchanged_messages) == 1
+      assert hd(updated_chain.exchanged_messages) == updated_chain.last_message
+    end
+
+    test "mode: :step - multiple steps to complete a full interaction", %{
+      chain: chain,
+      greet: greet
+    } do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok,
+         [
+           new_function_calls!([
+             ToolCall.new!(%{
+               call_id: "call_greet",
+               name: "greet",
+               arguments: %{"name" => "Alice"}
+             })
+           ])
+         ]}
+      end)
+
+      {:ok, step1_chain} =
+        chain
+        |> LLMChain.add_tools([greet])
+        |> LLMChain.add_message(Message.new_system!())
+        |> LLMChain.add_message(Message.new_user!("Please greet Alice"))
+        |> LLMChain.run(mode: :step)
+
+      assert step1_chain.last_message.role == :assistant
+      assert [%ToolCall{name: "greet"}] = step1_chain.last_message.tool_calls
+      assert step1_chain.needs_response == true
+
+      {:ok, step2_chain} = LLMChain.run(step1_chain, mode: :step)
+
+      assert step2_chain.last_message.role == :tool
+
+      assert [
+               %ToolResult{
+                 content: [
+                   %LangChain.Message.ContentPart{type: :text, content: "Hi Alice!", options: []}
+                 ],
+                 is_error: false
+               }
+             ] =
+               step2_chain.last_message.tool_results
+
+      assert step2_chain.needs_response == true
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!(%{content: "I've greeted Alice for you!"})]}
+      end)
+
+      {:ok, step3_chain} = LLMChain.run(step2_chain, mode: :step)
+
+      assert step3_chain.last_message.role == :assistant
+
+      assert step3_chain.last_message.content == [
+               %LangChain.Message.ContentPart{
+                 type: :text,
+                 content: "I've greeted Alice for you!",
+                 options: []
+               }
+             ]
+
+      assert step3_chain.last_message.tool_calls == []
+      assert step3_chain.needs_response == false
+    end
+
+    test "mode: :step - supports fallbacks", %{chain: chain, hello_world: hello_world} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:error, LangChainError.exception(type: "rate_limited", message: "Rate limited")}
+      end)
+
+      expect(ChatAnthropic, :call, fn _model, _messages, _tools ->
+        {:ok,
+         [
+           new_function_calls!([
+             ToolCall.new!(%{call_id: "call_fallback", name: "hello_world", arguments: nil})
+           ])
+         ]}
+      end)
+
+      {:ok, updated_chain} =
+        chain
+        |> LLMChain.add_tools([hello_world])
+        |> LLMChain.add_message(Message.new_system!())
+        |> LLMChain.add_message(Message.new_user!("Say hello!"))
+        |> LLMChain.run(
+          mode: :step,
+          with_fallbacks: [ChatAnthropic.new!(%{stream: false})]
+        )
+
+      assert updated_chain.last_message.role == :assistant
+
+      assert [%ToolCall{name: "hello_world", call_id: "call_fallback"}] =
+               updated_chain.last_message.tool_calls
+    end
+
+    test "mode: :step - handles tool execution errors", %{chain: chain, fail_func: fail_func} do
+      tool_call_message = new_function_call!("call_fail", "fail_func", "{}")
+
+      chain_with_tool_call =
+        chain
+        |> LLMChain.add_tools([fail_func])
+        |> LLMChain.add_message(Message.new_system!())
+        |> LLMChain.add_message(Message.new_user!("Execute the failing function"))
+        |> LLMChain.add_message(tool_call_message)
+
+      {:ok, updated_chain} = LLMChain.run(chain_with_tool_call, mode: :step)
+
+      assert updated_chain.last_message.role == :tool
+
+      assert [
+               %ToolResult{
+                 content: [
+                   %LangChain.Message.ContentPart{
+                     type: :text,
+                     content: "Not what I wanted",
+                     options: []
+                   }
+                 ],
+                 is_error: true
+               }
+             ] =
+               updated_chain.last_message.tool_results
+
+      assert updated_chain.current_failure_count == 1
+      assert updated_chain.needs_response == true
+    end
+
+    test "mode: :step - processes message processors correctly", %{chain: chain} do
+      fake_messages = [
+        Message.new_assistant!(%{content: "Initial response"})
+      ]
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, fake_messages}
+      end)
+
+      {:ok, updated_chain} =
+        chain
+        |> LLMChain.message_processors([&fake_success_processor/2])
+        |> LLMChain.add_message(Message.new_system!())
+        |> LLMChain.add_message(Message.new_user!("Test message"))
+        |> LLMChain.run(mode: :step)
+
+      assert updated_chain.last_message.processed_content == "Initial response *"
+
+      assert updated_chain.needs_response == false
+    end
+
     test "with_fallbacks: re-runs with next LLM after first fails" do
       # Made NOT LIVE here - handles two calls
       expect(ChatOpenAI, :call, fn _model, _messages, _tools ->


### PR DESCRIPTION
Hey 👋

This PR introduces a new mode called `step` for `LangChain.Chains.LLMChain.run/2`.

## Context

At Cloudwalk, we are using Langchain to serve 4M users, all with an active assistant.
With that, we have been hitting a few use cases that are not supported by langchain which has made us use a [fork](https://github.com/cloudwalk/langchain/tree/o-3-3-with-stop) with an option to raise an error from tool calls.
This has been hard to keep up with new releases and also contribute back to the project.

## The problem

The existing chain execution modes (`:until_success`, `:while_needs_response`, and the default mode) don't provide the granular control we need for deterministic workflows in regulated environments.
**Our core challenge**: We need to conditionally stop execution based on which tools are called, but the current modes force us to decide the execution strategy upfront, before we know what tools the LLM will choose.
Consider this hipothetical scenario: We have a chain with two tools:

- `wire_transfer(amount, account)` - Executes a money transfer. **Must stop for user confirmation**.
- `user_debts()` - Returns outstanding debts. **Should continue to let LLM explain the results**.

The problem becomes apparent when a user says "Pay my debts":

1. LLM calls user_debts() to check what's owed ✅
2. Tool returns debt information ✅
3. LLM calls wire_transfer() to pay the debts ⚠️
4. We needed to stop here for confirmation, but we can't

### Why existing modes fail:

`:until_success` - Stops after the first successful tool call. Works for `wire_transfer` but fails for `user_debts` (No explanation of the result).
`:while_needs_response` - Continues until LLM provides a final response. Works for `user_debts` but fails for `wire_transfer` (Will explain the tool result, it shouldn't).
Default mode - Behaves like `:until_success`, same limitations.

| Use Case      | `:until_success`     | `:while_needs_response`         | What We Need             |
| ------------- | -------------------- | ------------------------------- | ------------------------ |
| Wire Transfer | ✅ Stops correctly    | ❌ Continues, executes transfer  | Stop after tool call     |
| Check Debts   | ❌ No LLM explanation | ✅ Provides explanation          | Continue after tool call |
| Pay Debts     | ❌ Stops too early    | ❌ Doesn't stop for confirmation | Conditional stopping     |


**The fundamental issue**: We can't know which execution mode we need until we see which tools the LLM decides to call. By then, we're already committed to a mode that might be wrong for the scenario.

What we need is the ability to inspect the chain state after each step and decide whether to continue - giving us the control to implement the deterministic behavior our regulated environment requires.

## The solution

Optionally giving control of the loop. While the loop has served and still is serving us well for some use cases it imposes the aforementioned limitations.
A **stepped execution will give clients control over execution to implement their own loops**. While still being able to call other modes in the middle of the execution.

With this mode we are able to stop on the major chain events: assistant response, tool calls and tool responses.
While still leveraging fallback models and all the data modeling from Langchain.

```elixir
def custom_run(chain, opts \\ []) do
  {:ok, updated_chain} = LLMChain.run(chain, opts ++ [mode: :step])

  if check_some_condition(updated_chain) do
    {:ok, updated_chain}
  else
    custom_run(updated_chain, opts)
  end
end
```

This allows clients to inspect the entire chain state and even alter chain state between executions.
For our use case, this will allow us to achieve the UX we need, and will allow new use cases like extending the chain with dynamic few-shot examples/tools in mid execution for example.
