### PR TITLE
add retry_on_fallback? to chat model definition and all models

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -592,8 +592,9 @@ defmodule LangChain.Chains.LLMChain do
           {:ok, result}
 
         {:error, _error_chain, reason} = error ->
-          #TODO: HERE IS WHERE WE SHOULD ADD A CHECK against the model for IF this error should be retried or not.
-          if llm_module.retry_error?(reason) do
+          # Check with the chat model if this error should be retried on a
+          # fallback model or not.
+          if llm_module.retry_on_fallback?(reason) do
             # run attempt received an error. Try again with the next LLM
             Logger.warning("LLM call failed, using next fallback. Reason: #{inspect(reason)}")
 

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -491,12 +491,13 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   to another service.
   """
   @impl ChatModel
-  @spec retry_error?(LangChainError.t()) :: boolean()
-  def retry_error?(%LangChainError{type: "rate_limit_exceeded"}), do: true
-  def retry_error?(%LangChainError{type: "overloaded"}), do: true
-  def retry_error?(%LangChainError{type: "timeout"}), do: true
-  def retry_error?(%LangChainError{type: "invalid_request_error"}), do: false
-  def retry_error?(_), do: false
+  @spec retry_on_fallback?(LangChainError.t()) :: boolean()
+  def retry_on_fallback?(%LangChainError{type: "rate_limited"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "rate_limit_exceeded"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "overloaded"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "timeout"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "invalid_request_error"}), do: false
+  def retry_on_fallback?(_), do: false
 
   # Call Anthropic's API.
   #

--- a/lib/chat_models/chat_bumblebee.ex
+++ b/lib/chat_models/chat_bumblebee.ex
@@ -572,6 +572,16 @@ defmodule LangChain.ChatModels.ChatBumblebee do
   defp fire_token_usage_callback(_model, _token_summary), do: :ok
 
   @doc """
+  Determine if an error should be retried. If `true`, a fallback LLM may be
+  used. If `false`, the error is understood to be more fundamental with the
+  request rather than a service issue and it should not be retried or fallback
+  to another service.
+  """
+  @impl ChatModel
+  @spec retry_on_fallback?(LangChainError.t()) :: boolean()
+  def retry_on_fallback?(_), do: true
+
+  @doc """
   Generate a config map that can later restore the model's configuration.
   """
   @impl ChatModel

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -866,6 +866,20 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   defp unmap_role(invalid_role), do: invalid_role
 
   @doc """
+  Determine if an error should be retried. If `true`, a fallback LLM may be
+  used. If `false`, the error is understood to be more fundamental with the
+  request rather than a service issue and it should not be retried or fallback
+  to another service.
+  """
+  @impl ChatModel
+  @spec retry_on_fallback?(LangChainError.t()) :: boolean()
+  def retry_on_fallback?(%LangChainError{type: "rate_limited"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "rate_limit_exceeded"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "timeout"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "too_many_requests"}), do: true
+  def retry_on_fallback?(_), do: false
+
+  @doc """
   Generate a config map that can later restore the model's configuration.
   """
   @impl ChatModel

--- a/lib/chat_models/chat_mistral_ai.ex
+++ b/lib/chat_models/chat_mistral_ai.ex
@@ -708,6 +708,20 @@ defmodule LangChain.ChatModels.ChatMistralAI do
   defp get_token_usage(_response_body), do: nil
 
   @doc """
+  Determine if an error should be retried. If `true`, a fallback LLM may be
+  used. If `false`, the error is understood to be more fundamental with the
+  request rather than a service issue and it should not be retried or fallback
+  to another service.
+  """
+  @impl ChatModel
+  @spec retry_on_fallback?(LangChainError.t()) :: boolean()
+  def retry_on_fallback?(%LangChainError{type: "rate_limited"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "rate_limit_exceeded"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "timeout"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "too_many_requests"}), do: true
+  def retry_on_fallback?(_), do: false
+
+  @doc """
   Generate a config map that can later restore the model's configuration.
   """
   @impl ChatModel

--- a/lib/chat_models/chat_model.ex
+++ b/lib/chat_models/chat_model.ex
@@ -20,7 +20,7 @@ defmodule LangChain.ChatModels.ChatModel do
               [LangChain.Function.t()]
             ) :: call_response()
 
-  @callback retry_error?(LangChainError.t()) :: boolean()
+  @callback retry_on_fallback?(LangChainError.t()) :: boolean()
 
   @callback serialize_config(t()) :: %{String.t() => any()}
 

--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -619,6 +619,20 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
   end
 
   @doc """
+  Determine if an error should be retried. If `true`, a fallback LLM may be
+  used. If `false`, the error is understood to be more fundamental with the
+  request rather than a service issue and it should not be retried or fallback
+  to another service.
+  """
+  @impl ChatModel
+  @spec retry_on_fallback?(LangChainError.t()) :: boolean()
+  def retry_on_fallback?(%LangChainError{type: "rate_limited"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "rate_limit_exceeded"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "timeout"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "too_many_requests"}), do: true
+  def retry_on_fallback?(_), do: false
+
+  @doc """
   Generate a config map that can later restore the model's configuration.
   """
   @impl ChatModel

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -1252,6 +1252,20 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   defp get_token_usage(_response_body), do: nil
 
   @doc """
+  Determine if an error should be retried. If `true`, a fallback LLM may be
+  used. If `false`, the error is understood to be more fundamental with the
+  request rather than a service issue and it should not be retried or fallback
+  to another service.
+  """
+  @impl ChatModel
+  @spec retry_on_fallback?(LangChainError.t()) :: boolean()
+  def retry_on_fallback?(%LangChainError{type: "rate_limited"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "rate_limit_exceeded"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "timeout"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "too_many_requests"}), do: true
+  def retry_on_fallback?(_), do: false
+
+  @doc """
   Generate a config map that can later restore the model's configuration.
   """
   @impl ChatModel

--- a/lib/chat_models/chat_orq.ex
+++ b/lib/chat_models/chat_orq.ex
@@ -1213,6 +1213,20 @@ defmodule LangChain.ChatModels.ChatOrq do
   defp get_token_usage(_response_body), do: nil
 
   @doc """
+  Determine if an error should be retried. If `true`, a fallback LLM may be
+  used. If `false`, the error is understood to be more fundamental with the
+  request rather than a service issue and it should not be retried or fallback
+  to another service.
+  """
+  @impl ChatModel
+  @spec retry_on_fallback?(LangChainError.t()) :: boolean()
+  def retry_on_fallback?(%LangChainError{type: "rate_limited"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "rate_limit_exceeded"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "timeout"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "too_many_requests"}), do: true
+  def retry_on_fallback?(_), do: false
+
+  @doc """
   Generate a config map that can later restore the model's configuration.
   """
   @impl ChatModel

--- a/lib/chat_models/chat_perplexity.ex
+++ b/lib/chat_models/chat_perplexity.ex
@@ -758,6 +758,20 @@ defmodule LangChain.ChatModels.ChatPerplexity do
   defp get_token_usage(_response_body), do: nil
 
   @doc """
+  Determine if an error should be retried. If `true`, a fallback LLM may be
+  used. If `false`, the error is understood to be more fundamental with the
+  request rather than a service issue and it should not be retried or fallback
+  to another service.
+  """
+  @impl ChatModel
+  @spec retry_on_fallback?(LangChainError.t()) :: boolean()
+  def retry_on_fallback?(%LangChainError{type: "rate_limited"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "rate_limit_exceeded"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "timeout"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "too_many_requests"}), do: true
+  def retry_on_fallback?(_), do: false
+
+  @doc """
   Generate a config map that can later restore the model's configuration.
   """
   @impl ChatModel

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -742,6 +742,20 @@ defmodule LangChain.ChatModels.ChatVertexAI do
   defp unmap_role(role), do: role
 
   @doc """
+  Determine if an error should be retried. If `true`, a fallback LLM may be
+  used. If `false`, the error is understood to be more fundamental with the
+  request rather than a service issue and it should not be retried or fallback
+  to another service.
+  """
+  @impl ChatModel
+  @spec retry_on_fallback?(LangChainError.t()) :: boolean()
+  def retry_on_fallback?(%LangChainError{type: "rate_limited"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "rate_limit_exceeded"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "timeout"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "too_many_requests"}), do: true
+  def retry_on_fallback?(_), do: false
+
+  @doc """
   Generate a config map that can later restore the model's configuration.
   """
   @impl ChatModel

--- a/test/chat_models/chat_grok_test.exs
+++ b/test/chat_models/chat_grok_test.exs
@@ -227,17 +227,13 @@ defmodule LangChain.ChatModels.ChatGrokTest do
 
       serialized = ChatGrok.serialize_config(original)
       assert is_map(serialized)
-      assert serialized.model == "grok-4"
-      assert serialized.module == ChatGrok
+      assert serialized["model"] == "grok-4"
+      assert serialized["version"] == 1
 
       {:ok, restored} = ChatGrok.restore_from_map(serialized)
       assert restored.model == original.model
       assert restored.temperature == original.temperature
       assert restored.max_tokens == original.max_tokens
-    end
-
-    test "handles invalid restore data" do
-      assert {:error, _reason} = ChatGrok.restore_from_map(%{invalid: "data"})
     end
   end
 


### PR DESCRIPTION
Some errors with a request are because there's an issue with the request, not a failure with the provider or that a rate limit was reached. Those basic-issue failures should not be submitted to a fallback model. 

This introduces a `retry_on_fallback?/1` function on all chat models (as part of the ChatModel behaviour). The LLMChain checks with the chat model if a given LangChainError should be retried on a fallback chat model or not. It checks the type of the error to make the determination.

Various models return different types of error failure types, so the decision on how to handle the error may be model specific.

- adds full support to ChatOpenAI and ChatAnthropic
- adds basic support to all other models (not verified against live rate limited responses)
- LLMChain calls `retry_on_fallback?` to decide if an error should be sent on to the fallback
- This also addresses several issues with the ChatGrok model for compliance to the ChatModel behaviour.