### PR TITLE
Prevent crash when ToolResult with string in ChatGoogleAI.for_api/1

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -360,9 +360,12 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   end
 
   def for_api(%ToolResult{} = result) do
-    content =
+    content_string =
       result.content
       |> ContentPart.parts_to_string()
+
+    content =
+      content_string
       |> Jason.decode()
       |> case do
         {:ok, data} ->
@@ -371,7 +374,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
 
         {:error, %Jason.DecodeError{}} ->
           # assume the result is intended to be a string and return it as-is
-          %{"result" => result.content}
+          %{"result" => content_string}
       end
 
     # There is no explanation for why they want it nested like this. Odd.

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -290,15 +290,7 @@ defmodule ChatModels.ChatGoogleAITest do
           "name" => "find_theaters",
           "response" => %{
             "name" => "find_theaters",
-            "content" => %{
-              "movie" => "Barbie",
-              "theaters" => [
-                %{
-                  "name" => "AMC",
-                  "address" => "2000 W El Camino Real"
-                }
-              ]
-            }
+            "content" => %{"result" => "I don't know where the theaters are."}
           }
         }
       }
@@ -307,16 +299,7 @@ defmodule ChatModels.ChatGoogleAITest do
         ToolResult.new!(%{
           name: "find_theaters",
           tool_call_id: "call-find_theaters",
-          content:
-            Jason.encode!(%{
-              "movie" => "Barbie",
-              "theaters" => [
-                %{
-                  "name" => "AMC",
-                  "address" => "2000 W El Camino Real"
-                }
-              ]
-            })
+          content: "I don't know where the theaters are."
         })
 
       assert expected == ChatGoogleAI.for_api(tool_result)


### PR DESCRIPTION
This PR resolves crash in `for_api/1` when `ToolResult` content is a string.

The original bug caused the following error during the process of converting the API request input to json.

```
** (Protocol.UndefinedError) protocol Jason.Encoder not implemented for type LangChain.Message.ContentPart (a struct), Jason.Encoder protocol must always be explicitly implemented.
```