### PR TITLE
 Bedrock OpenAI-compatible API compatibility fix

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -233,7 +233,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     # Number between -2.0 and 2.0. Positive values penalize new tokens based on
     # their existing frequency in the text so far, decreasing the model's
     # likelihood to repeat the same line verbatim.
-    field :frequency_penalty, :float, default: 0.0
+    field :frequency_penalty, :float, default: nil
 
     # Used when working with a reasoning model like `o1` and newer. This setting
     # is required when working with those models as the API behavior needs to
@@ -367,7 +367,6 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     %{
       model: openai.model,
       temperature: openai.temperature,
-      frequency_penalty: openai.frequency_penalty,
       n: openai.n,
       stream: openai.stream,
       # a single ToolResult can expand into multiple tool messages for OpenAI
@@ -385,6 +384,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
         |> Enum.reverse(),
       user: openai.user
     }
+    |> Utils.conditionally_add_to_map(:frequency_penalty, openai.frequency_penalty)
     |> Utils.conditionally_add_to_map(:response_format, set_response_format(openai))
     |> Utils.conditionally_add_to_map(
       :reasoning_effort,

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -136,6 +136,12 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert data[:response_format] == nil
     end
 
+    test "when frequency_penalty is not explicitly configured, it is not specified in the API call" do
+      {:ok, openai} = ChatOpenAI.new(%{"model" => @test_model})
+      data = ChatOpenAI.for_api(openai, [], [])
+      assert data[:frequency_penalty] == nil
+    end
+
     test "generates a map for an API call with JSON response set to true" do
       {:ok, openai} =
         ChatOpenAI.new(%{


### PR DESCRIPTION
Bedrock has support for the gpt-oss models via an OpenAI-compatible API [1] [2].

To test, create a Bedrock API key in the console [3] and configure `ChatOpenAI` with it, a supported gpt-oss model and the correct endpoint:

```elixir
      ChatOpenAI.new(%{
        model: "openai.gpt-oss-120b-1:0",
        api_key: api_key,
        endpoint: "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1/chat/completions",
      })
```

I had to stop `frequency_penalty` from being sent in order to get past this error: "The 'frequency_penalty' parameter is not supported". This should have no effect on existing code since the parameter is optional and also defaults to 0 (the same as this config) [4]

It'd be nice if support for this new OpenAI-compatible API was extended to the other models on Bedrock 🤞 

[1] https://aws.amazon.com/blogs/aws/openai-open-weight-models-now-available-on-aws/
[2] https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions.html
[3] https://us-west-2.console.aws.amazon.com/bedrock/home?region=us-west-2#/api-keys?tab=short-term
[4] https://platform.openai.com/docs/api-reference/introduction