### PR TITLE
only include "user" with OpenAI request when a value is provided

### DIFF
--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -50,6 +50,7 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
   alias LangChain.FunctionParam
   alias LangChain.LangChainError
   alias LangChain.Utils
+  alias LangChain.Callbacks
 
   @behaviour ChatModel
 

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -381,9 +381,9 @@ defmodule LangChain.ChatModels.ChatOpenAI do
               Enum.reverse(data) ++ acc
           end
         end)
-        |> Enum.reverse(),
-      user: openai.user
+        |> Enum.reverse()
     }
+    |> Utils.conditionally_add_to_map(:user, openai.user)
     |> Utils.conditionally_add_to_map(:frequency_penalty, openai.frequency_penalty)
     |> Utils.conditionally_add_to_map(:response_format, set_response_format(openai))
     |> Utils.conditionally_add_to_map(


### PR DESCRIPTION
- fixes an Ollama compiler warning and callback issue