### PR TITLE
fix: handle missing finish_reason in streaming responses for LiteLLM compatibility

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -1008,8 +1008,10 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   # Delta message tool call
   def do_process_response(
         model,
-        %{"delta" => delta_body, "finish_reason" => finish, "index" => index} = _msg
+        %{"delta" => delta_body, "index" => index} = msg
       ) do
+    # finish_reason might not be present in all streaming responses (e.g., LiteLLM proxy)
+    finish = Map.get(msg, "finish_reason", nil)
     status = finish_reason_to_status(finish)
 
     tool_calls =


### PR DESCRIPTION
- Modified do_process_response to handle streaming deltas without finish_reason field
- Added test case for LiteLLM proxy response format with tool calls
- Maintains backward compatibility with standard OpenAI responses

This fix enables compatibility with LiteLLM proxy and other OpenAI-compatible endpoints that may omit the finish_reason field in streaming delta responses.

🤖 Generated with [Claude Code](https://claude.ai/code)