### PR TITLE
Add `parallel_tool_calls` option to `ChatOpenAI` model

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -119,6 +119,14 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   By default, the LLM will choose a tool call if a tool is available and it
   determines it is needed. That's the "auto" mode.
 
+  ## Parallel Tool Calls
+
+  By default, OpenAI models may decide to make multiple tool calls at once,
+  including calling the same tool multiple times. You can limit this behavior by
+  setting the `parallel_tool_calls`
+  [option](https://platform.openai.com/docs/api-reference/chat/create#chat_create-parallel_tool_calls)
+  to false.
+
   ### Example
   For the LLM's response to make a tool call of the "get_weather" function.
 

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -270,6 +270,8 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     # Tool choice option
     field :tool_choice, :map
 
+    field :parallel_tool_calls, :boolean
+
     # A list of maps for callback handlers (treated as internal)
     field :callbacks, {:array, :map}, default: []
 
@@ -304,6 +306,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     :stream_options,
     :user,
     :tool_choice,
+    :parallel_tool_calls,
     :verbose_api
   ]
   @required_fields [:endpoint, :model]
@@ -398,6 +401,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     )
     |> Utils.conditionally_add_to_map(:tools, get_tools_for_api(openai, tools))
     |> Utils.conditionally_add_to_map(:tool_choice, get_tool_choice(openai))
+    |> Utils.conditionally_add_to_map(:parallel_tool_calls, openai.parallel_tool_calls)
   end
 
   defp get_tools_for_api(%_{} = _model, nil), do: []

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -116,6 +116,16 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       %ChatOpenAI{} = openai = ChatOpenAI.new!(%{"org_id" => "test-org-123"})
       assert openai.org_id == "test-org-123"
     end
+
+    test "supports passing parallel_tool_calls" do
+      # defaults to nil
+      %ChatOpenAI{} = openai = ChatOpenAI.new!()
+      assert openai.parallel_tool_calls == nil
+
+      # can override the default to "test-org-123"
+      %ChatOpenAI{} = openai = ChatOpenAI.new!(%{"parallel_tool_calls" => false})
+      assert openai.parallel_tool_calls == false
+    end
   end
 
   describe "for_api/3" do
@@ -134,6 +144,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert data.frequency_penalty == 0.5
       # NOTE: %{"type" => "text"} is the default when not specified
       assert data[:response_format] == nil
+      assert data[:parallel_tool_calls] == nil
     end
 
     test "when frequency_penalty is not explicitly configured, it is not specified in the API call" do
@@ -237,6 +248,18 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       data = ChatOpenAI.for_api(openai, [], [])
       assert data.model == @test_model
       assert data.tool_choice == %{"type" => "function", "function" => %{"name" => "set_weather"}}
+    end
+
+    test "generated a map for an API call with parallel_tool_calls set to false" do
+      {:ok, openai} =
+        ChatOpenAI.new(%{
+          model: @test_model,
+          parallel_tool_calls: false
+        })
+
+      data = ChatOpenAI.for_api(openai, [], [])
+      assert data.model == @test_model
+      assert data.parallel_tool_calls == false
     end
   end
 


### PR DESCRIPTION
I couldn't find an escape hatch that would allow me to pass `parallel_tool_calls: false` to the OpenAI API endpoint, so naturally here's a PR adding an explicit support for it!