### PR TITLE
Add optional AWS session token handling in BedrockHelpers

### DIFF
--- a/lib/utils/bedrock_config.ex
+++ b/lib/utils/bedrock_config.ex
@@ -26,7 +26,8 @@ defmodule LangChain.Utils.BedrockConfig do
       config :langchain,
         aws_access_key_id: System.fetch_env!("AWS_ACCESS_KEY_ID"),
         aws_secret_access_key: System.fetch_env!("AWS_SECRET_ACCESS_KEY"),
-        aws_region: System.get_env("AWS_REGION", "us-west-1")
+        aws_region: System.get_env("AWS_REGION", "us-west-1"),
+        aws_session_token: System.get_env("AWS_SESSION_TOKEN") # optional
 
   Then, when you want to later use a Bedrock Anthropic model, this is will load
   it:
@@ -83,7 +84,8 @@ defmodule LangChain.Utils.BedrockConfig do
       config :langchain,
         aws_access_key_id: System.fetch_env!("AWS_ACCESS_KEY_ID"),
         aws_secret_access_key: System.fetch_env!("AWS_SECRET_ACCESS_KEY"),
-        aws_region: System.get_env("AWS_REGION", "us-west-1")
+        aws_region: System.get_env("AWS_REGION", "us-west-1"),
+        aws_session_token: System.get_env("AWS_SESSION_TOKEN") # optional
 
   """
   def from_application_env!() do

--- a/lib/utils/bedrock_config.ex
+++ b/lib/utils/bedrock_config.ex
@@ -95,8 +95,19 @@ defmodule LangChain.Utils.BedrockConfig do
           access_key_id: Application.fetch_env!(:langchain, :aws_access_key_id),
           secret_access_key: Application.fetch_env!(:langchain, :aws_secret_access_key)
         ]
+        |> maybe_add_token()
       end,
       region: Application.fetch_env!(:langchain, :aws_region)
     }
+  end
+
+  defp maybe_add_token(credentials) do
+    case Application.fetch_env(:langchain, :aws_session_token) do
+      {:ok, token} ->
+        Keyword.put(credentials, :token, token)
+
+      :error ->
+        credentials
+    end
   end
 end

--- a/test/support/bedrock_helpers.ex
+++ b/test/support/bedrock_helpers.ex
@@ -6,6 +6,7 @@ defmodule LangChain.BedrockHelpers do
           access_key_id: Application.fetch_env!(:langchain, :aws_access_key_id),
           secret_access_key: Application.fetch_env!(:langchain, :aws_secret_access_key)
         ]
+        |> maybe_add_token()
       end,
       region: Application.fetch_env!(:langchain, :aws_region)
     }
@@ -13,5 +14,15 @@ defmodule LangChain.BedrockHelpers do
 
   def prefix_for(api) do
     "#{api} API:"
+  end
+
+  defp maybe_add_token(credentials) do
+    case Application.fetch_env(:langchain, :aws_session_token) do
+      {:ok, token} ->
+        Keyword.put(credentials, :token, token)
+
+      :error ->
+        credentials
+    end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -21,6 +21,8 @@ Application.put_env(
   System.get_env("AWS_REGION", "us-east-1")
 )
 
+Mimic.copy(Application)
+
 Mimic.copy(LangChain.Utils.BedrockStreamDecoder)
 Mimic.copy(LangChain.Utils.AwsEventstreamDecoder)
 

--- a/test/utils/bedrock_config_test.exs
+++ b/test/utils/bedrock_config_test.exs
@@ -1,15 +1,21 @@
 defmodule LangChain.Utils.BedrockConfigTest do
+  alias Ecto.Changeset
   alias LangChain.Utils.BedrockConfig
   use ExUnit.Case, async: true
+  use Mimic
 
   test "supports aws credentials without session token" do
     Application
+    |> stub(:fetch_env!, fn app, key ->
+      case {app, key} do
+        {:langchain, :aws_access_key_id} -> "KEY"
+        {:langchain, :aws_secret_access_key} -> "SECRET"
+        {:langchain, :aws_region} -> "us-east-1"
+      end
+    end)
     |> stub(:fetch_env, fn :langchain, :aws_session_token -> :error end)
-    |> stub(:fetch_env!, fn :langchain, :aws_session_token -> :error end)
-    |> stub(:get_env, fn :langchain, :aws_region -> "us-east-1" end)
-    |> stub(:get_env, fn :langchain, :aws_session_token -> :error end)
 
-    bedrock_config = BedrockConfig.from_application_env!()
+    bedrock_config = bedrock_config()
 
     assert BedrockConfig.aws_sigv4_opts(bedrock_config) == [
              access_key_id: "KEY",
@@ -21,19 +27,29 @@ defmodule LangChain.Utils.BedrockConfigTest do
 
   test "supports aws credentials with session token" do
     Application
-    |> stub(:fetch_env, fn :langchain, :aws_session_token -> "TOKEN" end)
-    |> stub(:fetch_env!, fn :langchain, :aws_session_token -> "TOKEN" end)
-    |> stub(:get_env, fn :langchain, :aws_region -> "ap-southeast-2" end)
-    |> stub(:get_env, fn :langchain, :aws_session_token -> "TOKEN" end)
+    |> stub(:fetch_env!, fn app, key ->
+      case {app, key} do
+        {:langchain, :aws_access_key_id} -> "KEY"
+        {:langchain, :aws_secret_access_key} -> "SECRET"
+        {:langchain, :aws_region} -> "ap-southeast-2"
+      end
+    end)
+    |> stub(:fetch_env, fn :langchain, :aws_session_token -> {:ok, "TOKEN"} end)
 
-    bedrock_config = BedrockConfig.from_application_env!()
+    bedrock_config = bedrock_config()
 
     assert BedrockConfig.aws_sigv4_opts(bedrock_config) == [
+             token: "TOKEN",
              access_key_id: "KEY",
              secret_access_key: "SECRET",
-             token: "TOKEN",
              region: "ap-southeast-2",
              service: :bedrock
            ]
+  end
+
+  defp bedrock_config() do
+    %BedrockConfig{}
+    |> BedrockConfig.changeset(BedrockConfig.from_application_env!())
+    |> Changeset.apply_changes()
   end
 end

--- a/test/utils/bedrock_config_test.exs
+++ b/test/utils/bedrock_config_test.exs
@@ -3,10 +3,13 @@ defmodule LangChain.Utils.BedrockConfigTest do
   use ExUnit.Case, async: true
 
   test "supports aws credentials without session token" do
-    bedrock_config = %BedrockConfig{
-      credentials: fn -> [access_key_id: "KEY", secret_access_key: "SECRET"] end,
-      region: "us-east-1"
-    }
+    Application
+    |> stub(:fetch_env, fn :langchain, :aws_session_token -> :error end)
+    |> stub(:fetch_env!, fn :langchain, :aws_session_token -> :error end)
+    |> stub(:get_env, fn :langchain, :aws_region -> "us-east-1" end)
+    |> stub(:get_env, fn :langchain, :aws_session_token -> :error end)
+
+    bedrock_config = BedrockConfig.from_application_env!()
 
     assert BedrockConfig.aws_sigv4_opts(bedrock_config) == [
              access_key_id: "KEY",
@@ -17,10 +20,13 @@ defmodule LangChain.Utils.BedrockConfigTest do
   end
 
   test "supports aws credentials with session token" do
-    bedrock_config = %BedrockConfig{
-      credentials: fn -> [access_key_id: "KEY", secret_access_key: "SECRET", token: "TOKEN"] end,
-      region: "ap-southeast-2"
-    }
+    Application
+    |> stub(:fetch_env, fn :langchain, :aws_session_token -> "TOKEN" end)
+    |> stub(:fetch_env!, fn :langchain, :aws_session_token -> "TOKEN" end)
+    |> stub(:get_env, fn :langchain, :aws_region -> "ap-southeast-2" end)
+    |> stub(:get_env, fn :langchain, :aws_session_token -> "TOKEN" end)
+
+    bedrock_config = BedrockConfig.from_application_env!()
 
     assert BedrockConfig.aws_sigv4_opts(bedrock_config) == [
              access_key_id: "KEY",


### PR DESCRIPTION
This change allows for improved handling of AWS credentials, accommodating scenarios where a session token may be required (e.g. when use credentials given by AWS Sts)

- Introduced a new private function `maybe_add_token/1` to conditionally add the AWS session token to the credentials if it is available in the application environment.
- Updated the credentials retrieval logic to incorporate this new functionality, enhancing the flexibility of AWS credential management.

