### PR TITLE
fix(ChatGoogleAI): Handle cumulative token usage

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -915,7 +915,9 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     TokenUsage.new!(%{
       input: Map.get(usage, "promptTokenCount", 0),
       output: Map.get(usage, "candidatesTokenCount", 0),
-      raw: usage
+      raw: usage,
+      # Empirically, each delta's token usage includes the total token usage so far.
+      cumulative: true
     })
   end
 

--- a/lib/token_usage.ex
+++ b/lib/token_usage.ex
@@ -29,11 +29,15 @@ defmodule LangChain.TokenUsage do
     field :input, :integer
     field :output, :integer
     field :raw, :map, default: %{}
+    # For token usage attached to a MessageDelta, whether the token usage is cumulative
+    # (all tokens for the message so far) or just the token usage for this delta.
+    # Varies by model.
+    field :cumulative, :boolean, default: false
   end
 
   @type t :: %TokenUsage{}
 
-  @create_fields [:input, :output, :raw]
+  @create_fields [:input, :output, :raw, :cumulative]
   # Anthropic returns only the output token count when streaming deltas
   @required_fields []
 
@@ -101,6 +105,8 @@ defmodule LangChain.TokenUsage do
   def add(nil, nil), do: nil
   def add(nil, usage), do: usage
   def add(usage, nil), do: usage
+
+  def add(_, %TokenUsage{cumulative: true} = usage), do: usage
 
   def add(%TokenUsage{} = usage1, %TokenUsage{} = usage2) do
     new!(%{


### PR DESCRIPTION
When streaming with ChatGoogleAI, empirically, Google returns the *cumulative* token usage with each delta - unlike other models that return only the incremental token usage. Thus we need to avoid adding together the delta's token usages, instead just taking the last one.

I noticed this by comparing usage stats to those reported in [Helicone](https://www.helicone.ai/) for the same requests. With this PR, they match exactly.