### PR TITLE
fix(ChatGoogleAI): Prevent error from thinking content parts

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -327,19 +327,30 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   def for_api(%Message{content: content} = message) when is_list(content) do
     %{
       "role" => map_role(message.role),
-      "parts" => Enum.map(content, &for_api/1)
+      "parts" =>
+        Enum.map(content, &for_api/1)
+        |> List.flatten()
     }
   end
 
   def for_api(%Message{content: content} = message) when is_list(content) do
     %{
       "role" => map_role(message.role),
-      "parts" => Enum.map(content, &for_api/1)
+      "parts" =>
+        Enum.map(content, &for_api/1)
+        |> List.flatten()
     }
   end
 
   def for_api(%ContentPart{type: :text} = part) do
     %{"text" => part.content}
+  end
+
+  def for_api(%ContentPart{type: :thinking}) do
+    # The thinking parts are only thought summaries and are not meant to be
+    # included in future generation requests.
+    # See https://ai.google.dev/gemini-api/docs/thinking#summaries.
+    []
   end
 
   def for_api(%ContentPart{type: :file_url} = part) do
@@ -859,6 +870,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
 
   def get_message_contents(%{content: contents} = _message) when is_list(contents) do
     Enum.map(contents, &for_api/1)
+    |> List.flatten()
   end
 
   def get_message_contents(%{content: nil} = _message) do


### PR DESCRIPTION
If you enable thought summaries for ChatGoogleAI (using https://github.com/brainlid/langchain/pull/354) and then send a follow-up message, the :thinking content parts cause a "no function clause matching" error in `for_api`. This PR adds an empty case and some `List.flatten` calls to filter it out of the resulting lists.

(The :thinking parts are only thought summaries and are not meant to be included in future generation requests; see https://ai.google.dev/gemini-api/docs/thinking#summaries. There is a separate way to include thinking in future generation requests, [thought signatures](https://ai.google.dev/gemini-api/docs/thinking#signatures), but it is more complicated and only used alongside function calling.)

Error stack trace:
```
[error] ** (FunctionClauseError) no function clause matching in LangChain.ChatModels.ChatGoogleAI.for_api/1
    (langchain 0.4.0-rc.2) lib/chat_models/chat_google_ai.ex:303: LangChain.ChatModels.ChatGoogleAI.for_api(%LangChain.Message.ContentPart{type: :thinking, content: "**Acknowledging the Greeting**\n\nI've received a \"Hi\" message from the user. [...]", options: []})
    (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (langchain 0.4.0-rc.2) lib/chat_models/chat_google_ai.ex:304: LangChain.ChatModels.ChatGoogleAI.for_api/1
    (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (langchain 0.4.0-rc.2) lib/chat_models/chat_google_ai.ex:228: LangChain.ChatModels.ChatGoogleAI.for_api/3
    (langchain 0.4.0-rc.2) lib/chat_models/chat_google_ai.ex:584: LangChain.ChatModels.ChatGoogleAI.do_api_request/3
    (langchain 0.4.0-rc.2) lib/chat_models/chat_google_ai.ex:504: anonymous fn/3 in LangChain.ChatModels.ChatGoogleAI.call/3
    (langchain 0.4.0-rc.2) lib/telemetry.ex:135: LangChain.Telemetry.span/3
    (langchain 0.4.0-rc.2) lib/chains/llm_chain.ex:848: LangChain.Chains.LLMChain.do_run/1
    (langchain 0.4.0-rc.2) lib/telemetry.ex:135: LangChain.Telemetry.span/3
    (langchain 0.4.0-rc.2) lib/chains/llm_chain.ex:494: LangChain.Chains.LLMChain.run/2
```