### PR TITLE
Add Orq AI chat

### DIFF
--- a/lib/chat_models/chat_orq.ex
+++ b/lib/chat_models/chat_orq.ex
@@ -817,7 +817,7 @@ defmodule LangChain.ChatModels.ChatOrq do
 
     data_map =
       message
-      |> Map.update("content", [], &content_to_single_part/1)
+      |> Map.update("content", nil, &content_to_single_part/1)
       |> Map.put("index", data["index"])
       |> Map.put("status", status)
       |> Map.put("tool_calls", Enum.map(calls || [], &do_process_response(model, &1)))
@@ -877,7 +877,7 @@ defmodule LangChain.ChatModels.ChatOrq do
 
     data =
       message
-      |> Map.update("content", [], &content_to_single_part/1)
+      |> Map.update("content", nil, &content_to_single_part/1)
       |> Map.put("index", index)
       |> Map.put("status", status)
 
@@ -910,7 +910,7 @@ defmodule LangChain.ChatModels.ChatOrq do
 
     data =
       message_body
-      |> Map.update("content", [], &content_to_single_part/1)
+      |> Map.update("content", nil, &content_to_single_part/1)
       |> Map.put("index", index)
       |> Map.put("status", status)
       |> Map.put("tool_calls", tool_calls)
@@ -964,7 +964,7 @@ defmodule LangChain.ChatModels.ChatOrq do
 
     data =
       message_body
-      |> Map.update("content", [], &content_to_single_part/1)
+      |> Map.update("content", nil, &content_to_single_part/1)
       |> Map.put("index", index)
       |> Map.put("status", status)
       |> Map.put("tool_calls", tool_calls)
@@ -1025,7 +1025,7 @@ defmodule LangChain.ChatModels.ChatOrq do
 
     data =
       delta_body
-      |> Map.update("content", [], &content_to_single_part/1)
+      |> Map.update("content", nil, &content_to_single_part/1)
       |> Map.put("role", role)
       |> Map.put("index", index)
       |> Map.put("status", status)

--- a/test/chat_models/chat_orq_test.exs
+++ b/test/chat_models/chat_orq_test.exs
@@ -128,8 +128,8 @@ defmodule LangChain.ChatModels.ChatOrqTest do
                index: 0
              } = d4
 
-      # Content should be empty list for empty delta body
-      assert d4.content == []
+      # Content should be nil for empty delta body
+      assert d4.content == nil
     end
 
     test "handles streaming tool call deltas correctly" do


### PR DESCRIPTION
Chat adapter for the orq.ai Deployments APIs, https://orq.ai/

  Non-streaming:
  - POST https://api.orq.ai/v2/deployments/invoke
  Streaming (SSE, sentinel "[DONE]"):
  - POST https://api.orq.ai/v2/deployments/stream
 
API key can be configured via application env `:langchain, :orq_key`
