### PR TITLE
Support verbosity parameter for ChatOpenAI

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -255,6 +255,10 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     # faster responses and fewer tokens used on reasoning in a response.
     field :reasoning_effort, :string, default: "medium"
 
+    # Verbosity level for the response.
+    # https://platform.openai.com/docs/api-reference/chat/create#chat-create-verbosity
+    field :verbosity, :string
+
     # Duration in seconds for the response to be received. When streaming a very
     # lengthy response, a longer time limit may be required. However, when it
     # goes on too long by itself, it tends to hallucinate more.
@@ -312,6 +316,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     :stream,
     :reasoning_mode,
     :reasoning_effort,
+    :verbosity,
     :receive_timeout,
     :json_response,
     :json_schema,
@@ -407,6 +412,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       :reasoning_effort,
       if(openai.reasoning_mode, do: openai.reasoning_effort, else: nil)
     )
+    |> Utils.conditionally_add_to_map(:verbosity, openai.verbosity)
     |> Utils.conditionally_add_to_map(:max_tokens, openai.max_tokens)
     |> Utils.conditionally_add_to_map(:seed, openai.seed)
     |> Utils.conditionally_add_to_map(

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -107,6 +107,16 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert openai.reasoning_effort == "high"
     end
 
+    test "supports overriding verbosity" do
+      # defaults to nil
+      %ChatOpenAI{} = openai = ChatOpenAI.new!()
+      assert openai.verbosity == nil
+
+      # can override the default to "high"
+      %ChatOpenAI{} = openai = ChatOpenAI.new!(%{"verbosity" => "high"})
+      assert openai.verbosity == "high"
+    end
+
     test "supports setting org_id" do
       # defaults to nil
       %ChatOpenAI{} = openai = ChatOpenAI.new!()


### PR DESCRIPTION
GPT-5 has a new `verbosity` parameter: https://platform.openai.com/docs/api-reference/chat/create#chat-create-verbosity

This PR adds support for optionally passing it in (defaults to `nil`)