### PR TITLE
Use moduledoc instead of doc for LLMChain documentation

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1,5 +1,5 @@
 defmodule LangChain.Chains.LLMChain do
-  @doc """
+  @moduledoc """
   Define an LLMChain. This is the heart of the LangChain library.
 
   The chain deals with tools, a tool map, delta tracking, tracking the messages


### PR DESCRIPTION
Using `@doc` was probably a typo.