### PR TITLE
Add AGENTS.md and CLAUDE.md file support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,109 @@
+# LangChain Elixir
+
+This file provides guidance for Coding Agents working in this repository.
+
+## Project Overview
+
+Elixir LangChain is a toolchain framework for integrating Large Language Models (LLMs) into Elixir applications.
+It provides a chain-based architecture to connect processes, services, tools, and functionality with various AI models including OpenAI, Anthropic Claude, Google Gemini, and others.
+It draws inspiration from LangChain for Python and JavaScript, but follows it's own path that aims for integration with Elixir ecosystem.
+
+## Common Development Commands
+
+### Setup and Dependencies
+```bash
+# Install dependencies
+mix deps.get
+
+# Set up environment variables for API keys
+cp .envrc_template .envrc
+# Edit .envrc with API keys, then:
+source .envrc
+```
+
+### Testing
+```bash
+# Run unit tests only (makes no external API calls)
+mix test
+
+# Run specific live API tests (billable and should be confirmed first)
+mix test --include live_call
+mix test --include live_open_ai
+mix test --include live_anthropic
+mix test --include live_grok
+
+# Run a single test file
+mix test test/path/to/test_file.exs
+
+# Run a specific test by line number
+mix test test/path/to/test_file.exs:42
+```
+
+### Code Quality
+
+Always run this before committing:
+
+```bash
+# Performs a set of pre-commit steps of compile checks, formatting, running test, etc.
+mix precommit
+```
+
+## High-Level Architecture
+
+### Core Components
+
+1. **Chat Models** (`lib/chat_models/`)
+   - `ChatModel` behavior defines the interface for all LLM implementations
+   - Each provider (OpenAI, Anthropic, etc.) implements this behavior
+   - Supports streaming, function calling, and multi-modal inputs
+
+2. **Chains** (`lib/chains/`)
+   - `LLMChain`: Primary abstraction for core orchestration of conversations and other LLM workflows
+   - `DataExtractionChain`: Structured data extraction from text
+   - `RoutingChain`: Dynamic routing based on input
+   - Chains compose multiple operations and maintain conversation state
+
+3. **Messages** (`lib/message.ex` and `lib/message/`)
+   - `Message`: Core structure with roles (system, user, assistant, tool)
+   - `ContentPart`: Handles multi-modal content (text, images, files)
+   - `ToolCall` and `ToolResult`: Function invocation and results
+
+4. **Functions** (`lib/function.ex`)
+   - Integrates custom Elixir functions with LLMs
+   - JSON Schema-based parameter validation
+   - Context-aware execution with async support
+
+### Key Patterns
+
+- **Behavior-based design**: All chat models implement the `ChatModel` behavior
+- **Ecto schemas**: Used for data validation and type casting throughout
+- **Streaming support**: Built-in streaming capabilities for real-time responses
+- **Error handling**: Consistent error tuples `{:ok, result}` / `{:error, reason}`
+
+### Adding New Features
+
+When adding a new LLM provider:
+1. Create a new module in `lib/chat_models/`
+2. Implement the `ChatModel` behavior
+3. Add corresponding tests in `test/chat_models/`
+4. Update documentation with supported features
+
+When adding new chain types:
+1. Create in `lib/chains/` following existing patterns
+2. Use `Ecto.Schema` for configuration
+3. Implement `run/2` function for execution
+4. Add comprehensive tests including async scenarios
+
+## Testing Guidelines
+
+- Tests mirror the source structure (e.g., `lib/chains/llm_chain.ex` → `test/chains/llm_chain_test.exs`)
+- Use `@tag :live_call` for tests requiring actual API calls
+- Mock external dependencies using `Mimic` for unit tests
+- Always test both sync and async execution paths when applicable
+
+## Important Notes
+
+- **API Keys**: Never commit API keys. Use environment variables via `.envrc`
+- **Live Tests**: Be cautious with live tests as they incur API costs
+- **Multi-modal**: When working with messages, use `ContentPart` structures
+- **Callbacks**: Chains support extensive callback system for monitoring and extending behavior

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -205,15 +205,15 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
 
   # https://platform.openai.com/docs/api-reference/responses/create
   embedded_schema do
-    field(:receive_timeout, :integer, default: @receive_timeout)
-    field(:api_key, :string, redact: true)
-    field(:endpoint, :string, default: "https://api.openai.com/v1/responses")
+    field :receive_timeout, :integer, default: @receive_timeout
+    field :api_key, :string, redact: true
+    field :endpoint, :string, default: "https://api.openai.com/v1/responses"
 
-    field(:model, :string, default: "gpt-3.5-turbo")
+    field :model, :string, default: "gpt-3.5-turbo"
 
-    field(:include, {:array, :string}, default: [])
+    field :include, {:array, :string}, default: []
     # omit instructions becasue langchain assumes statelessness
-    field(:max_output_tokens, :integer, default: nil)
+    field :max_output_tokens, :integer, default: nil
     # omit metadata because chat_open_ai also omits it
     # omit parallel_tool_calls because chat_open_ai also omits it
     # omit previous_response_id becasue langchain assumes statelessness
@@ -221,20 +221,20 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     embeds_one(:reasoning, ReasoningOptions)
     # omit service_tier because chat_open_ai also omits it
     # omit store, but set it explicitly to false later to keep statelessness. the API will default true unless we set it
-    field(:stream, :boolean, default: false)
-    field(:temperature, :float, default: nil)
-    field(:json_response, :boolean, default: false)
-    field(:json_schema, :map, default: nil)
-    field(:json_schema_name, :string, default: nil)
+    field :stream, :boolean, default: false
+    field :temperature, :float, default: nil
+    field :json_response, :boolean, default: false
+    field :json_schema, :map, default: nil
+    field :json_schema_name, :string, default: nil
 
     # This can be a string or object. We will need to allow ["none", "auto", "required", "file_search", "web_search_preview", and "computer_use_preview"] and take any other string and turn it to %{name: value, type: "function"}
-    field(:tool_choice, :any, default: nil, virtual: true)
-    field(:top_p, :float, default: 1.0)
-    field(:truncation, :string)
-    field(:user, :string)
+    field :tool_choice, :any, default: nil, virtual: true
+    field :top_p, :float, default: 1.0
+    field :truncation, :string
+    field :user, :string
 
-    field(:callbacks, {:array, :map}, default: [])
-    field(:verbose_api, :boolean, default: false)
+    field :callbacks, {:array, :map}, default: []
+    field :verbose_api, :boolean, default: false
   end
 
   @type t :: %ChatOpenAIResponses{}

--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule LangChain.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       test_options: [docs: true],
       start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
       deps: deps(),
       package: package(),
       docs: &docs/0,
@@ -27,6 +28,12 @@ defmodule LangChain.MixProject do
   def application do
     [
       extra_applications: [:logger]
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [precommit: :test]
     ]
   end
 
@@ -47,6 +54,18 @@ defmodule LangChain.MixProject do
     ]
   end
 
+  # Aliases are shortcuts or tasks specific to the current project.
+  # For example, before performing a commit, run the following checks:
+  #
+  #     $ mix precommit
+  #
+  # See the documentation for `Mix` for more info on aliases.
+  defp aliases do
+    [
+      precommit: ["compile --warning-as-errors", "deps.unlock --unused", "format", "test"]
+    ]
+  end
+
   defp docs do
     [
       main: "readme",
@@ -63,6 +82,7 @@ defmodule LangChain.MixProject do
       groups_for_modules: [
         "Chat Models": [
           LangChain.ChatModels.ChatOpenAI,
+          LangChain.ChatModels.ChatOpenAIResponses,
           LangChain.ChatModels.ChatAnthropic,
           LangChain.ChatModels.ChatBumblebee,
           LangChain.ChatModels.ChatGoogleAI,


### PR DESCRIPTION
This adds an AGENTS.md file. Thanks @vasspilka for getting that started!

This adds a CLAUDE.md symlink to the same file for easier cross-tool support.

Additionally, this adds the `mix precommit` alias borrowed from a Phoenix 1.8.1 generated project.

Other minor changes:
- Formatting of some ecto schemas
- Added `LangChain.ChatModels.ChatOpenAIResponses` to the docs menu