### PR TITLE
fix: Support for json-schema in OpenAI responses API

### DIFF
--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -375,7 +375,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
   end
 
   defp set_text_format(%ChatOpenAIResponses{json_response: true}) do
-    %{"type" => "json_object"}
+    %{"format" => %{"type" => "json_object"}}
   end
 
   defp set_text_format(%ChatOpenAIResponses{json_response: false}) do

--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -365,9 +365,12 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
        })
        when not is_nil(json_schema) and not is_nil(json_schema_name) do
     %{
-      "name" => json_schema_name,
-      "schema" => json_schema,
-      "type" => "json_schema"
+      "format" => %{
+        "type" => "json_schema",
+        "name" => json_schema_name,
+        "schema" => json_schema,
+        "strict" => true
+      }
     }
   end
 

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -348,9 +348,12 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       assert data.model == @test_model
 
       assert data.text == %{
-               "type" => "json_schema",
-               "name" => "person",
-               "schema" => json_schema
+               "format" => %{
+                 "type" => "json_schema",
+                 "name" => "person",
+                 "schema" => json_schema,
+                 "strict" => true
+               }
              }
     end
 

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -322,7 +322,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
 
       data = ChatOpenAIResponses.for_api(openai, [], [])
       assert data.model == @test_model
-      assert data.text == %{"type" => "json_object"}
+      assert data.text == %{"format" => %{"type" => "json_object"}}
       refute data[:temperature]
     end
 


### PR DESCRIPTION
Noticed that we had a small bug in OpenAI responses API for json-schema format.

**https://platform.openai.com/docs/guides/structured-outputs#structured-outputs-vs-json-mode**

Tested via automated tests connected to Azure (below) + manually in Teacherspace were we used structured schemas already.

<img width="790" height="191" alt="Screenshot 2025-09-30 at 14 07 47" src="https://github.com/user-attachments/assets/bd07ab7d-daf7-4f75-bead-02f11376a27a" />

Note: OpenAI now requires these prompts to contain *JSON* in the description.

So for example a prompt like: `"Analyze #{text} and measure it's helpfulness, accuracy and weirdness"` needs to be changed so something `"Analyze #{text} and measure it's helpfulness, accuracy and weirdness as JSON"`
