### PR TITLE
Support Anthropic `disable_parallel_tool_use` tool_choice setting

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -399,14 +399,24 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   end
 
   defp get_tool_choice(%ChatAnthropic{
-         tool_choice: %{"type" => "tool", "name" => name} = _tool_choice
+         tool_choice: %{"type" => "tool", "name" => name} = tool_choice
        })
-       when is_binary(name) and byte_size(name) > 0,
-       do: %{"type" => "tool", "name" => name}
+       when is_binary(name) and byte_size(name) > 0 do
+    %{"type" => "tool", "name" => name}
+    |> Utils.conditionally_add_to_map(
+      "disable_parallel_tool_use",
+      Map.get(tool_choice, "disable_parallel_tool_use")
+    )
+  end
 
-  defp get_tool_choice(%ChatAnthropic{tool_choice: %{"type" => type} = _tool_choice})
-       when is_binary(type) and byte_size(type) > 0,
-       do: %{"type" => type}
+  defp get_tool_choice(%ChatAnthropic{tool_choice: %{"type" => type} = tool_choice})
+       when is_binary(type) and byte_size(type) > 0 do
+    %{"type" => type}
+    |> Utils.conditionally_add_to_map(
+      "disable_parallel_tool_use",
+      Map.get(tool_choice, "disable_parallel_tool_use")
+    )
+  end
 
   defp get_tool_choice(%ChatAnthropic{}), do: nil
 

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -238,6 +238,30 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
       assert data.tool_choice == %{"type" => "tool", "name" => "get_weather"}
     end
 
+    test "includes disable_parallel_tool_use when set in tool_choice" do
+      {:ok, anthropic} =
+        ChatAnthropic.new(%{
+          model: @test_model,
+          tool_choice: %{"type" => "auto", "disable_parallel_tool_use" => true}
+        })
+
+      data = ChatAnthropic.for_api(anthropic, [], [])
+      assert data.model == @test_model
+      assert data.tool_choice == %{"type" => "auto", "disable_parallel_tool_use" => true}
+    end
+
+    test "includes disable_parallel_tool_use with specific tool" do
+      {:ok, anthropic} =
+        ChatAnthropic.new(%{
+          model: @test_model,
+          tool_choice: %{"type" => "tool", "name" => "get_weather", "disable_parallel_tool_use" => true}
+        })
+
+      data = ChatAnthropic.for_api(anthropic, [], [])
+      assert data.model == @test_model
+      assert data.tool_choice == %{"type" => "tool", "name" => "get_weather", "disable_parallel_tool_use" => true}
+    end
+
     test "adds tool definitions to map" do
       tool =
         Function.new!(%{


### PR DESCRIPTION
Anthropic's Messages API has a `tool_choice` field named [`disable_parallel_tool_use`](https://docs.claude.com/en/api/messages#body-tool-choice). I've found it helpful to configure this setting in my application.

Please let me know if you'd like me to make any improvements to this PR.