### PR TITLE
Open AI Responses API: Add support for file_url with link to file

### DIFF
--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -541,6 +541,16 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
 
   def content_part_for_api(
         %ChatOpenAIResponses{} = _model,
+        %ContentPart{type: :file_url} = part
+      ) do
+    %{
+      "type" => "input_file",
+      "file_url" => part.content
+    }
+  end
+
+  def content_part_for_api(
+        %ChatOpenAIResponses{} = _model,
         %ContentPart{type: :file, options: opts} = part
       ) do
     case Keyword.get(opts, :type, :base64) do

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -454,6 +454,23 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       assert part["type"] == "input_file"
       assert part["file_id"] == "file-123"
     end
+
+    test "converts file_url to input_file" do
+      model = ChatOpenAIResponses.new!(%{"model" => @test_model})
+
+      file_url =
+        LangChain.Message.ContentPart.new!(%{
+          type: :file_url,
+          content: "https://example.com/document.pdf"
+        })
+
+      msg = LangChain.Message.new_user!([file_url])
+
+      api = ChatOpenAIResponses.for_api(model, msg)
+      [part] = api["content"]
+      assert part["type"] == "input_file"
+      assert part["file_url"] == "https://example.com/document.pdf"
+    end
   end
 
   describe "for_api/1 tool calls and results" do


### PR DESCRIPTION
Noticed that [this](https://platform.openai.com/docs/guides/pdf-files#file-urls) part of the API doesn't work and crashes if you add a `ContentPart.file_url!` part with `LangChain.ChatModels.ChatOpenAIResponses`. Tested locally to confirm that it works, let me know if you want me to add any more tests

```js
const response = await client.responses.create({
    model: "gpt-5",
    input: [
        {
            role: "user",
            content: [
                {
                    type: "input_text",
                    text: "Analyze the letter and provide a summary of the key points.",
                },
                {
                    type: "input_file", // This one should have `file_url`, not content
                    file_url: "https://www.berkshirehathaway.com/letters/2024ltr.pdf",
                },
            ],
        },
    ],
});
```