### PR TITLE
Loosen the gettext dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule LangChain.MixProject do
   defp deps do
     [
       {:ecto, "~> 3.10 or ~> 3.11"},
-      {:gettext, "~> 1.0"},
+      {:gettext, "~> 0.26.2 or ~> 1.0.0"},
       {:req, ">= 0.5.2"},
       {:nimble_parsec, "~> 1.4", optional: true},
       {:abacus, "~> 2.1.0", optional: true},


### PR DESCRIPTION
- it's an unusual situation: gettext published a major version with no breaking changes.
- since it was a major version upgrade this is incompatible with libraries that still require 0.26.x.
- with no breaking changes between the versions, allowing both comes with little risk and fewer apps run into a dependency mess.

https://github.com/elixir-gettext/gettext/blob/v1.0.0/CHANGELOG.md#v100