### PR TITLE
feat: Add support for `:file_url` to ChatAnthropic too

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -1719,6 +1719,16 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     }
   end
 
+  def content_part_for_api(%ContentPart{type: :file_url} = part) do
+    %{
+      "type" => "document",
+      "source" => %{
+        "type" => "url",
+        "url" => part.content
+      }
+    }
+  end
+
   def content_part_for_api(%ContentPart{type: :image_url} = _part) do
     raise LangChainError, "Anthropic does not support image_url"
   end

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -2243,6 +2243,23 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
                )
     end
 
+    test "turns a file_url ContentPart into the expected JSON format" do
+      expected = %{
+        "type" => "document",
+        "source" => %{
+          "type" => "url",
+          "url" => "https://example.com/myfile.pdf"
+        }
+      }
+
+      result =
+        ChatAnthropic.content_part_for_api(
+          ContentPart.file_url!("https://example.com/myfile.pdf")
+        )
+
+      assert result == expected
+    end
+
     test "cache_control: true uses default settings" do
       part = ContentPart.text!("content", cache_control: true)
 


### PR DESCRIPTION
I kind of willfully ignored this piece in the last PR I posted and realizing that URLs are probably the best way to let you LLM provider stream content, decided it would be best if I closed that gap.

https://docs.claude.com/en/docs/build-with-claude/pdf-support#option-1%3A-url-based-pdf-document