### PR TITLE
Support reasoning_content of deepseek model

### DIFF
--- a/lib/message/content_part.ex
+++ b/lib/message/content_part.ex
@@ -168,6 +168,14 @@ defmodule LangChain.Message.ContentPart do
     new!(%{type: :file_url, content: content, options: opts})
   end
 
+  @doc """
+  Create a new ContentPart that contains thinking text. Raises an exception if not valid.
+  """
+  @spec thinking!(String.t(), Keyword.t()) :: t() | no_return()
+  def thinking!(content, opts \\ []) do
+    new!(%{type: :thinking, content: content, options: opts})
+  end
+
   @doc false
   def changeset(message, attrs) do
     message


### PR DESCRIPTION
Unlike ChatGPT, DeepSeek model only supports one choice and there's only one index `0` in DeepSeek response. However, I wish I could get the thinking text from API response when I evaluate `LLMChain.run()`. As a result, I utilize the index `0` to place the thinking message and the index `1` to place the text message.