### PR TITLE
Add req_opts to ChatAnthropic

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -480,9 +480,9 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     # Set to %{enabled: false} or nil to disable automatic message caching.
     field :cache_messages, :map
 
-    # Req options (as a map) to merge into the request.
+    # Req options to merge into the request.
     # https://hexdocs.pm/req/Req.html#new/1-options
-    field :req_config, :map, default: %{}
+    field :req_opts, :any, virtual: true, default: []
   end
 
   @type t :: %ChatAnthropic{}
@@ -503,7 +503,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     :beta_headers,
     :verbose_api,
     :cache_messages,
-    :req_config
+    :req_opts
   ]
   @required_fields [:endpoint, :model]
 
@@ -752,7 +752,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
         retry_delay: fn attempt -> 300 * attempt end,
         aws_sigv4: aws_sigv4_opts(anthropic.bedrock)
       )
-      |> Req.merge(anthropic.req_config |> Keyword.new())
+      |> Req.merge(anthropic.req_opts)
 
     req
     |> Req.post()
@@ -845,7 +845,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
       aws_sigv4: aws_sigv4_opts(anthropic.bedrock),
       retry: :transient
     )
-    |> Req.merge(anthropic.req_config |> Keyword.new())
+    |> Req.merge(anthropic.req_opts)
     |> Req.post(
       into:
         Utils.handle_stream_fn(

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -1376,7 +1376,7 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
         {:error, RuntimeError.exception("Something went wrong")}
       end)
 
-      model = ChatAnthropic.new!(%{stream: true, model: @test_model, req_config: %{retry: false}})
+      model = ChatAnthropic.new!(%{stream: true, model: @test_model, req_opts: [retry: false]})
 
       assert {:error, %LangChainError{message: error_message}} =
                ChatAnthropic.call(model, "prompt", [])
@@ -1392,7 +1392,7 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
       end)
 
       model =
-        ChatAnthropic.new!(%{stream: false, model: @test_model, req_config: %{retry: false}})
+        ChatAnthropic.new!(%{stream: false, model: @test_model, req_opts: [retry: false]})
 
       assert {:error, %LangChainError{message: error_message}} =
                ChatAnthropic.call(model, "prompt", [])


### PR DESCRIPTION
Hey @brainlid 👋 

Following on from the discussion & PRs in https://github.com/brainlid/langchain/issues/347, this PR adds the same functionality to ChatAnthropic.

The first commit follows the same approach as https://github.com/brainlid/langchain/pull/357, `req_config` using a map (which would be serializable).

The second commit switches to `req_opts` with a virtual keyword list. I have a slight preference for this approach since req takes a keyword list, but we may need to implement a custom `Ecto.Type` to make it serializable (if this is needed). Thoughts?