### PR TITLE
Allow multi-part tool responses.

### DIFF
--- a/lib/function.ex
+++ b/lib/function.ex
@@ -295,6 +295,9 @@ defmodule LangChain.Function do
         text when is_binary(text) ->
           {:ok, text}
 
+        parts when is_list(parts) ->
+          {:ok, parts}
+
         other ->
           Logger.error(
             "Function #{function.name} unexpectedly returned #{inspect(other)}. Expect a string. Unable to present as response to LLM."


### PR DESCRIPTION
- previously if a tool response was mult-part it would return an error.
- tools that return images often return a 2-part message as in the test case.