### PR TITLE
Add `req_config` to `ChatOpenAIResponses`

### DIFF
--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -235,6 +235,11 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
 
     field :callbacks, {:array, :map}, default: []
     field :verbose_api, :boolean, default: false
+
+    # Req options to merge into the request.
+    # Refer to `https://hexdocs.pm/req/Req.html#new/1-options` for
+    # `Req.new` supported set of options.
+    field :req_config, :map, default: %{}
   end
 
   @type t :: %ChatOpenAIResponses{}
@@ -256,7 +261,8 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     :top_p,
     :truncation,
     :user,
-    :verbose_api
+    :verbose_api,
+    :req_config
   ]
   @required_fields [:endpoint, :model]
 
@@ -716,6 +722,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     req
     |> maybe_add_org_id_header()
     |> maybe_add_proj_id_header()
+    |> Req.merge(openai.req_config |> Keyword.new())
     |> Req.post()
     # parse the body and return it as parsed structs
     |> case do
@@ -782,6 +789,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     )
     |> maybe_add_org_id_header()
     |> maybe_add_proj_id_header()
+    |> Req.merge(openai.req_config |> Keyword.new())
     |> Req.post(
       into: Utils.handle_stream_fn(openai, &decode_stream/1, &do_process_response(openai, &1))
     )

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -1,5 +1,6 @@
 defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
   use LangChain.BaseCase
+  use Mimic
 
   doctest LangChain.ChatModels.ChatOpenAIResponses
   alias LangChain.ChatModels.ChatOpenAIResponses
@@ -906,6 +907,42 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       assert restored.temperature == original.temperature
       assert restored.endpoint == original.endpoint
       assert restored.reasoning.effort == original.reasoning.effort
+    end
+  end
+
+  describe "req_config" do
+    test "merges req_config into the request (non-streaming)" do
+      expect(Req, :post, fn req_struct ->
+        # assert retry value from req_config
+        assert req_struct.options.retry == false
+
+        {:error, RuntimeError.exception("Something went wrong")}
+      end)
+
+      model =
+        ChatOpenAIResponses.new!(%{
+          stream: false,
+          model: @test_model,
+          req_config: %{retry: false}
+        })
+
+      assert {:error, _} = ChatOpenAIResponses.call(model, "prompt", [])
+      verify!()
+    end
+
+    test "merges req_config into the request (streaming)" do
+      expect(Req, :post, fn req_struct, _opts ->
+        # assert retry value from req_config
+        assert req_struct.options.retry == false
+
+        {:error, RuntimeError.exception("Something went wrong")}
+      end)
+
+      model =
+        ChatOpenAIResponses.new!(%{stream: true, model: @test_model, req_config: %{retry: false}})
+
+      assert {:error, _} = ChatOpenAIResponses.call(model, "prompt", [])
+      verify!()
     end
   end
 end


### PR DESCRIPTION
Add `req_config` field to `ChatOpenAIResponses`, similarly as in `ChatGoogleAI`, `ChatOpenAI`, `ChatDeepSeek`, and `ChatAnthropic`.

Based on #357. Includes tests inspired by #408.