### PR TITLE
fix ChatGrok tool call arguments and message flattening

### DIFF
--- a/lib/chat_models/chat_grok.ex
+++ b/lib/chat_models/chat_grok.ex
@@ -744,11 +744,13 @@ defmodule LangChain.ChatModels.ChatGrok do
 
   defp parse_tool_calls(tool_calls) when is_list(tool_calls) do
     Enum.map(tool_calls, fn tool_call ->
-      %ToolCall{
+      ToolCall.new!(%{
+        status: :complete,
+        type: :function,
         call_id: tool_call["id"],
         name: tool_call["function"]["name"],
         arguments: tool_call["function"]["arguments"]
-      }
+      })
     end)
   end
 


### PR DESCRIPTION
not sure if grok isn't used at all or is this a versioning issue. but i decided to use it and couldn't. seems that the format Grok replies in has some differences in how langchain expects them. so i made the necessary changes so that Grok works.