### PR TITLE
refactor: make chain modes extensible via behaviour pattern

### DIFF
--- a/lib/chains/llm_chain/mode.ex
+++ b/lib/chains/llm_chain/mode.ex
@@ -1,0 +1,67 @@
+defmodule LangChain.Chains.LLMChain.Mode do
+  @moduledoc """
+  Behavior for LLMChain execution modes.
+
+  Execution modes control how an LLMChain processes messages and handles tool
+  execution. By implementing this behavior, you can create custom execution
+  strategies tailored to your specific use case.
+
+  ## Built-in Modes
+
+  LangChain provides several built-in modes:
+
+  - `LangChain.Chains.LLMChain.Modes.WhileNeedsResponseMode` - Loops while the chain needs a response
+  - `LangChain.Chains.LLMChain.Modes.UntilSuccessMode` - Retries until successful tool execution
+  - `LangChain.Chains.LLMChain.Modes.StepMode` - Step-by-step execution with optional continuation
+
+  ## Implementing a Custom Mode
+
+  To create a custom mode, implement the `c:run/2` callback:
+
+      defmodule MyApp.CustomMode do
+        @behaviour LangChain.Chains.LLMChain.Mode
+
+        alias LangChain.Chains.LLMChain
+
+        @impl true
+        def run(%LLMChain{} = chain, opts) do
+          # Your custom execution logic here
+          # Use LLMChain.execute_step/1 to run a single step
+          # Use LLMChain.execute_tools/1 to execute pending tool calls
+          # Return {:ok, updated_chain} or {:error, chain, reason}
+        end
+      end
+
+  Then use it with `LLMChain.run/2`:
+
+      LLMChain.run(chain, mode: MyApp.CustomMode)
+  """
+
+  alias LangChain.Chains.LLMChain
+
+  @doc """
+  Execute the chain according to the mode's strategy.
+
+  This callback receives the chain and options, and returns either:
+  - `{:ok, updated_chain}` on success
+  - `{:error, chain, reason}` on failure
+
+  The mode is responsible for:
+  - Determining when to call the LLM
+  - Executing tool calls when needed
+  - Handling retry logic
+  - Deciding when to stop execution
+
+  ## Parameters
+
+  - `chain` - The LLMChain to execute
+  - `opts` - Keyword list of options that may include mode-specific configuration
+
+  ## Returns
+
+  - `{:ok, LLMChain.t()}` - Successfully executed chain
+  - `{:error, LLMChain.t(), LangChainError.t()}` - Execution failed
+  """
+  @callback run(chain :: LLMChain.t(), opts :: Keyword.t()) ::
+              {:ok, LLMChain.t()} | {:error, LLMChain.t(), LangChain.LangChainError.t()}
+end

--- a/lib/chains/llm_chain/modes/step_mode.ex
+++ b/lib/chains/llm_chain/modes/step_mode.ex
@@ -1,0 +1,89 @@
+defmodule LangChain.Chains.LLMChain.Modes.StepMode do
+  @moduledoc """
+  Execution mode for step-by-step control of the chain.
+
+  This mode executes one step at a time, giving you control over the execution
+  flow. Each step:
+
+  1. Executes any pending tool calls
+  2. If no tools were executed, automatically calls the LLM
+  3. Returns the updated chain
+
+  The mode supports two usage patterns:
+
+  ## Manual Stepping
+
+  Execute one step at a time without a continuation function. This allows you to
+  inspect the chain, modify it, and decide whether to continue:
+
+      {:ok, chain} = LLMChain.run(chain, mode: :step)
+      # Inspect chain.last_message, check tool calls, etc.
+      if should_continue?(chain) do
+        # Optionally modify the chain before continuing
+        {:ok, chain} = LLMChain.run(chain, mode: :step)
+      end
+
+  ## Automated Stepping with Continuation Function
+
+  Provide a `should_continue?` function that inspects the chain state and returns
+  a boolean. The mode will automatically loop based on this function:
+
+      should_continue_fn = fn chain ->
+        chain.needs_response && length(chain.exchanged_messages) < 10
+      end
+
+      {:ok, final_chain} = LLMChain.run(chain,
+        mode: :step,
+        should_continue?: should_continue_fn
+      )
+
+  ## Use Cases
+
+  - Debugging workflows where you need to inspect each step
+  - Conditional stopping based on chain state
+  - Building custom control flows
+  - Implementing max iteration limits
+  - Stopping when specific conditions are met
+
+  ## Example
+
+      chain
+      |> LLMChain.run(mode: :step)
+
+  Or using the module directly:
+
+      chain
+      |> LLMChain.run(mode: LangChain.Chains.LLMChain.Modes.StepMode)
+
+  """
+
+  @behaviour LangChain.Chains.LLMChain.Mode
+
+  alias LangChain.Chains.LLMChain
+
+  @impl true
+  def run(%LLMChain{} = chain, opts) do
+    case Keyword.get(opts, :should_continue?) do
+      should_continue_fn when is_function(should_continue_fn, 1) ->
+        run_with_continuation(chain, should_continue_fn)
+
+      _ ->
+        LLMChain.execute_step_with_tools(chain)
+    end
+  end
+
+  # Run step with automatic continuation based on the provided function
+  defp run_with_continuation(%LLMChain{} = chain, should_continue_fn) do
+    case LLMChain.execute_step_with_tools(chain) do
+      {:ok, updated_chain} ->
+        if should_continue_fn.(updated_chain) do
+          run_with_continuation(updated_chain, should_continue_fn)
+        else
+          {:ok, updated_chain}
+        end
+
+      {:error, updated_chain, reason} ->
+        {:error, updated_chain, reason}
+    end
+  end
+end

--- a/lib/chains/llm_chain/modes/until_success.ex
+++ b/lib/chains/llm_chain/modes/until_success.ex
@@ -1,0 +1,98 @@
+defmodule LangChain.Chains.LLMChain.Modes.UntilSuccess do
+  @moduledoc """
+  Execution mode that retries until a successful result is obtained.
+
+  This mode is designed for non-interactive processing where the LLM may need to
+  retry failed operations. It:
+
+  1. Calls the LLM to get a response
+  2. Executes any tool calls
+  3. Checks if the result is successful:
+     - Successful tool result (no errors) → stops
+     - Assistant message → stops
+     - Failed tool result → retries
+  4. Repeats until success or max retry count is exceeded
+
+  The key characteristic is that execution stops as soon as a successful result
+  is obtained. Unlike `:while_needs_response`, the LLM does not get the last word.
+
+  ## Use Cases
+
+  - Non-interactive workflows where you want to stop once a tool succeeds
+  - Processing tasks where errors should trigger retries
+  - Data extraction where you want to stop once valid data is obtained
+
+  ## Example
+
+      chain
+      |> LLMChain.run(mode: :until_success)
+
+  Or using the module directly:
+
+      chain
+      |> LLMChain.run(mode: LangChain.Chains.LLMChain.Modes.UntilSuccessMode)
+
+  ## How it works
+
+  The mode checks the last message and failure count:
+  - If max retries exceeded → returns error
+  - If last message is a successful tool result → returns success
+  - If last message is an assistant message → returns success
+  - Otherwise → retries by calling the LLM again
+  """
+
+  @behaviour LangChain.Chains.LLMChain.Mode
+
+  alias LangChain.Chains.LLMChain
+  alias LangChain.Message
+  alias LangChain.LangChainError
+
+  @impl true
+  def run(%LLMChain{last_message: %Message{} = last_message} = chain, opts) do
+    force_recurse = Keyword.get(opts, :force_recurse, false)
+
+    stop_or_recurse =
+      cond do
+        force_recurse ->
+          :recurse
+
+        chain.current_failure_count >= chain.max_retry_count ->
+          {:error, chain,
+           LangChainError.exception(
+             type: "exceeded_failure_count",
+             message: "Exceeded max failure count"
+           )}
+
+        last_message.role == :tool && !Message.tool_had_errors?(last_message) ->
+          # a successful tool result has no errors
+          {:ok, chain}
+
+        last_message.role == :assistant ->
+          # it was successful if we didn't generate a user message in response to
+          # an error.
+          {:ok, chain}
+
+        true ->
+          :recurse
+      end
+
+    case stop_or_recurse do
+      :recurse ->
+        chain
+        |> LLMChain.execute_step()
+        |> case do
+          {:ok, updated_chain} ->
+            updated_chain
+            |> LLMChain.execute_tool_calls()
+            |> then(&run(&1, opts))
+
+          {:error, updated_chain, reason} ->
+            {:error, updated_chain, reason}
+        end
+
+      other ->
+        # return the error or success result
+        other
+    end
+  end
+end

--- a/lib/chains/llm_chain/modes/while_needs_response.ex
+++ b/lib/chains/llm_chain/modes/while_needs_response.ex
@@ -1,0 +1,60 @@
+defmodule LangChain.Chains.LLMChain.Modes.WhileNeedsResponse do
+  @moduledoc """
+  Execution mode that loops while the chain needs a response.
+
+  This mode is designed for interactive chats that make tool calls. It:
+
+  1. Executes any pending tool calls
+  2. Calls the LLM to get a response
+  3. Repeats steps 1-2 until the chain no longer needs a response
+
+  The key characteristic is that the LLM always gets the "last word" - execution
+  continues until the assistant provides a final response without tool calls.
+
+  ## Use Cases
+
+  - Conversational chatbots with tool/function calling
+  - Interactive agents that need to use tools and respond to results
+  - Any workflow where the assistant should respond to tool execution results
+
+  ## Example
+
+      chain
+      |> LLMChain.run(mode: :while_needs_response)
+
+  Or using the module directly:
+
+      chain
+      |> LLMChain.run(mode: LangChain.Chains.LLMChain.Modes.WhileNeedsResponseMode)
+
+  ## How it works
+
+  The mode checks the `needs_response` field on the chain:
+  - If `false`, execution stops and returns the chain
+  - If `true`, it executes tools, calls the LLM, and recursively continues
+  """
+
+  @behaviour LangChain.Chains.LLMChain.Mode
+
+  alias LangChain.Chains.LLMChain
+
+  @impl true
+  def run(chain, opts \\ [])
+
+  def run(%LLMChain{needs_response: false} = chain, _opts) do
+    {:ok, chain}
+  end
+
+  def run(%LLMChain{needs_response: true} = chain, opts) do
+    chain
+    |> LLMChain.execute_tool_calls()
+    |> LLMChain.execute_step()
+    |> case do
+      {:ok, updated_chain} ->
+        run(updated_chain, opts)
+
+      {:error, updated_chain, reason} ->
+        {:error, updated_chain, reason}
+    end
+  end
+end


### PR DESCRIPTION
Extracts hardcoded modes from single file into separate modules that each implement a common _Mode_ Behaviour, allowing users to define custom modes without modifying the library.

## Comments 

I'm not expecting this PR to get merged necessarily, but I wanted to propose a possible way of making run Modes more approachable with a Behaviour pattern. 

I found myself wanting to write my own "mode" to have control over the restart strategy, but some functions like `do_run` are private and unaccessible. So I'd end up using the :step mode and then copying some of the private functions internals. Perhaps that's the intention of the author, in which case feel free to close this PR. By having a module that defines the Mode behaviour, you can pass it in as an option and the higher level api of calling LLMChain.run(...) stays the same in your code. 