### PR TITLE
use elixir 1.17

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule LangChain.MixProject do
     [
       app: :langchain,
       version: @version,
-      elixir: "~> 1.16",
+      elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       test_options: [docs: true],
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
the ChatGoogleAI module uses the `get_in` macro which is only available in Elixir 1.17 onwards. Using elixir 1.16 throws a compile error.

## Context

I ran into [this issue](https://github.com/brainlid/langchain/issues/405) at compile time since I was using 1.16. 