### PR TITLE
Handle thought content parts from Google Vertex

### DIFF
--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -542,8 +542,15 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     text_part =
       parts
       |> filter_parts_for_types(["text"])
+      |> filter_text_parts()
       |> Enum.map(fn part ->
-        ContentPart.new!(%{type: :text, content: part["text"]})
+        type =
+          case part["thought"] do
+            true -> :thinking
+            _ -> :text
+          end
+
+        ContentPart.new!(%{type: type, content: part["text"]})
       end)
 
     tool_calls_from_parts =
@@ -717,6 +724,16 @@ defmodule LangChain.ChatModels.ChatVertexAI do
   def filter_parts_for_types(parts, types) when is_list(parts) and is_list(types) do
     Enum.filter(parts, fn p ->
       Enum.any?(types, &Map.has_key?(p, &1))
+    end)
+  end
+
+  @doc false
+  def filter_text_parts(parts) when is_list(parts) do
+    Enum.filter(parts, fn p ->
+      case p do
+        %{"text" => text} -> text && text != ""
+        _ -> false
+      end
     end)
   end
 

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -437,6 +437,22 @@ defmodule ChatModels.ChatVertexAITest do
     end
   end
 
+  describe "filter_text_parts/1" do
+    test "returns only text parts that are not nil or empty" do
+      parts = [
+        %{"text" => "I have text"},
+        %{"text" => nil},
+        %{"text" => ""},
+        %{"text" => "I have more text"}
+      ]
+
+      assert ChatVertexAI.filter_text_parts(parts) == [
+               %{"text" => "I have text"},
+               %{"text" => "I have more text"}
+             ]
+    end
+  end
+
   describe "get_message_contents/1" do
     test "returns basic text as a ContentPart" do
       message = Message.new_user!("Howdy!")


### PR DESCRIPTION
This is again just copying google ai functionality.

The next move is to extract a lot of common stuff from here. I'm thinking we just delegate a lot of functions to `LangChain.ChatModels.ChatGoogleAI` and then override the couple differences/divergences.

The main difference I'm seeing is both are handling file uploads differently (in our code) which may require a deprecation.