### PR TITLE
feat(GoogleChatAI): add thought_signature support for Gemini 3 function calls

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -375,7 +375,8 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     }
   end
 
-  def for_api(%ToolCall{thought_signature: signature} = call) when is_binary(signature) do
+  def for_api(%ToolCall{metadata: %{thought_signature: signature}} = call)
+      when is_binary(signature) do
     %{
       "functionCall" => %{
         "args" => call.arguments,
@@ -726,7 +727,6 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
       content: text_part,
       complete: true,
       index: data["index"],
-      thought_signature: data["thoughtSignature"],
       metadata: if(data["groundingMetadata"], do: data["groundingMetadata"], else: nil)
     }
     |> Utils.conditionally_add_to_map(:tool_calls, tool_calls_from_parts)
@@ -772,8 +772,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
       role: unmap_role(role),
       content: content,
       status: finish_reason_to_status(data["finishReason"]),
-      index: data["index"],
-      thought_signature: data["thoughtSignature"]
+      index: data["index"]
     }
     |> Utils.conditionally_add_to_map(:tool_calls, tool_calls_from_parts)
     |> MessageDelta.new()
@@ -797,7 +796,11 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
       arguments: raw_args,
       complete: true,
       index: data["index"],
-      thought_signature: data["thoughtSignature"]
+      metadata:
+        if(data["thoughtSignature"],
+          do: %{thought_signature: data["thoughtSignature"]},
+          else: nil
+        )
     }
     |> ToolCall.new()
     |> case do

--- a/lib/message/tool_call.ex
+++ b/lib/message/tool_call.ex
@@ -28,8 +28,8 @@ defmodule LangChain.Message.ToolCall do
     # when the tool call is incomplete, the index indicates which tool call to
     # update on a ToolCall.
     field :index, :integer
-    # Gemini 3 thought signature for function calls (required for Gemini 3 models)
-    field :thought_signature, :string
+    # Map of model-specific metadata attributes
+    field :metadata, :map
   end
 
   # https://cookbook.openai.com/examples/how_to_call_functions_with_chat_models
@@ -40,7 +40,7 @@ defmodule LangChain.Message.ToolCall do
 
   @type t :: %ToolCall{}
 
-  @update_fields [:status, :type, :call_id, :name, :arguments, :index, :thought_signature]
+  @update_fields [:status, :type, :call_id, :name, :arguments, :index, :metadata]
   @create_fields @update_fields
 
   @doc """

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -195,13 +195,13 @@ defmodule ChatModels.ChatGoogleAITest do
              } = tool_result
     end
 
-    test "for_api includes thoughtSignature when present on ToolCall" do
+    test "for_api includes thoughtSignature when present in ToolCall metadata" do
       tool_call =
         ToolCall.new!(%{
           call_id: "call_123",
           name: "test_function",
           arguments: %{"arg" => "value"},
-          thought_signature: "sig_abc123"
+          metadata: %{thought_signature: "sig_abc123"}
         })
 
       result = ChatGoogleAI.for_api(tool_call)
@@ -210,7 +210,7 @@ defmodule ChatModels.ChatGoogleAITest do
       assert result["functionCall"]["name"] == "test_function"
     end
 
-    test "for_api excludes thoughtSignature when nil on ToolCall" do
+    test "for_api excludes thoughtSignature when not in ToolCall metadata" do
       tool_call =
         ToolCall.new!(%{
           call_id: "call_123",
@@ -574,7 +574,7 @@ defmodule ChatModels.ChatGoogleAITest do
 
       assert [%Message{} = msg] = ChatGoogleAI.do_process_response(model, response)
       assert [%ToolCall{} = call] = msg.tool_calls
-      assert call.thought_signature == "gemini3_thought_sig_xyz"
+      assert call.metadata.thought_signature == "gemini3_thought_sig_xyz"
       assert call.name == "my_func"
     end
 
@@ -594,7 +594,7 @@ defmodule ChatModels.ChatGoogleAITest do
 
       assert [%Message{} = msg] = ChatGoogleAI.do_process_response(model, response)
       assert [%ToolCall{} = call] = msg.tool_calls
-      assert call.thought_signature == nil
+      assert call.metadata == nil
     end
 
     test "handles no parts in content", %{model: model} do

--- a/test/message/tool_call_test.exs
+++ b/test/message/tool_call_test.exs
@@ -98,7 +98,7 @@ defmodule LangChain.Message.ToolCallTest do
       assert msg.arguments == four_spaces
     end
 
-    test "accepts thought_signature field" do
+    test "accepts metadata field with thought_signature" do
       assert {:ok, %ToolCall{} = call} =
                ToolCall.new(%{
                  "status" => :complete,
@@ -106,15 +106,15 @@ defmodule LangChain.Message.ToolCallTest do
                  "call_id" => "call_123",
                  "name" => "test_function",
                  "arguments" => "{}",
-                 "thought_signature" => "abc123signature"
+                 "metadata" => %{thought_signature: "abc123signature"}
                })
 
-      assert call.thought_signature == "abc123signature"
+      assert call.metadata == %{thought_signature: "abc123signature"}
     end
 
-    test "thought_signature defaults to nil" do
+    test "metadata defaults to nil" do
       {:ok, call} = ToolCall.new(%{})
-      assert call.thought_signature == nil
+      assert call.metadata == nil
     end
   end
 


### PR DESCRIPTION
The Gemini 3 family of models requires [thought_signatures](https://ai.google.dev/gemini-api/docs/thought-signatures) in order to do a tool call. This information provides Google with the reasoning why the tool call was made and apparently is mandatory in order for tool calls to work. 

This PR adds a thought_signature support for Gemini 3 models, it's not required for older models though. 

