### PR TITLE
feat(ChatMistralAI): add parallel tool calling, verbose API, add missing converter for tool call result content

### DIFF
--- a/test/chat_models/chat_mistral_ai_test.exs
+++ b/test/chat_models/chat_mistral_ai_test.exs
@@ -40,6 +40,19 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
 
       assert model.endpoint == override_url
     end
+
+    test "supports passing parallel_tool_calls" do
+      # defaults to nil
+      %ChatMistralAI{} = mistral_ai = ChatMistralAI.new!(%{"model" => "mistral-tiny"})
+      assert mistral_ai.parallel_tool_calls == nil
+
+      # can override the default to false
+      %ChatMistralAI{} =
+        mistral_ai =
+        ChatMistralAI.new!(%{"model" => "mistral-tiny", "parallel_tool_calls" => false})
+
+      assert mistral_ai.parallel_tool_calls == false
+    end
   end
 
   describe "for_api/3" do
@@ -71,6 +84,20 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
                  safe_prompt: true,
                  random_seed: 42
                }
+
+      assert data[:parallel_tool_calls] == nil
+    end
+
+    test "generates a map for an API call with parallel_tool_calls set to false" do
+      {:ok, mistral_ai} =
+        ChatMistralAI.new(%{
+          model: "mistral-tiny",
+          parallel_tool_calls: false
+        })
+
+      data = ChatMistralAI.for_api(mistral_ai, [], [])
+      assert data.model == "mistral-tiny"
+      assert data.parallel_tool_calls == false
     end
 
     test "generates a map containing user and assistant messages", %{mistral_ai: mistral_ai} do


### PR DESCRIPTION
This PR solves three things when using Mistral:
1. Tool call results might be a list. The current implementation wasn't able to handle that
2. While doing so, I have realized that Mistral calls tools in parallel. Mistral supports `parallel_tool_calls` - like OpenAI does
3. `verbose_api` was a required addition for easier bug fixing

I did use Claude Opus 4.5 for creating the changes. I tried to align them as close as possible to the `ChatOpenAI` module.

Hope this PR meets your quality standard. 🙏