### PR TITLE
Fixes image file_id content type for ChatOpenAIResponses

### DIFF
--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -433,6 +433,17 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       assert part["detail"] == "low"
     end
 
+    test "converts file_id to input_image" do
+      model = ChatOpenAIResponses.new!(%{"model" => @test_model})
+      file = LangChain.Message.ContentPart.image!("file-123", type: :file_id)
+      msg = LangChain.Message.new_user!([file])
+
+      api = ChatOpenAIResponses.for_api(model, msg)
+      [part] = api["content"]
+      assert part["type"] == "input_image"
+      assert part["file_id"] == "file-123"
+    end
+
     test "converts file base64 to input_file with filename" do
       model = ChatOpenAIResponses.new!(%{"model" => @test_model})
       file = LangChain.Message.ContentPart.file!("PDF_BASE64", type: :base64, filename: "a.pdf")


### PR DESCRIPTION
This PR fixes support for image as file_id in content parts for the ChatOpenAIResponses API.

This will allow calls like this:

```elixir
alias LangChain.{ChatModels.ChatOpenAIResponses, Message}
alias LangChain.Chains.LLMChain

file_id = "file-WEgmo69H1MRMtbRjkiYQMc"

message = Message.new_user!([
  Message.ContentPart.text!("Describe this image contents:"),
  Message.ContentPart.image!(file_id, type: :file_id, detail: "low")
])

output =
  %{llm: ChatOpenAIResponses.new!(%{model: "gpt-4o-mini"})}
  |> LLMChain.new!()
  |> LLMChain.add_message(message)
  |> LLMChain.run()
```