### PR TITLE
add req_config to vertexai

### DIFF
--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -111,6 +111,11 @@ defmodule LangChain.ChatModels.ChatVertexAI do
 
     # Additional level of raw api request and response data
     field :verbose_api, :boolean, default: false
+
+    # Req options to merge into the request.
+    # Refer to `https://hexdocs.pm/req/Req.html#new/1-options` for
+    # `Req.new` supported set of options.
+    field :req_config, :map, default: %{}
   end
 
   @type t :: %ChatVertexAI{}
@@ -126,7 +131,8 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     :receive_timeout,
     :json_response,
     :json_schema,
-    :stream
+    :stream,
+    :req_config
   ]
   @required_fields [
     :endpoint,
@@ -434,6 +440,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
         auth: {:bearer, get_api_key(vertex_ai)},
         retry_delay: fn attempt -> 300 * attempt end
       )
+      |> Req.merge(vertex_ai.req_config |> Keyword.new())
 
     req
     |> Req.post()
@@ -479,6 +486,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
       receive_timeout: vertex_ai.receive_timeout
     )
     |> Req.Request.put_header("accept-encoding", "utf-8")
+    |> Req.merge(vertex_ai.req_config |> Keyword.new())
     |> Req.post(
       into:
         Utils.handle_stream_fn(


### PR DESCRIPTION
Inspired by https://github.com/brainlid/langchain/pull/357 and https://github.com/brainlid/langchain/pull/408, adding `req_config` to `LangChain.ChatModels.ChatVertexAI`.

The primary use case is for us to pass the `X-Vertex-AI-LLM-Request-Type` header to switch between [shared and provisioned throughput](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput/use-provisioned-throughput).