### PR TITLE
Fix exception handling in run_message_processors

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1255,7 +1255,7 @@ defmodule LangChain.Chains.LLMChain do
           Logger.error("Exception raised in processor #{inspect(proc)}")
 
           {:halt,
-           {:halted,
+           {:halted, m,
             Message.new_user!("ERROR: An exception was raised! Exception: #{inspect(err)}")}}
       end
     end)


### PR DESCRIPTION
The calling function, `process_message`, expects a 3-tuple in case of failures. This works for normal failures, but not for exceptions. This PR fixes that oversight, amends the existing test for `run_message_processors` and adds a new test for `process_message`.