### PR TITLE
Add explicit Auth error handler to ChatAnthropic

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -780,6 +780,14 @@ defmodule LangChain.ChatModels.ChatAnthropic do
             result
         end
 
+      {:ok, %Req.Response{status: 401} = error} ->
+        {:error,
+         LangChainError.exception(
+           type: "authentication_error",
+           message: "Authentication Error",
+           original: error
+         )}
+
       {:ok, %Req.Response{status: 429} = response} ->
         rate_limit_info = get_ratelimit_info(response.headers)
 


### PR DESCRIPTION
- a status 401 when an invalid API key is provided wasn't being handled gracefully