### PR TITLE
Customizable run modes via Mode behaviour

### DIFF
--- a/lib/chains/llm_chain/mode.ex
+++ b/lib/chains/llm_chain/mode.ex
@@ -1,0 +1,58 @@
+defmodule LangChain.Chains.LLMChain.Mode do
+  @moduledoc """
+  Behaviour for LLMChain execution modes.
+
+  A mode controls the execution loop of an LLMChain — how many times the LLM
+  is called, when tools are executed, and under what conditions the loop
+  terminates.
+
+  ## Built-in Modes
+
+  - `LangChain.Chains.LLMChain.Modes.WhileNeedsResponse` - loop while `needs_response` is true
+  - `LangChain.Chains.LLMChain.Modes.UntilSuccess` - loop until successful tool execution or assistant response
+  - `LangChain.Chains.LLMChain.Modes.Step` - single step with optional continuation
+  - `LangChain.Chains.LLMChain.Modes.UntilToolUsed` - loop until a specific tool is called
+
+  ## Custom Modes
+
+  Implement this behaviour to define custom execution loops:
+
+      defmodule MyApp.Modes.Custom do
+        @behaviour LangChain.Chains.LLMChain.Mode
+
+        @impl true
+        def run(chain, opts) do
+          case LLMChain.execute_step(chain) do
+            {:ok, updated} ->
+              updated = LLMChain.execute_tool_calls(updated)
+              if updated.needs_response, do: run(updated, opts), else: {:ok, updated}
+            error -> error
+          end
+        end
+      end
+
+  ## Return Types
+
+  - `{:ok, chain}` - normal completion
+  - `{:ok, chain, extra}` - completion with additional data
+  - `{:pause, chain}` - execution paused at a clean checkpoint; resumable
+  - `{:error, chain, reason}` - execution failed
+  """
+
+  alias LangChain.Chains.LLMChain
+  alias LangChain.LangChainError
+
+  @type run_result ::
+          {:ok, LLMChain.t()}
+          | {:ok, LLMChain.t(), term()}
+          | {:pause, LLMChain.t()}
+          | {:error, LLMChain.t(), LangChainError.t()}
+
+  @doc """
+  Execute the chain according to this mode's logic.
+
+  The `opts` keyword list contains all options passed to `LLMChain.run/2`,
+  allowing modes to define their own options.
+  """
+  @callback run(chain :: LLMChain.t(), opts :: Keyword.t()) :: run_result()
+end

--- a/lib/chains/llm_chain/mode/steps.ex
+++ b/lib/chains/llm_chain/mode/steps.ex
@@ -1,0 +1,209 @@
+defmodule LangChain.Chains.LLMChain.Mode.Steps do
+  @moduledoc """
+  Pipe-friendly building blocks for composing custom execution modes.
+
+  Every step function follows the pipeline convention:
+
+  - Input/output: `{:continue, chain}` means keep processing
+  - Any other tuple (`:ok`, `:pause`, `:error`) is a terminal — passed through unchanged
+  - Step functions take the pipeline result as first arg, optional config as second
+
+  ## Example: Custom Mode
+
+      defmodule MyApp.Modes.Simple do
+        @behaviour LangChain.Chains.LLMChain.Mode
+        import LangChain.Chains.LLMChain.Mode.Steps
+
+        @impl true
+        def run(chain, opts) do
+          chain = ensure_mode_state(chain)
+
+          {:continue, chain}
+          |> call_llm()
+          |> execute_tools()
+          |> check_max_runs(opts)
+          |> continue_or_done(&run/2, opts)
+        end
+      end
+  """
+
+  alias LangChain.Chains.LLMChain
+
+  @type pipeline_result ::
+          {:continue, LLMChain.t()}
+          | {:ok, LLMChain.t()}
+          | {:ok, LLMChain.t(), term()}
+          | {:pause, LLMChain.t()}
+          | {:error, LLMChain.t(), term()}
+          | {:interrupt, LLMChain.t(), term()}
+
+  # ── Core Execution ──────────────────────────────────────────────
+
+  @doc """
+  Call the LLM (single step). Wraps `LLMChain.execute_step/1`.
+
+  On success, increments `mode_state.run_count` in `custom_context`.
+  """
+  def call_llm({:continue, chain}) do
+    case LLMChain.execute_step(chain) do
+      {:ok, updated_chain} ->
+        {:continue, increment_run_count(updated_chain)}
+
+      {:error, chain, reason} ->
+        {:error, chain, reason}
+    end
+  end
+
+  def call_llm(terminal), do: terminal
+
+  @doc """
+  Execute pending tool calls. Wraps `LLMChain.execute_tool_calls/1`.
+  """
+  def execute_tools({:continue, chain}) do
+    {:continue, LLMChain.execute_tool_calls(chain)}
+  end
+
+  def execute_tools(terminal), do: terminal
+
+  # ── Safety Checks ───────────────────────────────────────────────
+
+  @doc """
+  Check if max runs have been exceeded.
+
+  Reads `run_count` from `custom_context.mode_state` and compares against
+  `:max_runs` in opts (default: 25).
+  """
+  def check_max_runs({:continue, chain}, opts) do
+    max = Keyword.get(opts, :max_runs, 25)
+    count = get_run_count(chain)
+
+    if count >= max do
+      {:error, chain,
+       LangChain.LangChainError.exception(
+         type: "exceeded_max_runs",
+         message: "Exceeded maximum number of runs"
+       )}
+    else
+      {:continue, chain}
+    end
+  end
+
+  def check_max_runs(terminal, _opts), do: terminal
+
+  # ── Pause (Infrastructure Drain) ────────────────────────────────
+
+  @doc """
+  Check if execution should pause (e.g., node draining).
+
+  Reads `:should_pause?` from opts — a zero-arity function that returns boolean.
+  """
+  def check_pause({:continue, chain}, opts) do
+    case Keyword.get(opts, :should_pause?) do
+      fun when is_function(fun, 0) ->
+        if fun.(), do: {:pause, chain}, else: {:continue, chain}
+
+      _ ->
+        {:continue, chain}
+    end
+  end
+
+  def check_pause(terminal, _opts), do: terminal
+
+  # ── Until-Tool Termination ──────────────────────────────────────
+
+  @doc """
+  Check if a target tool was called in the most recent tool results.
+
+  Reads `:tool_names` from opts — a list of tool name strings.
+  If a matching tool result is found, returns `{:ok, chain, tool_result}`.
+  """
+  def check_until_tool({:continue, chain}, opts) do
+    case Keyword.get(opts, :tool_names) do
+      nil ->
+        {:continue, chain}
+
+      names when is_list(names) ->
+        case find_matching_tool_result(chain, names) do
+          {:found, tool_result} -> {:ok, chain, tool_result}
+          :not_found -> {:continue, chain}
+        end
+    end
+  end
+
+  def check_until_tool(terminal, _opts), do: terminal
+
+  # ── Loop Boundary ───────────────────────────────────────────────
+
+  @doc """
+  Decide whether to loop or return.
+
+  - `{:continue, chain}` with `needs_response: true` → call `run_fn.(chain, opts)` (loop)
+  - `{:continue, chain}` with `needs_response: false` → `{:ok, chain}` (done)
+  - Any terminal result → pass through as-is
+  """
+  def continue_or_done({:continue, %LLMChain{needs_response: true} = chain}, run_fn, opts) do
+    run_fn.(chain, opts)
+  end
+
+  def continue_or_done({:continue, chain}, _run_fn, _opts) do
+    {:ok, chain}
+  end
+
+  def continue_or_done(terminal, _run_fn, _opts) do
+    terminal
+  end
+
+  # ── Mode State Helpers ──────────────────────────────────────────
+
+  @doc """
+  Initialize mode_state in custom_context if not already present.
+
+  Call this at the top of your mode's `run/2` to set up run_count tracking.
+  On the first call, creates `mode_state: %{run_count: 0}`.
+  On recursive calls (mode_state already exists), returns chain unchanged.
+  """
+  def ensure_mode_state(%LLMChain{} = chain) do
+    case get_in_custom_context(chain, [:mode_state]) do
+      nil ->
+        LLMChain.update_custom_context(chain, %{mode_state: %{run_count: 0}})
+
+      _existing ->
+        chain
+    end
+  end
+
+  @doc """
+  Get the current run count from mode_state.
+  """
+  def get_run_count(%LLMChain{} = chain) do
+    get_in_custom_context(chain, [:mode_state, :run_count]) || 0
+  end
+
+  # ── Private Helpers ─────────────────────────────────────────────
+
+  defp increment_run_count(%LLMChain{} = chain) do
+    count = get_run_count(chain)
+    mode_state = get_in_custom_context(chain, [:mode_state]) || %{}
+    updated_mode_state = Map.put(mode_state, :run_count, count + 1)
+    LLMChain.update_custom_context(chain, %{mode_state: updated_mode_state})
+  end
+
+  defp find_matching_tool_result(%LLMChain{last_message: last_message}, tool_names) do
+    case last_message do
+      %{role: :tool, tool_results: tool_results} when is_list(tool_results) ->
+        case Enum.find(tool_results, &(&1.name in tool_names)) do
+          nil -> :not_found
+          tool_result -> {:found, tool_result}
+        end
+
+      _ ->
+        :not_found
+    end
+  end
+
+  defp get_in_custom_context(%LLMChain{custom_context: ctx}, keys) when is_map(ctx) do
+    get_in(ctx, keys)
+  end
+
+  defp get_in_custom_context(_chain, _keys), do: nil
+end

--- a/lib/chains/llm_chain/modes/step.ex
+++ b/lib/chains/llm_chain/modes/step.ex
@@ -1,0 +1,57 @@
+defmodule LangChain.Chains.LLMChain.Modes.Step do
+  @moduledoc """
+  Execution mode that runs a single step at a time.
+
+  A "step" is: execute any pending tool calls, then call the LLM.
+  If no tools were pending, just call the LLM.
+
+  ## Options
+
+  - `:should_continue?` — Function `(LLMChain.t() -> boolean())` called after
+    each step. If it returns `true`, another step runs. If `false` or not
+    provided, the mode returns after one step.
+
+  ## Usage
+
+      # Single step
+      LLMChain.run(chain, mode: :step)
+
+      # Auto-loop with condition
+      LLMChain.run(chain, mode: :step,
+        should_continue?: fn chain ->
+          chain.needs_response && length(chain.exchanged_messages) < 10
+        end)
+  """
+
+  @behaviour LangChain.Chains.LLMChain.Mode
+
+  alias LangChain.Chains.LLMChain
+
+  @impl true
+  def run(%LLMChain{} = chain, opts) do
+    should_continue_fn = Keyword.get(opts, :should_continue?)
+
+    case run_single_step(chain) do
+      {:ok, updated_chain} ->
+        if is_function(should_continue_fn, 1) && should_continue_fn.(updated_chain) do
+          run(updated_chain, opts)
+        else
+          {:ok, updated_chain}
+        end
+
+      {:error, _chain, _reason} = error ->
+        error
+    end
+  end
+
+  defp run_single_step(%LLMChain{} = chain) do
+    chain_after_tools = LLMChain.execute_tool_calls(chain)
+
+    # If no tools were executed, automatically run LLM
+    if chain_after_tools == chain do
+      LLMChain.execute_step(chain_after_tools)
+    else
+      {:ok, chain_after_tools}
+    end
+  end
+end

--- a/lib/chains/llm_chain/modes/until_success.ex
+++ b/lib/chains/llm_chain/modes/until_success.ex
@@ -1,0 +1,81 @@
+defmodule LangChain.Chains.LLMChain.Modes.UntilSuccess do
+  @moduledoc """
+  Execution mode that loops until a successful result.
+
+  Calls the LLM, executes tool calls, and repeats until:
+  - The last message is an assistant response (success)
+  - The last message is a tool result with no errors (success)
+  - Max retry count is exceeded (error)
+
+  ## Options
+
+  - `:force_recurse` — When `true`, forces recursion even after a successful
+    result. Used internally by `UntilToolUsed` mode. Default: `false`.
+
+  ## Usage
+
+      LLMChain.run(chain, mode: :until_success)
+  """
+
+  @behaviour LangChain.Chains.LLMChain.Mode
+
+  alias LangChain.Chains.LLMChain
+  alias LangChain.Message
+  alias LangChain.LangChainError
+
+  @impl true
+  def run(%LLMChain{last_message: %Message{} = last_message} = chain, opts) do
+    force_recurse = Keyword.get(opts, :force_recurse, false)
+
+    stop_or_recurse =
+      cond do
+        force_recurse ->
+          :recurse
+
+        chain.current_failure_count >= chain.max_retry_count ->
+          {:error, chain,
+           LangChainError.exception(
+             type: "exceeded_failure_count",
+             message: "Exceeded max failure count"
+           )}
+
+        last_message.role == :tool && !Message.tool_had_errors?(last_message) ->
+          {:ok, chain}
+
+        last_message.role == :assistant ->
+          {:ok, chain}
+
+        true ->
+          :recurse
+      end
+
+    case stop_or_recurse do
+      :recurse ->
+        case LLMChain.execute_step(chain) do
+          {:ok, updated_chain} ->
+            updated_chain
+            |> LLMChain.execute_tool_calls()
+            |> run(opts)
+
+          {:error, _chain, _reason} = error ->
+            error
+        end
+
+      other ->
+        other
+    end
+  end
+
+  # Initial call when no messages have been processed yet
+  def run(%LLMChain{} = chain, opts) do
+    case LLMChain.execute_step(chain) do
+      {:ok, updated_chain} ->
+        updated_chain
+        |> LLMChain.execute_tool_calls()
+        |> run(opts)
+
+      {:error, _chain, _reason} = error ->
+        error
+    end
+  end
+end

--- a/lib/chains/llm_chain/modes/until_tool_used.ex
+++ b/lib/chains/llm_chain/modes/until_tool_used.ex
@@ -1,0 +1,63 @@
+defmodule LangChain.Chains.LLMChain.Modes.UntilToolUsed do
+  @moduledoc """
+  Execution mode that loops until a specific tool is called.
+
+  Repeatedly calls the LLM and executes tools until a tool result
+  matching one of the target tool names is found.
+
+  ## Options
+
+  - `:tool_names` — (required) List of tool name strings to watch for.
+  - `:max_runs` — Maximum LLM calls before error. Default: 25.
+
+  ## Usage
+
+      LLMChain.run(chain,
+        mode: LangChain.Chains.LLMChain.Modes.UntilToolUsed,
+        tool_names: ["submit"],
+        max_runs: 25
+      )
+      # => {:ok, chain, %ToolResult{name: "submit", ...}}
+  """
+
+  @behaviour LangChain.Chains.LLMChain.Mode
+  import LangChain.Chains.LLMChain.Mode.Steps
+
+  alias LangChain.Chains.LLMChain
+  alias LangChain.LangChainError
+
+  @impl true
+  def run(%LLMChain{} = chain, opts) do
+    tool_names = Keyword.fetch!(opts, :tool_names)
+
+    # Validate tools exist
+    missing = Enum.filter(tool_names, fn name -> !Map.has_key?(chain._tool_map, name) end)
+
+    if missing != [] do
+      message =
+        if length(missing) > 1 do
+          "Tool names '#{Enum.join(missing, ", ")}' not found in available tools"
+        else
+          "Tool name '#{List.first(missing)}' not found in available tools"
+        end
+
+      {:error, chain,
+       LangChainError.exception(
+         type: "invalid_tool_name",
+         message: message
+       )}
+    else
+      chain = ensure_mode_state(chain)
+      do_run(chain, opts)
+    end
+  end
+
+  defp do_run(chain, opts) do
+    {:continue, chain}
+    |> call_llm()
+    |> check_max_runs(opts)
+    |> execute_tools()
+    |> check_until_tool(opts)
+    |> continue_or_done(&do_run/2, opts)
+  end
+end

--- a/lib/chains/llm_chain/modes/while_needs_response.ex
+++ b/lib/chains/llm_chain/modes/while_needs_response.ex
@@ -1,0 +1,38 @@
+defmodule LangChain.Chains.LLMChain.Modes.WhileNeedsResponse do
+  @moduledoc """
+  Execution mode that loops while the chain needs a response.
+
+  After each LLM call, if the response contains tool calls, this mode:
+  1. Executes the pending tool calls
+  2. Calls the LLM again with the tool results
+  3. Repeats until `needs_response` is false (no more tool calls)
+
+  The LLM always gets the last word after tool execution.
+
+  ## Usage
+
+      LLMChain.run(chain, mode: :while_needs_response)
+      # or
+      LLMChain.run(chain, mode: LangChain.Chains.LLMChain.Modes.WhileNeedsResponse)
+  """
+
+  @behaviour LangChain.Chains.LLMChain.Mode
+
+  import LangChain.Chains.LLMChain.Mode.Steps
+
+  alias LangChain.Chains.LLMChain
+
+  @impl true
+  def run(%LLMChain{needs_response: false} = chain, _opts) do
+    {:ok, chain}
+  end
+
+  def run(%LLMChain{} = chain, opts) do
+    chain = ensure_mode_state(chain)
+
+    {:continue, chain}
+    |> execute_tools()
+    |> call_llm()
+    |> continue_or_done(&run/2, opts)
+  end
+end

--- a/test/chains/llm_chain/mode/steps_test.exs
+++ b/test/chains/llm_chain/mode/steps_test.exs
@@ -1,0 +1,317 @@
+defmodule LangChain.Chains.LLMChain.Mode.StepsTest do
+  use LangChain.BaseCase
+  use Mimic
+
+  alias LangChain.Chains.LLMChain
+  alias LangChain.Chains.LLMChain.Mode.Steps
+  alias LangChain.ChatModels.ChatOpenAI
+  alias LangChain.Message
+  alias LangChain.Message.ToolCall
+  alias LangChain.Message.ToolResult
+  alias LangChain.Function
+  alias LangChain.LangChainError
+
+  setup :verify_on_exit!
+
+  setup do
+    {:ok, chat} = ChatOpenAI.new(%{temperature: 0})
+    chain = LLMChain.new!(%{llm: chat})
+    %{chat: chat, chain: chain}
+  end
+
+  describe "call_llm/1" do
+    test "calls LLM and returns {:continue, updated_chain}", %{chain: chain} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Hello!")]}
+      end)
+
+      chain =
+        chain
+        |> LLMChain.add_message(Message.new_user!("Hi"))
+        |> Steps.ensure_mode_state()
+
+      assert {:continue, updated_chain} = Steps.call_llm({:continue, chain})
+      assert updated_chain.last_message.role == :assistant
+      assert Steps.get_run_count(updated_chain) == 1
+    end
+
+    test "increments run_count on each call", %{chain: chain} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Hello!")]}
+      end)
+
+      chain =
+        chain
+        |> LLMChain.add_message(Message.new_user!("Hi"))
+        |> Steps.ensure_mode_state()
+        |> LLMChain.update_custom_context(%{mode_state: %{run_count: 3}})
+
+      assert {:continue, updated_chain} = Steps.call_llm({:continue, chain})
+      assert Steps.get_run_count(updated_chain) == 4
+    end
+
+    test "returns error on LLM failure", %{chain: chain} do
+      chain =
+        chain
+        |> LLMChain.add_message(Message.new_user!("Hi"))
+        |> Steps.ensure_mode_state()
+        |> Map.put(:current_failure_count, 3)
+        |> Map.put(:max_retry_count, 3)
+
+      assert {:error, _chain, %LangChainError{type: "exceeded_failure_count"}} =
+               Steps.call_llm({:continue, chain})
+    end
+
+    test "passes through terminal results", %{chain: chain} do
+      error = {:error, chain, LangChainError.exception(message: "fail")}
+      assert ^error = Steps.call_llm(error)
+
+      ok = {:ok, chain}
+      assert ^ok = Steps.call_llm(ok)
+    end
+  end
+
+  describe "execute_tools/1" do
+    test "executes pending tool calls", %{chain: chain} do
+      hello_world =
+        Function.new!(%{
+          name: "hello_world",
+          description: "Says hello",
+          function: fn _args, _context -> "Hello world!" end
+        })
+
+      tool_call = ToolCall.new!(%{call_id: "call_1", name: "hello_world", arguments: %{}})
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!(%{tool_calls: [tool_call]})]}
+      end)
+
+      chain =
+        chain
+        |> LLMChain.add_tools(hello_world)
+        |> LLMChain.add_message(Message.new_user!("Hi"))
+
+      {:ok, chain_with_tool_calls} = LLMChain.execute_step(chain)
+
+      assert {:continue, updated_chain} = Steps.execute_tools({:continue, chain_with_tool_calls})
+      assert updated_chain.last_message.role == :tool
+    end
+
+    test "no-op when no pending tool calls", %{chain: chain} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Hello!")]}
+      end)
+
+      chain = LLMChain.add_message(chain, Message.new_user!("Hi"))
+      {:ok, chain_with_response} = LLMChain.execute_step(chain)
+
+      assert {:continue, ^chain_with_response} =
+               Steps.execute_tools({:continue, chain_with_response})
+    end
+
+    test "passes through terminal results", %{chain: chain} do
+      ok = {:ok, chain}
+      assert ^ok = Steps.execute_tools(ok)
+    end
+  end
+
+  describe "check_max_runs/2" do
+    test "returns error when run_count exceeds max_runs", %{chain: chain} do
+      chain =
+        chain
+        |> Steps.ensure_mode_state()
+        |> LLMChain.update_custom_context(%{mode_state: %{run_count: 26}})
+
+      assert {:error, _chain, %LangChainError{type: "exceeded_max_runs"}} =
+               Steps.check_max_runs({:continue, chain}, max_runs: 25)
+    end
+
+    test "returns continue when under limit", %{chain: chain} do
+      chain =
+        chain
+        |> Steps.ensure_mode_state()
+        |> LLMChain.update_custom_context(%{mode_state: %{run_count: 5}})
+
+      assert {:continue, ^chain} = Steps.check_max_runs({:continue, chain}, max_runs: 25)
+    end
+
+    test "uses default max_runs of 25", %{chain: chain} do
+      chain =
+        chain
+        |> Steps.ensure_mode_state()
+        |> LLMChain.update_custom_context(%{mode_state: %{run_count: 26}})
+
+      assert {:error, _chain, %LangChainError{type: "exceeded_max_runs"}} =
+               Steps.check_max_runs({:continue, chain}, [])
+    end
+
+    test "passes through terminal results", %{chain: chain} do
+      ok = {:ok, chain}
+      assert ^ok = Steps.check_max_runs(ok, max_runs: 25)
+    end
+  end
+
+  describe "check_pause/2" do
+    test "returns pause when should_pause? returns true", %{chain: chain} do
+      assert {:pause, ^chain} =
+               Steps.check_pause({:continue, chain}, should_pause?: fn -> true end)
+    end
+
+    test "returns continue when should_pause? returns false", %{chain: chain} do
+      assert {:continue, ^chain} =
+               Steps.check_pause({:continue, chain}, should_pause?: fn -> false end)
+    end
+
+    test "returns continue when no should_pause? function", %{chain: chain} do
+      assert {:continue, ^chain} = Steps.check_pause({:continue, chain}, [])
+    end
+
+    test "passes through terminal results", %{chain: chain} do
+      ok = {:ok, chain}
+      assert ^ok = Steps.check_pause(ok, should_pause?: fn -> true end)
+    end
+  end
+
+  describe "check_until_tool/2" do
+    test "returns ok with tool_result when matching tool found", %{chain: chain} do
+      tool_result =
+        ToolResult.new!(%{
+          tool_call_id: "call_1",
+          name: "submit",
+          content: "submitted"
+        })
+
+      tool_message = %Message{role: :tool, tool_results: [tool_result]}
+
+      chain = %{chain | last_message: tool_message}
+
+      assert {:ok, ^chain, ^tool_result} =
+               Steps.check_until_tool({:continue, chain}, tool_names: ["submit"])
+    end
+
+    test "returns continue when no matching tool found", %{chain: chain} do
+      tool_result =
+        ToolResult.new!(%{
+          tool_call_id: "call_1",
+          name: "other_tool",
+          content: "result"
+        })
+
+      tool_message = %Message{role: :tool, tool_results: [tool_result]}
+
+      chain = %{chain | last_message: tool_message}
+
+      assert {:continue, ^chain} =
+               Steps.check_until_tool({:continue, chain}, tool_names: ["submit"])
+    end
+
+    test "returns continue when no tool_names in opts", %{chain: chain} do
+      assert {:continue, ^chain} = Steps.check_until_tool({:continue, chain}, [])
+    end
+
+    test "passes through terminal results", %{chain: chain} do
+      ok = {:ok, chain}
+      assert ^ok = Steps.check_until_tool(ok, tool_names: ["submit"])
+    end
+  end
+
+  describe "continue_or_done/3" do
+    test "loops when needs_response is true", %{chain: chain} do
+      chain = %{chain | needs_response: true}
+      run_fn = fn c, _opts -> {:ok, c} end
+
+      assert {:ok, ^chain} = Steps.continue_or_done({:continue, chain}, run_fn, [])
+    end
+
+    test "returns ok when needs_response is false", %{chain: chain} do
+      chain = %{chain | needs_response: false}
+      run_fn = fn _c, _opts -> raise "should not be called" end
+
+      assert {:ok, ^chain} = Steps.continue_or_done({:continue, chain}, run_fn, [])
+    end
+
+    test "passes through terminal results", %{chain: chain} do
+      run_fn = fn _c, _opts -> raise "should not be called" end
+
+      ok = {:ok, chain}
+      assert ^ok = Steps.continue_or_done(ok, run_fn, [])
+
+      pause = {:pause, chain}
+      assert ^pause = Steps.continue_or_done(pause, run_fn, [])
+
+      error = {:error, chain, LangChainError.exception(message: "fail")}
+      assert ^error = Steps.continue_or_done(error, run_fn, [])
+
+      ok_extra = {:ok, chain, :extra}
+      assert ^ok_extra = Steps.continue_or_done(ok_extra, run_fn, [])
+    end
+  end
+
+  describe "ensure_mode_state/1" do
+    test "creates mode_state on first call", %{chain: chain} do
+      updated = Steps.ensure_mode_state(chain)
+      assert updated.custom_context.mode_state == %{run_count: 0}
+    end
+
+    test "preserves existing mode_state", %{chain: chain} do
+      chain =
+        chain
+        |> Steps.ensure_mode_state()
+        |> LLMChain.update_custom_context(%{mode_state: %{run_count: 5}})
+
+      updated = Steps.ensure_mode_state(chain)
+      assert updated.custom_context.mode_state == %{run_count: 5}
+    end
+  end
+
+  describe "end-to-end pipeline" do
+    test "compose steps into a mini-mode", %{chain: chain} do
+      # First call: LLM returns tool call
+      tool_call = ToolCall.new!(%{call_id: "call_1", name: "hello_world", arguments: %{}})
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!(%{tool_calls: [tool_call]})]}
+      end)
+
+      # Second call: LLM returns final response
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Done!")]}
+      end)
+
+      hello_world =
+        Function.new!(%{
+          name: "hello_world",
+          description: "Says hello",
+          function: fn _args, _context -> "Hello world!" end
+        })
+
+      chain =
+        chain
+        |> LLMChain.add_tools(hello_world)
+        |> LLMChain.add_message(Message.new_user!("Hi"))
+
+      chain = Steps.ensure_mode_state(chain)
+
+      # First iteration: call LLM (returns tool call), execute tools, loop
+      assert {:ok, final_chain} =
+               {:continue, chain}
+               |> Steps.call_llm()
+               |> Steps.execute_tools()
+               |> Steps.check_max_runs(max_runs: 25)
+               |> Steps.continue_or_done(
+                 fn c, o ->
+                   # Second iteration: call LLM (returns assistant msg), done
+                   {:continue, c}
+                   |> Steps.call_llm()
+                   |> Steps.execute_tools()
+                   |> Steps.check_max_runs(o)
+                   |> Steps.continue_or_done(fn _, _ -> raise "too many loops" end, o)
+                 end,
+                 max_runs: 25
+               )
+
+      assert final_chain.last_message.role == :assistant
+      assert Steps.get_run_count(final_chain) == 2
+    end
+  end
+end

--- a/test/chains/llm_chain/mode_test.exs
+++ b/test/chains/llm_chain/mode_test.exs
@@ -1,0 +1,142 @@
+defmodule LangChain.Chains.LLMChain.ModeTest do
+  use LangChain.BaseCase
+  use Mimic
+
+  alias LangChain.Chains.LLMChain
+  alias LangChain.ChatModels.ChatOpenAI
+  alias LangChain.Message
+  alias LangChain.Message.ToolCall
+  alias LangChain.Function
+
+  setup :verify_on_exit!
+
+  defmodule TestMode do
+    @behaviour LangChain.Chains.LLMChain.Mode
+
+    @impl true
+    def run(chain, opts) do
+      case LLMChain.execute_step(chain) do
+        {:ok, updated_chain} ->
+          if Keyword.get(opts, :return_extra) do
+            {:ok, updated_chain, :test_extra}
+          else
+            {:ok, updated_chain}
+          end
+
+        error ->
+          error
+      end
+    end
+  end
+
+  defmodule PauseMode do
+    @behaviour LangChain.Chains.LLMChain.Mode
+
+    @impl true
+    def run(chain, _opts) do
+      {:pause, chain}
+    end
+  end
+
+  setup do
+    {:ok, chat} = ChatOpenAI.new(%{temperature: 0})
+    chain = LLMChain.new!(%{llm: chat})
+    %{chat: chat, chain: chain}
+  end
+
+  describe "execute_step/1" do
+    test "executes single LLM call and returns assistant message", %{chain: chain} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Hello!")]}
+      end)
+
+      chain = LLMChain.add_message(chain, Message.new_user!("Hi"))
+
+      assert {:ok, updated_chain} = LLMChain.execute_step(chain)
+
+      assert LangChain.Message.ContentPart.parts_to_string(updated_chain.last_message.content) ==
+               "Hello!"
+
+      assert updated_chain.last_message.role == :assistant
+      assert updated_chain.needs_response == false
+    end
+
+    test "executes single LLM call with tool calls and sets needs_response", %{chain: chain} do
+      tool_call = ToolCall.new!(%{call_id: "call_1", name: "hello_world", arguments: %{}})
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!(%{tool_calls: [tool_call]})]}
+      end)
+
+      hello_world =
+        Function.new!(%{
+          name: "hello_world",
+          description: "Says hello",
+          function: fn _args, _context -> "Hello world!" end
+        })
+
+      chain =
+        chain
+        |> LLMChain.add_tools(hello_world)
+        |> LLMChain.add_message(Message.new_user!("Hi"))
+
+      assert {:ok, updated_chain} = LLMChain.execute_step(chain)
+      assert updated_chain.needs_response == true
+      assert Message.is_tool_call?(updated_chain.last_message)
+    end
+
+    test "returns error when max retries exceeded", %{chain: chain} do
+      chain =
+        chain
+        |> LLMChain.add_message(Message.new_user!("Hi"))
+        |> Map.put(:current_failure_count, 3)
+        |> Map.put(:max_retry_count, 3)
+
+      assert {:error, _chain, %LangChain.LangChainError{type: "exceeded_failure_count"}} =
+               LLMChain.execute_step(chain)
+    end
+  end
+
+  describe "run/2 with custom mode module" do
+    test "dispatches to module's run/2", %{chain: chain} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Hello!")]}
+      end)
+
+      chain = LLMChain.add_message(chain, Message.new_user!("Hi"))
+
+      assert {:ok, updated_chain} = LLMChain.run(chain, mode: TestMode)
+
+      assert LangChain.Message.ContentPart.parts_to_string(updated_chain.last_message.content) ==
+               "Hello!"
+    end
+
+    test "passes through 3-tuple from custom mode", %{chain: chain} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Hello!")]}
+      end)
+
+      chain = LLMChain.add_message(chain, Message.new_user!("Hi"))
+
+      assert {:ok, _chain, :test_extra} =
+               LLMChain.run(chain, mode: TestMode, return_extra: true)
+    end
+
+    test "passes through pause from custom mode", %{chain: chain} do
+      chain = LLMChain.add_message(chain, Message.new_user!("Hi"))
+
+      assert {:pause, _chain} = LLMChain.run(chain, mode: PauseMode)
+    end
+
+    test "passes opts to custom mode", %{chain: chain} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Hello!")]}
+      end)
+
+      chain = LLMChain.add_message(chain, Message.new_user!("Hi"))
+
+      # Without return_extra, should return 2-tuple
+      assert {:ok, _chain} = LLMChain.run(chain, mode: TestMode)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Introduces a `LangChain.Chains.LLMChain.Mode` behaviour that lets consumers define custom execution loops without modifying the library or copying private internals
- Extracts existing modes (`WhileNeedsResponse`, `UntilSuccess`, `Step`) into standalone modules implementing the behaviour — atom shortcuts (`:while_needs_response`, `:until_success`, `:step`) continue working identically
- Reimplements `UntilToolUsed` as a mode, with `run_until_tool_used/3` delegating to it for backward compatibility
- Makes `do_run/1` public as `execute_step/1` — the missing primitive that modes (and consumers) need to compose custom execution loops
- Adds `LangChain.Chains.LLMChain.Mode.Steps` — pipe-friendly building blocks (`call_llm`, `execute_tools`, `check_max_runs`, `check_pause`, `check_until_tool`, `continue_or_done`) that make composing a custom mode as simple as piping steps together
- `run/2` now accepts module references alongside atom shortcuts and passes through `{:ok, chain, extra}` and `{:pause, chain}` return types from custom modes

## Motivation

LLMChain's execution modes were hardcoded as private functions, creating two problems:

1. **Consumers can't compose behaviors.** Downstream libraries need execution loops that combine concerns like "run until a specific tool is called" + "check for HITL interrupts before executing tools" + "propagate state updates between iterations." The only option was to reimplement the entire execution loop externally, duplicating logic that belongs in LLMChain.

2. **Consumers can't define new modes.** The only way to get custom execution behavior was `:step` mode with manual loop reimplementation, copying private function internals. There was no extension point.

This PR addresses the same root issue identified in [PR #426](https://github.com/brainlid/langchain/pull/426) but goes further — beyond extracting what exists, it provides composable primitives and a pipe-friendly step system that makes building custom modes trivial.

## Example: Custom Mode in ~10 Lines

```elixir
defmodule MyApp.Modes.WithPause do
  @behaviour LangChain.Chains.LLMChain.Mode
  import LangChain.Chains.LLMChain.Mode.Steps

  @impl true
  def run(chain, opts) do
    chain = ensure_mode_state(chain)

    {:continue, chain}
    |> call_llm()
    |> check_pause(opts)           # infrastructure drain
    |> execute_tools()
    |> check_max_runs(opts)
    |> continue_or_done(&run/2, opts)
  end
end

LLMChain.run(chain, mode: MyApp.Modes.WithPause, should_pause?: fn -> false end)
```

## Changes

| File | What |
|------|------|
| `lib/chains/llm_chain/mode.ex` | `Mode` behaviour with `run/2` callback |
| `lib/chains/llm_chain/mode/steps.ex` | Pipe-friendly step functions for composing modes |
| `lib/chains/llm_chain/modes/while_needs_response.ex` | Extracted from private `run_while_needs_response/1` |
| `lib/chains/llm_chain/modes/until_success.ex` | Extracted from private `run_until_success/1` |
| `lib/chains/llm_chain/modes/step.ex` | Extracted from private `run_step/2` |
| `lib/chains/llm_chain/modes/until_tool_used.ex` | Reimplemented using pipe steps |
| `lib/chains/llm_chain.ex` | `execute_step/1` public API, mode dispatch accepts modules |
| `test/chains/llm_chain/mode_test.exs` | Tests for `execute_step/1` and custom mode dispatch |
| `test/chains/llm_chain/mode/steps_test.exs` | Tests for all pipe step functions |

## Test plan

- [x] All 1299 existing tests pass (0 failures)
- [x] New tests for `execute_step/1` (single LLM call, tool calls, error handling)
- [x] New tests for custom mode dispatch via `run/2` (module dispatch, 3-tuple passthrough, pause passthrough, opts forwarding)
- [x] New tests for all pipe step functions (`call_llm`, `execute_tools`, `check_max_runs`, `check_pause`, `check_until_tool`, `continue_or_done`, `ensure_mode_state`)
- [x] End-to-end pipeline test composing steps into a working mini-mode
- [x] Verify backward compatibility: `:while_needs_response`, `:until_success`, `:step` atom shortcuts
- [x] Verify `run_until_tool_used/3` backward compatibility