### PR TITLE
fix: handle nil content in run_message_processors

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1107,7 +1107,10 @@ defmodule LangChain.Chains.LLMChain do
       )
       when is_list(processors) and processors != [] do
     # start `processed_content` with the message's content as a string
-    message = %Message{message | processed_content: ContentPart.parts_to_string(message.content)}
+    message = %Message{
+      message
+      | processed_content: ContentPart.content_to_string(message.content) || ""
+    }
 
     processors
     |> Enum.reduce_while(message, fn proc, m = _acc ->

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -998,6 +998,19 @@ defmodule LangChain.Chains.LLMChainTest do
 
       assert message == LLMChain.run_message_processors(chain, message)
     end
+
+    test "handles nil content on assistant message", %{chain: chain} do
+      chain =
+        LLMChain.message_processors(chain, [
+          &fake_success_processor/2
+        ])
+
+      message = Message.new_assistant!(%{content: nil})
+
+      final_message = LLMChain.run_message_processors(chain, message)
+      assert final_message.processed_content == " *"
+      assert is_nil(final_message.content)
+    end
   end
 
   describe "process_message/2" do


### PR DESCRIPTION
Some OpenAI-compatible providers (e.g. Groq) omit the content field in assistant messages with tool calls, resulting in nil content. This caused a FunctionClauseError in parts_to_string/2 which requires a list argument.

Replaced parts_to_string with content_to_string which handles nil, string, and list content types. Defaults to empty string to ensure downstream processors can safely operate on processed_content.