### PR TITLE
fix: Fix verbosity parameter and better error handling

### DIFF
--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -457,7 +457,6 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
   defp maybe_add_verbosity(map, verbosity) when is_binary(verbosity),
     do: Map.put(map, "verbosity", verbosity)
 
-
   defp get_tool_choice(%ChatOpenAIResponses{tool_choice: choice})
        when choice in ["none", "auto", "required"],
        do: choice
@@ -870,6 +869,9 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
       into: Utils.handle_stream_fn(openai, &decode_stream/1, &do_process_response(openai, &1))
     )
     |> case do
+      {:ok, %Req.Response{body: {:error, %LangChainError{} = error}}} ->
+        {:error, error}
+
       {:ok, %Req.Response{body: data} = response} ->
         Callbacks.fire(openai.callbacks, :on_llm_ratelimit_info, [
           get_ratelimit_info(response.headers)

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -1682,6 +1682,27 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
     end
   end
 
+  describe "streaming error handling" do
+    test "returns error when streaming response contains an API error" do
+      expect(Req, :post, fn _req_struct, _opts ->
+        response = %Req.Response{
+          status: 400,
+          body: {:error, LangChain.LangChainError.exception(message: "Unsupported parameter")}
+        }
+
+        {:ok, response}
+      end)
+
+      model =
+        ChatOpenAIResponses.new!(%{stream: true, model: @test_model})
+
+      assert {:error, %LangChain.LangChainError{} = error} =
+               ChatOpenAIResponses.call(model, "prompt", [])
+
+      assert error.message == "Unsupported parameter"
+    end
+  end
+
   describe "req_config" do
     test "merges req_config into the request (non-streaming)" do
       expect(Req, :post, fn req_struct ->

--- a/test/chat_models/responses_openai_azure_live_api_test.exs
+++ b/test/chat_models/responses_openai_azure_live_api_test.exs
@@ -530,6 +530,23 @@ defmodule LangChain.ChatModels.ResponseOpenAIAzureLiveApiTest do
            "Expected error about invalid schema, got: #{error_message}"
   end
 
+  test "verbosity parameter affects response", %{llm: llm} do
+    llm_with_verbosity = %{llm | verbosity: "low"}
+
+    {:ok, message} =
+      ChatOpenAIResponses.call(
+        llm_with_verbosity,
+        [Message.new_user!("Explain what the number 42 is.")],
+        []
+      )
+
+    assert message.role == :assistant
+    assert is_list(message.content)
+
+    content_str = ContentPart.parts_to_string(message.content)
+    assert String.length(content_str) > 0
+  end
+
   # # Not supported yet
   # test "native web_search_preview tool", %{llm: llm} do
   #   # Create native web_search_preview tool


### PR DESCRIPTION
Hello, in my last PR #470 I made a mistake. The verbosity option needs to be passed inside the `text` parameter.

I am extremely sorry for not testing this properly before opening the PR.

In this PR we make 2 changes:

1. We fix the verbosity option to now be passed inside the text parameter
2. We a have improved error handling that fixes the following error and properly bubbles it up the stack

```elixir
[error] Error during chat call. Reason: %{message: "Unexpected error: %FunctionClauseError{module: :lists, function: :flatten, arity: 1, kind: nil, args: nil, clauses: nil}", stacktrace: [{:lists, :flatten, [error: %LangChain.LangChainError{type: nil, message: "Unsupported parameter: 'verbosity'. In the Responses API, this parameter has moved to 'text.verbosity'. Try again with the new parameter. See the API documentation for more information: https://platform.openai.com/docs/api-reference/responses/create.", original: nil}], [file: ~c"lists.erl", line: 811]}, {LangChain.ChatModels.ChatOpenAIResponses, :"-call/3-fun-0-", 3, [file: ~c"lib/chat_models/chat_open_ai_responses.ex", line: 725]}, {LangChain.Telemetry, :span, 3, [file: ~c"lib/telemetry.ex", line: 135]}, {LangChain.Chains.LLMChain, :do_run, 1, [file: ~c"lib/chains/llm_chain.ex", line: 838]}, {LangChain.Chains.LLMChain.Mode.Steps, :call_llm, 1, [file: ~c"lib/chains/llm_chain/mode/steps.ex", line: 48]}, {LangChain.Chains.LLMChain.Modes.WhileNeedsResponse, :run, 2, [file: ~c"lib/chains/llm_chain/modes/while_needs_response.ex", line: 35]}, {LangChain.Telemetry, :span, 3, [file: ~c"lib/telemetry.ex", line: 135]}, {LangChain.Chains.LLMChain, :run, 2, [file: ~c"lib/chains/llm_chain.ex", line: 638]}]}
```

This time I have properly tested the API request with live tests and in our staging env
<img width="752" height="188" alt="Screenshot 2026-02-26 at 16 14 02" src="https://github.com/user-attachments/assets/876fde7b-b459-4af2-b890-193d7c50e20a" />
