### PR TITLE
Handle streaming errors (content moderation, etc.) in LLMChain

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -981,8 +981,14 @@ defmodule LangChain.Chains.LLMChain do
   end
 
   # Handle when the server is overloaded and cancelled the stream on the server side.
-  def merge_delta(%LLMChain{} = chain, {:error, %LangChainError{type: "overloaded"}}) do
-    cancel_delta(chain, :cancelled)
+  def merge_delta(%LLMChain{} = chain, {:error, %LangChainError{type: "overloaded"} = error}) do
+    cancel_delta(chain, :cancelled, error)
+  end
+
+  # Handle any other error received during streaming (e.g. content filtering, invalid_request_error).
+  def merge_delta(%LLMChain{} = chain, {:error, %LangChainError{} = error}) do
+    Logger.warning("Received error during streaming: #{error.message}")
+    cancel_delta(chain, :cancelled, error)
   end
 
   # Unified function to augment tool calls with display_text and optionally
@@ -1717,13 +1723,34 @@ defmodule LangChain.Chains.LLMChain do
   """
   def cancel_delta(%LLMChain{delta: nil} = chain, _message_status), do: chain
 
-  def cancel_delta(%LLMChain{delta: %MessageDelta{} = delta} = chain, message_status) do
+  def cancel_delta(%LLMChain{} = chain, message_status) do
+    cancel_delta(chain, message_status, nil)
+  end
+
+  @doc """
+  Same as `cancel_delta/2` but stores an optional error in the message's
+  metadata under `:streaming_error`. This preserves the error reason through the
+  chain so higher layers (like the Sagents Agent and AgentServer) can detect and
+  surface it.
+  """
+  def cancel_delta(%LLMChain{delta: nil} = chain, _message_status, _error), do: chain
+
+  def cancel_delta(%LLMChain{delta: %MessageDelta{} = delta} = chain, message_status, error) do
     # remove the in-progress delta and reset streaming state
     updated_chain = reset_streaming_state(chain)
 
     case MessageDelta.to_message(%MessageDelta{delta | status: :complete}) do
       {:ok, %Message{} = message} ->
         message = %Message{message | status: message_status}
+
+        message =
+          if error do
+            metadata = (message.metadata || %{}) |> Map.put(:streaming_error, error)
+            %Message{message | metadata: metadata}
+          else
+            message
+          end
+
         add_message(updated_chain, message)
 
       {:error, reason} ->

--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -154,9 +154,15 @@ defmodule LangChain.MessageDelta do
         MessageDelta.merge_deltas(list_of_delta_messages)
 
   """
-  @spec merge_delta(nil | t(), t()) :: t()
+  @spec merge_delta(nil | t(), t() | {:error, any()}) :: t()
   def merge_delta(nil, %MessageDelta{} = delta_part) do
     merge_delta(%MessageDelta{role: :assistant}, delta_part)
+  end
+
+  # Skip error tuples that may arrive mid-stream (e.g. content filtering).
+  # Return the accumulated delta unchanged so callers like LiveView don't crash.
+  def merge_delta(primary, {:error, _reason}) do
+    primary || %MessageDelta{role: :assistant}
   end
 
   def merge_delta(%MessageDelta{role: :assistant} = primary, %MessageDelta{} = delta_part) do

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -248,6 +248,56 @@ defmodule LangChain.Chains.LLMChainTest do
              } =
                new_chain.last_message
     end
+
+    test "cancel_delta/3 stores error in message metadata" do
+      model = ChatOpenAI.new!(%{temperature: 1, stream: true})
+      chain = LLMChain.new!(%{llm: model, verbose: false})
+
+      error =
+        LangChainError.exception(
+          type: "content_filter",
+          message: "Response blocked by safety filter"
+        )
+
+      chain_with_delta =
+        chain
+        |> LLMChain.merge_delta(
+          MessageDelta.new!(%{role: :assistant, content: "Partial content"})
+        )
+
+      new_chain = LLMChain.cancel_delta(chain_with_delta, :cancelled, error)
+      assert new_chain.delta == nil
+
+      assert %Message{status: :cancelled, metadata: metadata} = new_chain.last_message
+      assert %LangChainError{type: "content_filter"} = metadata.streaming_error
+      assert metadata.streaming_error.message == "Response blocked by safety filter"
+    end
+
+    test "cancel_delta/3 with nil error does not set streaming_error in metadata" do
+      model = ChatOpenAI.new!(%{temperature: 1, stream: true})
+      chain = LLMChain.new!(%{llm: model, verbose: false})
+
+      chain_with_delta =
+        chain
+        |> LLMChain.merge_delta(MessageDelta.new!(%{role: :assistant, content: "Some text"}))
+
+      new_chain = LLMChain.cancel_delta(chain_with_delta, :cancelled, nil)
+      assert new_chain.delta == nil
+
+      msg = new_chain.last_message
+      assert msg.status == :cancelled
+      refute match?(%{streaming_error: _}, msg.metadata || %{})
+    end
+
+    test "cancel_delta/3 does nothing when no delta is present" do
+      model = ChatOpenAI.new!(%{temperature: 1, stream: true})
+      chain = LLMChain.new!(%{llm: model, verbose: false})
+      assert chain.delta == nil
+
+      error = LangChainError.exception(message: "Some error")
+      new_chain = LLMChain.cancel_delta(chain, :cancelled, error)
+      assert new_chain == chain
+    end
   end
 
   describe "JS inspired test" do
@@ -510,6 +560,8 @@ defmodule LangChain.Chains.LLMChainTest do
     test "cancels the current delta when applying an overloaded error", %{chain: chain} do
       assert chain.messages == []
 
+      error = LangChainError.exception(type: "overloaded", message: "Overloaded")
+
       updated_chain =
         chain
         |> LLMChain.merge_delta(
@@ -517,9 +569,7 @@ defmodule LangChain.Chains.LLMChainTest do
         )
         |> LLMChain.merge_delta(MessageDelta.new!(%{content: "your "}))
         |> LLMChain.merge_delta(MessageDelta.new!(%{content: "favorite "}))
-        |> LLMChain.merge_delta(
-          {:error, LangChainError.exception(type: "overloaded", message: "Overloaded")}
-        )
+        |> LLMChain.merge_delta({:error, error})
 
       # the delta is complete and removed from the chain
       assert updated_chain.delta == nil
@@ -528,6 +578,29 @@ defmodule LangChain.Chains.LLMChainTest do
       assert new_message.role == :assistant
       assert new_message.content == [ContentPart.text!("Greetings from your favorite ")]
       assert new_message.status == :cancelled
+      # the error is stored in metadata
+      assert new_message.metadata.streaming_error == error
+    end
+
+    test "cancels the current delta on a generic streaming error", %{chain: chain} do
+      error =
+        LangChainError.exception(
+          type: "invalid_request_error",
+          message: "Output blocked by content filtering policy"
+        )
+
+      updated_chain =
+        chain
+        |> LLMChain.merge_delta(MessageDelta.new!(%{role: :assistant, content: "Some partial "}))
+        |> LLMChain.merge_delta(MessageDelta.new!(%{content: "response"}))
+        |> LLMChain.merge_delta({:error, error})
+
+      assert updated_chain.delta == nil
+      assert [%Message{} = msg] = updated_chain.messages
+      assert msg.role == :assistant
+      assert msg.content == [ContentPart.text!("Some partial response")]
+      assert msg.status == :cancelled
+      assert msg.metadata.streaming_error == error
     end
   end
 

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -1058,6 +1058,45 @@ defmodule LangChain.MessageDeltaTest do
       # Should preserve existing content and skip unknown types
       assert merged.merged_content == [ContentPart.text!("existing")]
     end
+
+    test "returns accumulated delta unchanged when receiving an error tuple" do
+      accumulated =
+        MessageDelta.merge_delta(nil, %MessageDelta{content: "Hello", role: :assistant})
+
+      result =
+        MessageDelta.merge_delta(
+          accumulated,
+          {:error, LangChainError.exception(type: "content_filter", message: "Content blocked")}
+        )
+
+      # The accumulated delta should be returned unchanged
+      assert result == accumulated
+    end
+
+    test "returns a fresh assistant delta when nil receives an error tuple" do
+      result = MessageDelta.merge_delta(nil, {:error, "some error"})
+
+      assert %MessageDelta{role: :assistant} = result
+    end
+
+    test "preserves accumulated content when error arrives mid-stream" do
+      accumulated =
+        [
+          %MessageDelta{content: "Greetings", role: :assistant},
+          %MessageDelta{content: " from"},
+          %MessageDelta{content: " your assistant"}
+        ]
+        |> Enum.reduce(nil, fn delta, acc -> MessageDelta.merge_delta(acc, delta) end)
+
+      result =
+        MessageDelta.merge_delta(
+          accumulated,
+          {:error, LangChainError.exception(message: "Server error")}
+        )
+
+      assert result.merged_content == [ContentPart.text!("Greetings from your assistant")]
+      assert result.status == :incomplete
+    end
   end
 
   describe "merge_deltas/2" do


### PR DESCRIPTION
## Summary

- Add a catch-all `LLMChain.merge_delta/2` clause for any `LangChainError` received during streaming (not just `"overloaded"`), so errors like content filtering rejections are handled gracefully instead of crashing
- Introduce `cancel_delta/3` which stores the error in the cancelled message's `metadata` under `:streaming_error`, preserving the error reason for higher layers (Agent, AgentServer, LiveView) to detect and surface
- Add a `MessageDelta.merge_delta/2` clause that absorbs `{:error, _}` tuples mid-stream, returning the accumulated delta unchanged so callers like LiveView don't crash
- Comprehensive test coverage for all new behaviors (8 new tests)

## Test plan

- [x] `MessageDelta.merge_delta/2` returns accumulated delta unchanged on error tuple
- [x] `MessageDelta.merge_delta/2` returns fresh assistant delta when nil receives error
- [x] `MessageDelta.merge_delta/2` preserves accumulated content when error arrives mid-stream
- [x] `LLMChain.merge_delta/2` cancels delta on generic `LangChainError` and stores error in metadata
- [x] `LLMChain.merge_delta/2` overloaded error now also stores error in metadata
- [x] `cancel_delta/3` stores error in message metadata
- [x] `cancel_delta/3` with nil error does not set streaming_error
- [x] `cancel_delta/3` does nothing when no delta is present
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)