### PR TITLE
Handle empty LLM response in do_run/1 (thinking model streaming fix)

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -888,6 +888,29 @@ defmodule LangChain.Chains.LLMChain do
         if chain.verbose, do: IO.inspect(string_reason, label: "ERROR")
         Logger.error("Error during chat call. Reason: #{inspect(string_reason)}")
         {:error, chain, LangChainError.exception(message: string_reason)}
+
+      {:ok, []} ->
+        # Empty response — all choices were filtered out (e.g., thinking model
+        # streaming where all chunks produce empty parsed results). Treat as
+        # an error rather than crashing with CaseClauseError.
+        Logger.warning("LLM returned an empty response (no messages or deltas)")
+
+        {:error, chain,
+         LangChainError.exception(
+           type: "empty_response",
+           message:
+             "LLM returned an empty response with no messages. " <>
+               "This can happen with thinking/reasoning models during streaming."
+         )}
+
+      {:ok, unexpected} ->
+        Logger.warning("Unexpected LLM response format: #{inspect(unexpected)}")
+
+        {:error, chain,
+         LangChainError.exception(
+           type: "unexpected_response",
+           message: "Unexpected response format from LLM: #{inspect(unexpected)}"
+         )}
     end
   end
 

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -2290,6 +2290,34 @@ defmodule LangChain.Chains.LLMChainTest do
 
       assert_received :before_fallback_fired
     end
+
+    test "returns error when LLM produces an empty response (no messages or deltas)", %{
+      chain: chain
+    } do
+      # Simulate what happens with thinking models during streaming:
+      # all chunks produce empty parsed results, so the body becomes [[], [], ...]
+      # which after filtering becomes []. This previously caused a CaseClauseError.
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, []}
+      end)
+
+      chain = LLMChain.add_message(chain, Message.new_user!("Hello"))
+
+      assert {:error, _chain, %LangChainError{} = error} = LLMChain.run(chain)
+      assert error.type == "empty_response"
+      assert error.message =~ "empty response"
+    end
+
+    test "returns error when LLM produces an unexpected response format", %{chain: chain} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, :unexpected_atom}
+      end)
+
+      chain = LLMChain.add_message(chain, Message.new_user!("Hello"))
+
+      assert {:error, _chain, %LangChainError{} = error} = LLMChain.run(chain)
+      assert error.type == "unexpected_response"
+    end
   end
 
   describe "run_until_tool_used/3" do


### PR DESCRIPTION
## Summary

- Adds catch-all clauses to the `case message_response` block in `LLMChain.do_run/1` to handle `{:ok, []}` and other unexpected response formats
- Returns typed `LangChainError` instead of crashing with `CaseClauseError`

## Problem

When streaming with thinking/reasoning models (Qwen3, DeepSeek-R1, QwQ, etc.) via OpenAI-compatible APIs like OpenRouter, the model emits `<think>` tokens during its reasoning phase. The streaming parser in `handle_stream_fn` processes each chunk through `do_process_response`, which returns `:skip` for chunks with empty choices. After filtering skips, the response body accumulates as `[[], [], ...]`.

In `do_run/1`, the filter at line 840 rejects all empty lists:
```elixir
{:ok, Enum.reject(messages, &(&1 == []))}
```
This produces `{:ok, []}`, which doesn't match any clause in the subsequent `case`:
- `{:ok, [%Message{} = message]}` — needs at least one Message
- `{:ok, [%MessageDelta{} | _]}` — needs at least one MessageDelta
- etc.

Result: `CaseClauseError` crash.

## Fix

Two new clauses at the end of the `case`:

1. **`{:ok, []}`** — empty response, returns `LangChainError` with `type: "empty_response"`
2. **`{:ok, unexpected}`** — any other format, returns `LangChainError` with `type: "unexpected_response"`

## Test plan

- [x] Added test: empty response `{:ok, []}` returns structured error
- [x] Added test: unexpected format returns structured error
- [x] All 101 existing tests pass (6 live API tests excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)