### PR TITLE
fix: skip Azure keepalive events in streaming responses

### DIFF
--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -1312,6 +1312,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
   ]
 
   @skippable_streaming_events [
+    "keepalive",
     "response.created",
     "response.in_progress",
     "response.incomplete",

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -1166,6 +1166,11 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       end
     end
 
+    test "skips Azure keepalive events", %{model: model} do
+      event = %{"type" => "keepalive", "sequence_number" => 3}
+      assert :skip == ChatOpenAIResponses.do_process_response(model, event)
+    end
+
     test "handles list of streaming events", %{model: model} do
       events = [
         %{"type" => "response.output_text.delta", "delta" => "Hello"},


### PR DESCRIPTION
Azure OpenAI sends keepalive SSE events during long-running streaming responses.

Unfortunatelly this event is undocumented so I could not find an official doc from Azure or OpenAI that lists it. However I found a couple of github issue reffering to it

- https://github.com/enricoros/big-AGI/issues/918
- https://github.com/openai/openai-go/issues/556




These events were not matched by any do_process_response/2 clause, causing them to fall through to the catch-all error handler and crash the stream.

In this PR we skip those events so that we don't get the following error:
```
 {:error, %LangChain.LangChainError{
    type: "unexpected_response",
    message: "Unexpected response",
    original: %{"sequence_number" => 3, "type" => "keepalive"}
  }}
 ```
 
 **Note:** This raises the question whether we should have a generic pass-through like most libraries in other ecosystems do.