### PR TITLE
Fix/vertex ai multimodal tool results

### DIFF
--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -361,6 +361,16 @@ defmodule LangChain.ChatModels.ChatVertexAI do
 
   defp tool_result_response_for_api(nil), do: %{}
 
+  defp tool_result_response_for_api(content) when is_binary(content) do
+    case Jason.decode(content) do
+      {:ok, data} ->
+        data
+
+      {:error, %Jason.DecodeError{}} ->
+        %{"result" => content}
+    end
+  end
+
   defp tool_result_response_for_api(content_parts) when is_list(content_parts) do
     text_parts = Enum.filter(content_parts, &(&1.type == :text))
 
@@ -374,12 +384,14 @@ defmodule LangChain.ChatModels.ChatVertexAI do
             data
 
           {:error, %Jason.DecodeError{}} ->
-            %{"result" => text_parts}
+            %{"result" => text_content}
         end
     end
   end
 
   defp tool_result_parts_for_api(nil), do: []
+
+  defp tool_result_parts_for_api(content) when is_binary(content), do: []
 
   defp tool_result_parts_for_api(content_parts) when is_list(content_parts) do
     content_parts

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -593,10 +593,47 @@ defmodule ChatModels.ChatVertexAITest do
                      %{
                        "functionResponse" => %{
                          "name" => "render_chart",
+                         "response" => %{"result" => "plain text result"}
+                       }
+                     }
+                   ]
+                 }
+               ]
+             } = data
+    end
+
+    test "decodes JSON string tool results into function responses", %{vertex_ai: vertex_ai} do
+      data =
+        ChatVertexAI.for_api(
+          vertex_ai,
+          [
+            Message.new_tool_result!(%{
+              tool_results: [
+                ToolResult.new!(%{
+                  tool_call_id: "call_123",
+                  name: "resize_plan",
+                  content:
+                    Jason.encode!(%{
+                      "error" => "Unknown element alias: 05ba59c1-1234",
+                      "status" => "validation_error"
+                    })
+                })
+              ]
+            })
+          ],
+          []
+        )
+
+      assert %{
+               "contents" => [
+                 %{
+                   "parts" => [
+                     %{
+                       "functionResponse" => %{
+                         "name" => "resize_plan",
                          "response" => %{
-                           "result" => [
-                             %ContentPart{type: :text, content: "plain text result"}
-                           ]
+                           "error" => "Unknown element alias: 05ba59c1-1234",
+                           "status" => "validation_error"
                          }
                        }
                      }


### PR DESCRIPTION
Expands `ChatVertexAI` to support multimodal tool responses.

Vertex functionResponse has a very specific shape. 
- It has a single text or json "response", and zero-to-many media parts. 
  - Parts can not be text. 
- It's possible to reference a media part using a $ref block in the response json that matches the "displayName" property of the part. 
- Parts may be "inlineData" for base64 encoded media, or "fileData" for external references (generally a GCS uri). 

One example:

```json
"functionResponse": {
  "name": "name",
  "response": {
    "image": { "$ref": "image.png" }
  },
  "parts": [
    "inlineData": {
      "mimeType": "image/png",
      "data": "...",
      "displayName": "image.png"
    }
  ]
}
```

To map langchain content to this structure, all text parts are concatenated together to make the "response" and all media parts are added to the "parts" property. 

This was added in Gemini 3, but I don't think there are issues with backwards compatibility because attempting to return media parts would have always failed with earlier gemini versions.

Relevant docs: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling#mm-fr

