### PR TITLE
Support multimodal tool results in ChatVertexAI

### DIFF
--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -410,6 +410,17 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     }
   end
 
+  defp tool_result_media_part_for_api(%ContentPart{type: :file} = part) do
+    %{
+      "inlineData" =>
+        %{
+          "mimeType" => Keyword.fetch!(part.options, :media),
+          "data" => part.content
+        }
+        |> maybe_add_display_name(part.options)
+    }
+  end
+
   defp tool_result_media_part_for_api(%ContentPart{type: :image_url} = part) do
     %{
       "fileData" =>
@@ -440,7 +451,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
   end
 
   defp tool_result_media_part?(%ContentPart{type: type})
-       when type in [:image, :image_url, :file_url],
+       when type in [:image, :file, :image_url, :file_url],
        do: true
 
   defp tool_result_media_part?(%ContentPart{}), do: false

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -316,6 +316,57 @@ defmodule ChatModels.ChatVertexAITest do
              } = data
     end
 
+    test "preserves inline file parts as inlineData in functionResponse", %{
+      vertex_ai: vertex_ai
+    } do
+      data =
+        ChatVertexAI.for_api(
+          vertex_ai,
+          [
+            Message.new_tool_result!(%{
+              tool_results: [
+                ToolResult.new!(%{
+                  tool_call_id: "call_123",
+                  name: "read_document",
+                  content: [
+                    ContentPart.text!(Jason.encode!(%{"summary" => "See attached document"})),
+                    ContentPart.file!("base64-pdf-data",
+                      media: "application/pdf",
+                      display_name: "report.pdf"
+                    )
+                  ]
+                })
+              ]
+            })
+          ],
+          []
+        )
+
+      assert %{
+               "contents" => [
+                 %{
+                   "parts" => [
+                     %{
+                       "functionResponse" => %{
+                         "name" => "read_document",
+                         "response" => %{"summary" => "See attached document"},
+                         "parts" => [
+                           %{
+                             "inlineData" => %{
+                               "mimeType" => "application/pdf",
+                               "data" => "base64-pdf-data",
+                               "displayName" => "report.pdf"
+                             }
+                           }
+                         ]
+                       }
+                     }
+                   ]
+                 }
+               ]
+             } = data
+    end
+
     test "preserves display names for inline image tool results", %{vertex_ai: vertex_ai} do
       data =
         ChatVertexAI.for_api(


### PR DESCRIPTION
## Summary

- Expands `ChatVertexAI` to support Vertex AI's multimodal `functionResponse` shape for tool results — a JSON/text `response` plus optional non-text media `parts`
- Splits tool result content into decoded `response` (text parts) and optional `functionResponse.parts` (media entries as `inlineData` or `fileData`)
- Supports `:image` (base64), `:file` (base64), `:image_url`, and `:file_url` content part types with optional `displayName` propagation
- Handles plain text, JSON string, list-of-parts, media-only, and nil tool result content

Based on the work in #489 by @joechiarella, with an additional fix for `:file` type content parts (base64-encoded non-image files like PDFs) which were silently dropped. Supersedes #489 since maintainer push access was not enabled on that PR.

Relevant Vertex AI docs: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling#mm-fr

## Test plan

- [x] Unit tests for inline image parts, URL-based parts, `displayName` propagation
- [x] Unit test for `:file` content parts (e.g. `application/pdf`) serialized as `inlineData`
- [x] Unit test for media-only tool results (empty response object)
- [x] Unit tests for plain text and JSON string backward compatibility
- [x] Live integration test with `gemini-3-flash-preview` (tagged `live_call`)
- [x] Full `mix precommit` passes (1570 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)