### PR TITLE
test: add regression tests for streaming token usage with non-empty choices

### DIFF
--- a/test/chat_models/chat_deepseek_test.exs
+++ b/test/chat_models/chat_deepseek_test.exs
@@ -1173,5 +1173,50 @@ defmodule LangChain.ChatModels.ChatDeepSeekTest do
       assert msg.metadata.usage.input == 5
       assert msg.metadata.usage.output == 3
     end
+
+    test "handles streaming chunk with both choices and usage data" do
+      model = ChatDeepSeek.new!(%{"model" => @test_model})
+
+      # DeepSeek sends token usage in the final streaming chunk alongside a
+      # choice that has a delta with empty content and finish_reason "stop",
+      # unlike OpenAI which sends usage in a chunk with empty choices.
+      response = %{
+        "id" => "339eade8-b499-472e-bc0d-b267b6e4bceb",
+        "object" => "chat.completion.chunk",
+        "model" => "deepseek-chat",
+        "system_fingerprint" => "fp_3d5141a69a_prod0225",
+        "choices" => [
+          %{
+            "index" => 0,
+            "delta" => %{
+              "content" => ""
+            },
+            "logprobs" => nil,
+            "finish_reason" => "stop"
+          }
+        ],
+        "usage" => %{
+          "prompt_tokens" => 11,
+          "completion_tokens" => 12,
+          "total_tokens" => 23,
+          "prompt_tokens_details" => %{
+            "cached_tokens" => 0
+          },
+          "prompt_cache_hit_tokens" => 0,
+          "prompt_cache_miss_tokens" => 11
+        }
+      }
+
+      assert [%MessageDelta{} = delta] = ChatDeepSeek.do_process_response(model, response)
+      assert delta.status == :complete
+
+      # Token usage is extracted and attached to the delta
+      assert %TokenUsage{input: 11, output: 12} = delta.metadata.usage
+      assert delta.metadata.usage.raw["prompt_cache_hit_tokens"] == 0
+      assert delta.metadata.usage.raw["prompt_cache_miss_tokens"] == 11
+
+      # DeepSeek metadata is preserved
+      assert delta.metadata.system_fingerprint == "fp_3d5141a69a_prod0225"
+    end
   end
 end

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -2373,6 +2373,40 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert delta4.index == 0
       assert delta4.tool_calls == nil
     end
+
+    test "handles streaming chunk with both choices and usage data", %{model: model} do
+      # Some OpenAI-compatible providers (e.g. DeepSeek) send token usage in
+      # the final streaming chunk alongside a choice with a delta, rather
+      # than in a separate chunk with empty choices.
+      {:ok, model} = model
+
+      response = %{
+        "choices" => [
+          %{
+            "index" => 0,
+            "delta" => %{
+              "content" => ""
+            },
+            "logprobs" => nil,
+            "finish_reason" => "stop"
+          }
+        ],
+        "usage" => %{
+          "prompt_tokens" => 11,
+          "completion_tokens" => 12,
+          "total_tokens" => 23,
+          "prompt_tokens_details" => %{
+            "cached_tokens" => 0
+          }
+        }
+      }
+
+      assert [%MessageDelta{} = delta] = ChatOpenAI.do_process_response(model, response)
+      assert delta.status == :complete
+
+      # Token usage is extracted and attached to the delta
+      assert %TokenUsage{input: 11, output: 12} = delta.metadata.usage
+    end
   end
 
   def get_streamed_deltas_basic_text do


### PR DESCRIPTION
## Summary

- Adds regression tests for the DeepSeek streaming token usage format where usage data arrives in the final chunk alongside non-empty choices (with empty content delta and `finish_reason: "stop"`)
- Tests added to both `ChatDeepSeek` and `ChatOpenAI` (for OpenAI-compatible providers)
- The underlying code already handles this correctly after refactoring -- these tests prevent regressions

## Context

PR #288 identified that DeepSeek sends token usage in a different format than OpenAI during streaming. OpenAI sends usage in a separate chunk with empty choices, while DeepSeek bundles it in the final chunk alongside a choice.

The code has since been refactored so that `get_token_usage/1` is called upfront in `do_process_response/2` and the result is attached to all processed choices via `TokenUsage.set/2`, naturally handling both formats. However, there were no tests documenting or verifying this behavior.

This PR adds those tests using the exact sample data from the DeepSeek API documentation. PR #288 can be closed after this is merged.

Relates to #288

## Test plan

- [x] `mix precommit` passes (1602 tests, 0 failures)
- [x] New tests verify token usage extraction from non-empty-choices chunks
- [x] New tests verify the resulting `MessageDelta` has correct status and metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)