### PR TITLE
fix: handle streaming overloaded_error from Anthropic API

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -769,6 +769,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   def retry_on_fallback?(%LangChainError{type: "rate_limited"}), do: true
   def retry_on_fallback?(%LangChainError{type: "rate_limit_exceeded"}), do: true
   def retry_on_fallback?(%LangChainError{type: "overloaded"}), do: true
+  def retry_on_fallback?(%LangChainError{type: "overloaded_error"}), do: true
   def retry_on_fallback?(%LangChainError{type: "timeout"}), do: true
   def retry_on_fallback?(%LangChainError{type: "invalid_request_error"}), do: false
   def retry_on_fallback?(_), do: false
@@ -957,7 +958,15 @@ defmodule LangChain.ChatModels.ChatAnthropic do
           %{model: anthropic.model}
         )
 
-        data
+        # Check for error tuples embedded in the accumulated streaming data.
+        # When an API error event (e.g., overloaded_error) arrives mid-stream
+        # on a 200 connection, do_process_response returns
+        # {:error, %LangChainError{}} which gets accumulated in the response
+        # body list instead of short-circuiting the stream.
+        case extract_streaming_error(data) do
+          {:error, _} = error -> error
+          nil -> data
+        end
 
       # The error tuple was successfully received from the API. Unwrap it and
       # return it as an error.
@@ -1000,6 +1009,21 @@ defmodule LangChain.ChatModels.ChatAnthropic do
          )}
     end
   end
+
+  # Scan the accumulated streaming response body for error tuples. During
+  # streaming on a 200 connection, API error events (like overloaded_error)
+  # get accumulated into the body list as {:error, %LangChainError{}} tuples
+  # instead of being returned directly. This extracts the first such error.
+  defp extract_streaming_error(data) when is_list(data) do
+    data
+    |> List.flatten()
+    |> Enum.find_value(fn
+      {:error, %LangChainError{}} = error -> error
+      _ -> nil
+    end)
+  end
+
+  defp extract_streaming_error(_data), do: nil
 
   defp aws_sigv4_opts(nil), do: nil
   defp aws_sigv4_opts(%BedrockConfig{} = bedrock), do: BedrockConfig.aws_sigv4_opts(bedrock)

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -2008,6 +2008,31 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
       assert reason.message == "Overloaded (from test)"
     end
 
+    test "returns error when overloaded_error arrives as SSE event in streaming response" do
+      # Simulates the real streaming scenario: HTTP 200 succeeds, but an
+      # overloaded_error arrives as an SSE event. The streaming accumulator
+      # puts the {:error, error} tuple into the response body list.
+      error =
+        LangChainError.exception(
+          type: "overloaded_error",
+          message: "Overloaded",
+          original: %{
+            "type" => "error",
+            "error" => %{"type" => "overloaded_error", "message" => "Overloaded"}
+          }
+        )
+
+      expect(Req, :post, fn _req_struct, _opts ->
+        {:ok, %Req.Response{status: 200, body: [[{:error, error}]], headers: %{}}}
+      end)
+
+      model = ChatAnthropic.new!(%{stream: true, model: @test_model})
+      assert {:error, reason} = ChatAnthropic.call(model, "prompt", [])
+
+      assert reason.type == "overloaded_error"
+      assert reason.message == "Overloaded"
+    end
+
     for api <- @apis do
       Module.put_attribute(__MODULE__, :tag, {:"live_#{api}", true})
       @tag live_call: true, live_api: api
@@ -4739,6 +4764,44 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
       # Message-level helper collects all citations
       all_citations = Message.all_citations(merged)
       assert length(all_citations) == 2
+    end
+  end
+
+  describe "retry_on_fallback?/1" do
+    test "returns true for overloaded (non-streaming HTTP 529 type)" do
+      assert ChatAnthropic.retry_on_fallback?(
+               LangChainError.exception(type: "overloaded", message: "Overloaded")
+             )
+    end
+
+    test "returns true for overloaded_error (streaming SSE event type)" do
+      assert ChatAnthropic.retry_on_fallback?(
+               LangChainError.exception(type: "overloaded_error", message: "Overloaded")
+             )
+    end
+
+    test "returns true for rate_limited" do
+      assert ChatAnthropic.retry_on_fallback?(
+               LangChainError.exception(type: "rate_limited", message: "Rate limited")
+             )
+    end
+
+    test "returns true for timeout" do
+      assert ChatAnthropic.retry_on_fallback?(
+               LangChainError.exception(type: "timeout", message: "Timed out")
+             )
+    end
+
+    test "returns false for invalid_request_error" do
+      refute ChatAnthropic.retry_on_fallback?(
+               LangChainError.exception(type: "invalid_request_error", message: "Bad request")
+             )
+    end
+
+    test "returns false for unknown error types" do
+      refute ChatAnthropic.retry_on_fallback?(
+               LangChainError.exception(type: "something_else", message: "Unknown")
+             )
     end
   end
 end


### PR DESCRIPTION
## Summary

- When an `overloaded_error` arrives as an SSE event during streaming on a 200 connection, the error tuple gets accumulated into the response body list instead of being returned as `{:error, %LangChainError{}}`. This causes a `CaseClauseError` in `LLMChain.do_run/1` (or a generic "unexpected_response" error on v0.6.3+ after #484's catch-all).
- Adds `extract_streaming_error/1` in `ChatAnthropic.do_api_request` to scan the accumulated streaming body for error tuples and surface them properly before they reach `call/3`.
- Adds `"overloaded_error"` to `retry_on_fallback?/1` so streaming errors trigger fallback model retry. The non-streaming path (HTTP 529) creates type `"overloaded"` while the streaming SSE path passes through the API's raw type `"overloaded_error"` — both now match.

Reported in sagents-ai/sagents#31 and related to #193.

## Root cause

The streaming accumulator in `Utils.handle_stream_fn` treats all `transform_data_fn` return values identically — `%MessageDelta{}` structs and `{:error, %LangChainError{}}` tuples alike get appended to the response body. When Anthropic sends an error event mid-stream on a 200 connection:

1. `do_process_response/2` returns `{:error, %LangChainError{type: "overloaded_error"}}`
2. The streaming accumulator adds it to the body: `[[{:error, error}]]`
3. `do_api_request` returns the raw data
4. `call/3` wraps it as `{:ok, [[error: %LangChainError{...}]]}` 
5. `do_run/1` has no matching clause for this shape

The existing test for this scenario mocked `Req.post` to return `{:ok, {:error, ...}}` directly, bypassing the streaming accumulator entirely.

## Future improvement

The fix is scoped to `ChatAnthropic`, but the underlying issue is in the shared `Utils.handle_stream_fn` — it could detect `{:error, _}` tuples from `transform_data_fn` and halt the stream immediately, benefiting all providers. That would be a broader change worth considering separately.

## Test plan

- [x] New test: streaming 200 response with embedded `overloaded_error` tuple returns `{:error, %LangChainError{type: "overloaded_error"}}`
- [x] New tests: `retry_on_fallback?/1` covers both `"overloaded"` and `"overloaded_error"` types
- [x] All existing tests pass (`mix precommit` — 1609 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)