### PR TITLE
feat: add top-level cache_control support to ChatAnthropic

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -171,7 +171,55 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   reduce costs and latency for frequently repeated content. Prompt caching works by caching large blocks of
   content that are likely to be reused across multiple requests.
 
-  Prompt caching is configured through the `cache_control` option in `ContentPart` options. It can be applied
+  ### Automatic Caching (Recommended for Multi-Turn Conversations)
+
+  The simplest way to enable prompt caching is with the top-level `:cache_control` option. Instead of placing
+  `cache_control` on individual content blocks, set it once on the model and Anthropic automatically applies
+  the cache breakpoint to the last cacheable block in each request.
+
+  See [Automatic caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching)
+  in the Anthropic docs for full details.
+
+  **Basic usage (5-minute TTL, the default):**
+
+      model = ChatAnthropic.new!(%{
+        model: "claude-sonnet-4-6",
+        cache_control: %{"type" => "ephemeral"}
+      })
+
+  **With a 1-hour TTL (2x base input token price):**
+
+      model = ChatAnthropic.new!(%{
+        model: "claude-sonnet-4-6",
+        cache_control: %{"type" => "ephemeral", "ttl" => "1h"}
+      })
+
+  #### How It Works in Multi-Turn Conversations
+
+  With automatic caching the cache breakpoint moves forward automatically as conversations grow.
+  Each new request caches everything up to the last cacheable block, and previous content is read
+  from cache:
+
+  - **Request 1**: System + messages written to cache
+  - **Request 2**: Previous content read from cache; new messages written to cache
+  - **Request 3+**: Pattern continues -- old content from cache, new content written
+
+  You do not need to update any cache markers as the conversation grows.
+
+  #### Replaces Manual Message Caching
+
+  Automatic caching supersedes the explicitly managed `:cache_messages` setting. You should use one
+  or the other, not both:
+
+  - **`:cache_control`** (recommended) -- API-managed, automatic breakpoint placement
+  - **`:cache_messages`** -- client-managed, explicit breakpoints on individual user messages
+
+  For new code, prefer `:cache_control` for its simplicity. The `:cache_messages` option remains
+  available for cases where you need fine-grained control over exactly which content blocks are cached.
+
+  ### Per-Block Cache Control
+
+  For fine-grained control, prompt caching can also be configured through the `cache_control` option in `ContentPart` options. It can be applied
   to both system messages, regular user messages, tool results, and tool definitions.
 
   Anthropic limits a conversation to max of 4 cache_control blocks and will refuse to service requests with more.
@@ -510,6 +558,12 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     # Set to %{enabled: false} or nil to disable automatic message caching.
     field :cache_messages, :map
 
+    # Top-level automatic cache control. When set, Anthropic auto-applies the
+    # cache breakpoint to the last cacheable block in the request.
+    # Example: %{"type" => "ephemeral"} or %{"type" => "ephemeral", "ttl" => "1h"}
+    # See: https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching
+    field :cache_control, :map
+
     # Whether to request a JSON-formatted response with a specific schema.
     # Only supported on Claude Opus 4.6, Sonnet 4.6, Sonnet 4.5, Opus 4.5, Haiku 4.5.
     # When set to true, json_schema is required.
@@ -542,6 +596,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     :beta_headers,
     :verbose_api,
     :cache_messages,
+    :cache_control,
     :json_response,
     :json_schema,
     :req_opts
@@ -639,6 +694,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     |> Utils.conditionally_add_to_map(:top_k, anthropic.top_k)
     |> Utils.conditionally_add_to_map(:thinking, anthropic.thinking)
     |> Utils.conditionally_add_to_map(:output_config, set_output_config(anthropic))
+    |> Utils.conditionally_add_to_map(:cache_control, anthropic.cache_control)
     |> maybe_transform_for_bedrock(anthropic.bedrock)
   end
 

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -208,14 +208,16 @@ defmodule LangChain.ChatModels.ChatAnthropic do
 
   #### Replaces Manual Message Caching
 
-  Automatic caching supersedes the explicitly managed `:cache_messages` setting. You should use one
-  or the other, not both:
+  Automatic caching supersedes the `:cache_messages` setting. The `:cache_messages` option was a
+  client-side behavior coded into this module that applied `cache_control` blocks to the last N user
+  messages, approximating the automatic breakpoint behavior that Anthropic now offers natively through
+  the API. It remains available for backward compatibility, but you should use one or the other, not both:
 
   - **`:cache_control`** (recommended) -- API-managed, automatic breakpoint placement
-  - **`:cache_messages`** -- client-managed, explicit breakpoints on individual user messages
+  - **`:cache_messages`** (legacy) -- client-managed, adds `cache_control` to the last N user messages
 
-  For new code, prefer `:cache_control` for its simplicity. The `:cache_messages` option remains
-  available for cases where you need fine-grained control over exactly which content blocks are cached.
+  For fine-grained control over exactly which content blocks are cached, use the `cache_control` option
+  directly on `ContentPart`, `ToolResult`, and `Function` structs (see "Per-Block Cache Control" below).
 
   ### Per-Block Cache Control
 

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -231,6 +231,56 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
                ]
     end
 
+    test "does not include cache_control when not set" do
+      {:ok, anthropic} = ChatAnthropic.new(%{model: @test_model})
+
+      data = ChatAnthropic.for_api(anthropic, [], [])
+      refute Map.has_key?(data, :cache_control)
+    end
+
+    test "includes top-level cache_control when set to ephemeral" do
+      {:ok, anthropic} =
+        ChatAnthropic.new(%{
+          model: @test_model,
+          cache_control: %{"type" => "ephemeral"}
+        })
+
+      data = ChatAnthropic.for_api(anthropic, [], [])
+      assert %{cache_control: %{"type" => "ephemeral"}} = data
+    end
+
+    test "includes top-level cache_control with TTL" do
+      {:ok, anthropic} =
+        ChatAnthropic.new(%{
+          model: @test_model,
+          cache_control: %{"type" => "ephemeral", "ttl" => "1h"}
+        })
+
+      data = ChatAnthropic.for_api(anthropic, [], [])
+      assert %{cache_control: %{"type" => "ephemeral", "ttl" => "1h"}} = data
+    end
+
+    test "top-level cache_control works alongside messages and system prompt" do
+      {:ok, anthropic} =
+        ChatAnthropic.new(%{
+          model: @test_model,
+          cache_control: %{"type" => "ephemeral"}
+        })
+
+      data =
+        ChatAnthropic.for_api(
+          anthropic,
+          [
+            Message.new_system!("You are helpful."),
+            Message.new_user!("Hello")
+          ],
+          []
+        )
+
+      assert %{cache_control: %{"type" => "ephemeral"}, messages: [_user_msg]} = data
+      assert [%{"text" => "You are helpful.", "type" => "text"}] = data.system
+    end
+
     test "generates a map for an API call with max_tokens set" do
       {:ok, anthropic} =
         ChatAnthropic.new(%{


### PR DESCRIPTION
## Summary

- Adds support for Anthropic's [automatic caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#automatic-caching) feature via a new top-level `cache_control` field on `ChatAnthropic`
- When set, the API automatically applies the cache breakpoint to the last cacheable block in each request -- no manual breakpoint management needed
- This supersedes the existing `cache_messages` option for most multi-turn conversation use cases

## Usage

```elixir
# Basic automatic caching (5-minute TTL)
model = ChatAnthropic.new!(%{
  model: "claude-sonnet-4-6",
  cache_control: %{"type" => "ephemeral"}
})

# With 1-hour TTL
model = ChatAnthropic.new!(%{
  model: "claude-sonnet-4-6",
  cache_control: %{"type" => "ephemeral", "ttl" => "1h"}
})
```

## Changes

- **Struct**: New `cache_control` field (`:map`, default `nil`)
- **`for_api/3`**: Conditionally includes `cache_control` in the API request body
- **Docs**: New "Automatic Caching" section explaining the feature and its relationship to `cache_messages`
- **Tests**: 4 new tests covering default (nil), ephemeral, TTL, and coexistence with messages

## Test plan

- [x] `mix test test/chat_models/chat_anthropic_test.exs` -- 126 tests, 0 failures
- [x] `mix precommit` -- 1565 tests, 0 failures
- [ ] Live test with actual Anthropic API to verify cache utilization metrics in response metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)