### PR TITLE
Expand error detection and handling across LLMChain streaming pipeline

### DIFF
--- a/lib/chains/chain_callbacks.ex
+++ b/lib/chains/chain_callbacks.ex
@@ -216,6 +216,74 @@ defmodule LangChain.Chains.ChainCallbacks do
   @type chain_tool_response_created :: (LLMChain.t(), Message.t() -> any())
 
   @typedoc """
+  Executed when an individual LLM API call fails with an error.
+
+  This fires on **every** LLM call failure, including transient errors that may
+  be retried or recovered from via fallbacks. It provides visibility into errors
+  that would otherwise be invisible when retries succeed.
+
+  Use this callback for diagnostic/observational purposes -- logging, metrics,
+  debug dashboards. The chain may continue executing after this callback fires.
+
+  ## Examples
+
+  Common scenarios where this fires:
+  - Rate limit errors (may be retried)
+  - Overloaded/server errors (may fall back to another model)
+  - Authentication errors (terminal)
+  - Network timeouts (may be retried)
+
+  In a retry loop: fires once per failed attempt, not just when retries are
+  exhausted. In a fallback chain: fires for each model that fails before the
+  next one is tried.
+
+      callback_handler = %{
+        on_llm_error: fn _chain, error ->
+          Logger.warning("LLM call failed: \#{inspect(error)}")
+        end
+      }
+
+  - First argument: LLMChain.t() - Current chain state
+  - Second argument: LangChainError.t() - The error from the LLM call
+
+  The handler's return value is discarded.
+  """
+  @type chain_llm_error :: (LLMChain.t(), LangChainError.t() -> any())
+
+  @typedoc """
+  Executed when the chain encounters a terminal error and is returning an error
+  result to the caller.
+
+  Unlike `on_llm_error` which fires on every individual LLM failure (including
+  transient ones), this callback fires exactly **once** when the chain has
+  exhausted all recovery options (retries, fallbacks) and is giving up.
+
+  This is the chain-level "final answer is an error" signal. Use this for
+  application-level error handling -- updating UI state, notifying users,
+  recording failures.
+
+  ## Examples
+
+  Scenarios where this fires:
+  - All retry attempts exhausted
+  - All fallback models failed
+  - Unrecoverable error (e.g., invalid request)
+  - Rescued exception during chain execution
+
+      callback_handler = %{
+        on_error: fn _chain, error ->
+          send(live_view_pid, {:chain_error, error})
+        end
+      }
+
+  - First argument: LLMChain.t() - Chain state at time of failure
+  - Second argument: LangChainError.t() - The terminal error
+
+  The handler's return value is discarded.
+  """
+  @type chain_error :: (LLMChain.t(), LangChainError.t() -> any())
+
+  @typedoc """
   Executed when the chain failed multiple times used up the `max_retry_count`
   resulting in the process aborting and returning an error.
 
@@ -244,6 +312,8 @@ defmodule LangChain.Chains.ChainCallbacks do
           optional(:on_tool_execution_failed) => chain_tool_execution_failed(),
           optional(:on_tool_interrupted) => chain_tool_interrupted(),
           optional(:on_tool_response_created) => chain_tool_response_created(),
+          optional(:on_llm_error) => chain_llm_error(),
+          optional(:on_error) => chain_error(),
           optional(:on_retries_exceeded) => chain_retries_exceeded()
         }
 end

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -902,8 +902,7 @@ defmodule LangChain.Chains.LLMChain do
         case apply_deltas(chain, deltas) do
           {:ok, updated_chain} ->
             if chain.verbose,
-              do:
-                IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
+              do: IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
 
             {:ok, updated_chain}
 
@@ -917,8 +916,7 @@ defmodule LangChain.Chains.LLMChain do
         case apply_deltas(chain, deltas) do
           {:ok, updated_chain} ->
             if chain.verbose,
-              do:
-                IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
+              do: IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
 
             {:ok, updated_chain}
 

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -898,21 +898,33 @@ defmodule LangChain.Chains.LLMChain do
 
       {:ok, [%MessageDelta{} | _] = deltas} ->
         if chain.verbose_deltas, do: IO.inspect(deltas, label: "DELTA MESSAGE LIST RESPONSE")
-        updated_chain = apply_deltas(chain, deltas)
 
-        if chain.verbose,
-          do: IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
+        case apply_deltas(chain, deltas) do
+          {:ok, updated_chain} ->
+            if chain.verbose,
+              do:
+                IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
 
-        {:ok, updated_chain}
+            {:ok, updated_chain}
+
+          {:error, _chain, _reason} = error ->
+            error
+        end
 
       {:ok, [[%MessageDelta{} | _] | _] = deltas} ->
         if chain.verbose_deltas, do: IO.inspect(deltas, label: "DELTA MESSAGE LIST RESPONSE")
-        updated_chain = apply_deltas(chain, deltas)
 
-        if chain.verbose,
-          do: IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
+        case apply_deltas(chain, deltas) do
+          {:ok, updated_chain} ->
+            if chain.verbose,
+              do:
+                IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
 
-        {:ok, updated_chain}
+            {:ok, updated_chain}
+
+          {:error, _chain, _reason} = error ->
+            error
+        end
 
       {:error, %LangChainError{} = reason} ->
         if chain.verbose, do: IO.inspect(reason, label: "ERROR")
@@ -998,21 +1010,28 @@ defmodule LangChain.Chains.LLMChain do
   `last_message` and list of messages are updated. The message is processed and
   fires any registered callbacks.
   """
-  @spec apply_deltas(t(), list()) :: t()
+  @spec apply_deltas(t(), list()) :: {:ok, t()} | {:error, t(), LangChainError.t()}
   def apply_deltas(%LLMChain{} = chain, deltas) when is_list(deltas) do
-    chain
-    |> merge_deltas(deltas)
-    |> delta_to_message_when_complete()
+    case merge_deltas(chain, deltas) do
+      {:error, _chain, _reason} = error ->
+        error
+
+      %LLMChain{} = merged_chain ->
+        delta_to_message_when_complete(merged_chain)
+    end
   end
 
   @doc """
   Merge a list of deltas into the chain.
   """
-  @spec merge_deltas(t(), list()) :: t()
+  @spec merge_deltas(t(), list()) :: t() | {:error, t(), LangChainError.t()}
   def merge_deltas(%LLMChain{} = chain, deltas) do
     deltas
     |> List.flatten()
-    |> Enum.reduce(chain, fn d, acc -> merge_delta(acc, d) end)
+    |> Enum.reduce(chain, fn
+      _d, {:error, _chain, _reason} = error -> error
+      d, %LLMChain{} = acc -> merge_delta(acc, d)
+    end)
   end
 
   @doc """
@@ -1139,7 +1158,8 @@ defmodule LangChain.Chains.LLMChain do
 
   If the delta is `nil`, the chain is returned unmodified.
   """
-  @spec delta_to_message_when_complete(t()) :: t()
+  @spec delta_to_message_when_complete(t()) ::
+          {:ok, t()} | {:error, t(), LangChainError.t()}
   def delta_to_message_when_complete(
         %LLMChain{delta: %MessageDelta{status: status} = delta} = chain
       )
@@ -1147,19 +1167,24 @@ defmodule LangChain.Chains.LLMChain do
     # it's complete. Attempt to convert delta to a message
     case MessageDelta.to_message(delta) do
       {:ok, %Message{} = message} ->
-        process_message(reset_streaming_state(chain), message)
+        {:ok, process_message(reset_streaming_state(chain), message)}
 
       {:error, reason} ->
         # Delta conversion failed. Log the error and clear the delta to prevent
         # it from interfering with subsequent API calls.
         Logger.warning("Error applying delta message. Reason: #{inspect(reason)}")
-        reset_streaming_state(chain)
+
+        {:error, reset_streaming_state(chain),
+         LangChainError.exception(
+           type: "delta_conversion_failed",
+           message: "Error applying delta message: #{inspect(reason)}"
+         )}
     end
   end
 
   def delta_to_message_when_complete(%LLMChain{} = chain) do
     # either no delta or incomplete
-    chain
+    {:ok, chain}
   end
 
   # Process an assistant message sequentially through each message processor.
@@ -1812,8 +1837,17 @@ defmodule LangChain.Chains.LLMChain do
 
         add_message(updated_chain, message)
 
-      {:error, _reason} ->
-        chain
+      {:error, reason} ->
+        Logger.warning(
+          "Failed to convert delta to message during cancel_delta. Reason: #{inspect(reason)}"
+        )
+
+        {:error, updated_chain,
+         LangChainError.exception(
+           type: "delta_conversion_failed",
+           message:
+             "Failed to convert streaming delta to message during cancellation: #{inspect(reason)}"
+         )}
     end
   end
 

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -635,21 +635,32 @@ defmodule LangChain.Chains.LLMChain do
         tool_count: length(chain.tools)
       }
 
-      LangChain.Telemetry.span([:langchain, :chain, :execute], metadata, fn ->
-        # Run the chain and return the success or error results. NOTE: We do not add
-        # the current LLM to the list and process everything through a single
-        # codepath because failing after attempted fallbacks returns a different
-        # error.
-        if Keyword.has_key?(opts, :with_fallbacks) do
-          # run function and using fallbacks as needed.
-          with_fallbacks(chain, opts, function_to_run)
-        else
-          # run it directly right now and return the success or error
-          function_to_run.(chain)
-        end
-      end)
+      result =
+        LangChain.Telemetry.span([:langchain, :chain, :execute], metadata, fn ->
+          # Run the chain and return the success or error results. NOTE: We do not add
+          # the current LLM to the list and process everything through a single
+          # codepath because failing after attempted fallbacks returns a different
+          # error.
+          if Keyword.has_key?(opts, :with_fallbacks) do
+            # run function and using fallbacks as needed.
+            with_fallbacks(chain, opts, function_to_run)
+          else
+            # run it directly right now and return the success or error
+            function_to_run.(chain)
+          end
+        end)
+
+      case result do
+        {:error, error_chain, reason} ->
+          Callbacks.fire(error_chain.callbacks, :on_error, [error_chain, reason])
+          result
+
+        _other ->
+          result
+      end
     rescue
       err in LangChainError ->
+        Callbacks.fire(chain.callbacks, :on_error, [chain, err])
         {:error, chain, err}
     end
   end
@@ -816,11 +827,22 @@ defmodule LangChain.Chains.LLMChain do
         tool_count: length(chain.tools)
       }
 
-      LangChain.Telemetry.span([:langchain, :chain, :execute], metadata, fn ->
-        Modes.UntilToolUsed.run(chain, mode_opts)
-      end)
+      result =
+        LangChain.Telemetry.span([:langchain, :chain, :execute], metadata, fn ->
+          Modes.UntilToolUsed.run(chain, mode_opts)
+        end)
+
+      case result do
+        {:error, error_chain, reason} ->
+          Callbacks.fire(error_chain.callbacks, :on_error, [error_chain, reason])
+          result
+
+        _other ->
+          result
+      end
     rescue
       err in LangChainError ->
+        Callbacks.fire(chain.callbacks, :on_error, [chain, err])
         {:error, chain, err}
     end
   end
@@ -894,11 +916,14 @@ defmodule LangChain.Chains.LLMChain do
 
       {:error, %LangChainError{} = reason} ->
         if chain.verbose, do: IO.inspect(reason, label: "ERROR")
+        Callbacks.fire(chain.callbacks, :on_llm_error, [chain, reason])
         {:error, chain, reason}
 
       {:error, string_reason} when is_binary(string_reason) ->
         if chain.verbose, do: IO.inspect(string_reason, label: "ERROR")
-        {:error, chain, LangChainError.exception(message: string_reason)}
+        reason = LangChainError.exception(message: string_reason)
+        Callbacks.fire(chain.callbacks, :on_llm_error, [chain, reason])
+        {:error, chain, reason}
 
       {:ok, []} ->
         # Empty response — all choices were filtered out (e.g., thinking model

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -1964,7 +1964,11 @@ defmodule LangChain.ChatModels.ChatAnthropic do
 
       :base64 ->
         media =
-          case Keyword.fetch!(opts, :media) do
+          case Keyword.get(opts, :media) do
+            nil ->
+              raise LangChainError,
+                    "Required :media option missing for base64-encoded image ContentPart"
+
             :png ->
               "image/png"
 
@@ -2014,7 +2018,15 @@ defmodule LangChain.ChatModels.ChatAnthropic do
           }
 
         :base64 ->
-          media = Keyword.fetch!(opts, :media)
+          media =
+            case Keyword.get(opts, :media) do
+              nil ->
+                raise LangChainError,
+                      "Required :media option missing for base64-encoded document ContentPart"
+
+              value ->
+                value
+            end
 
           case media do
             :text ->

--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -51,7 +51,7 @@ defmodule LangChain.MessageDelta do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  require Logger
+
   alias __MODULE__
   alias LangChain.LangChainError
   alias LangChain.Message
@@ -438,10 +438,10 @@ defmodule LangChain.MessageDelta do
       |> Map.from_struct()
       |> Map.put(:content, content)
 
-    with :ok <- validate_not_empty(delta),
-         {:ok, message} <- Message.new(attrs) do
-      {:ok, message}
-    else
+    case Message.new(attrs) do
+      {:ok, message} ->
+        {:ok, message}
+
       {:error, %Ecto.Changeset{} = changeset} ->
         {:error, Utils.changeset_error_to_string(changeset)}
 
@@ -449,23 +449,6 @@ defmodule LangChain.MessageDelta do
         error
     end
   end
-
-  # Validate that assistant message is not empty (no content and no tool_calls).
-  # Empty assistant messages violate conversation flow rules in most LLM APIs.
-  defp validate_not_empty(%MessageDelta{
-         role: :assistant,
-         merged_content: merged_content,
-         tool_calls: tool_calls,
-         status: :complete
-       })
-       when (merged_content == [] or merged_content == nil) and
-              (tool_calls == [] or tool_calls == nil) do
-    Logger.warning("Received empty assistant message with no content and no tool_calls")
-
-    {:error, "Empty assistant message: no content and no tool_calls"}
-  end
-
-  defp validate_not_empty(_delta), do: :ok
 
   # Filter nil values from list (from index padding during delta merging)
   @spec reject_nil(list() | any()) :: list() | any()

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -2527,6 +2527,208 @@ defmodule LangChain.Chains.LLMChainTest do
       assert {:ok, log} = result
       assert log =~ "Error applying delta message"
     end
+
+    test "on_llm_error fires on each LLM call failure" do
+      handler = %{
+        on_llm_error: fn _chain, error ->
+          send(self(), {:llm_error_callback, error})
+        end
+      }
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:error, LangChainError.exception(type: "rate_limit", message: "Rate limited")}
+      end)
+
+      {:error, _chain, _reason} =
+        %{llm: ChatOpenAI.new!(%{stream: false}), callbacks: [handler]}
+        |> LLMChain.new!()
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+        |> LLMChain.run()
+
+      assert_received {:llm_error_callback, %LangChainError{type: "rate_limit"}}
+    end
+
+    test "on_llm_error fires for string error reasons" do
+      handler = %{
+        on_llm_error: fn _chain, error ->
+          send(self(), {:llm_error_callback, error})
+        end
+      }
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:error, "Something went wrong"}
+      end)
+
+      {:error, _chain, _reason} =
+        %{llm: ChatOpenAI.new!(%{stream: false}), callbacks: [handler]}
+        |> LLMChain.new!()
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+        |> LLMChain.run()
+
+      assert_received {:llm_error_callback, %LangChainError{message: "Something went wrong"}}
+    end
+
+    test "on_llm_error fires for each failed model during fallbacks" do
+      handler = %{
+        on_llm_error: fn _chain, error ->
+          send(self(), {:llm_error_callback, error})
+        end
+      }
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:error, LangChainError.exception(type: "too_many_requests", message: "Too many requests!")}
+      end)
+
+      expect(ChatAnthropic, :call, fn _model, _messages, _tools ->
+        {:error, LangChainError.exception(type: "overloaded", message: "Overloaded")}
+      end)
+
+      {:error, _chain, _reason} =
+        %{llm: ChatOpenAI.new!(%{stream: false}), callbacks: [handler]}
+        |> LLMChain.new!()
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+        |> LLMChain.run(with_fallbacks: [ChatAnthropic.new!(%{stream: false})])
+
+      # Both individual LLM failures should have fired
+      assert_received {:llm_error_callback, %LangChainError{type: "too_many_requests"}}
+      assert_received {:llm_error_callback, %LangChainError{type: "overloaded"}}
+    end
+
+    test "on_llm_error fires but on_error does not when fallback recovers" do
+      handler = %{
+        on_llm_error: fn _chain, error ->
+          send(self(), {:llm_error_callback, error})
+        end,
+        on_error: fn _chain, error ->
+          send(self(), {:error_callback, error})
+        end
+      }
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:error, LangChainError.exception(type: "too_many_requests", message: "Too many requests!")}
+      end)
+
+      expect(ChatAnthropic, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!(%{content: "Recovered!"})]}
+      end)
+
+      {:ok, _chain} =
+        %{llm: ChatOpenAI.new!(%{stream: false}), callbacks: [handler]}
+        |> LLMChain.new!()
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+        |> LLMChain.run(with_fallbacks: [ChatAnthropic.new!(%{stream: false})])
+
+      # Transient LLM error was observed
+      assert_received {:llm_error_callback, %LangChainError{type: "too_many_requests"}}
+      # But the chain succeeded, so on_error should NOT fire
+      refute_received {:error_callback, _}
+    end
+
+    test "on_error fires once on terminal failure" do
+      handler = %{
+        on_error: fn _chain, error ->
+          send(self(), {:error_callback, error})
+        end
+      }
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:error, LangChainError.exception(type: "auth_error", message: "Invalid API key")}
+      end)
+
+      {:error, _chain, _reason} =
+        %{llm: ChatOpenAI.new!(%{stream: false}), callbacks: [handler]}
+        |> LLMChain.new!()
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+        |> LLMChain.run()
+
+      assert_received {:error_callback, %LangChainError{type: "auth_error"}}
+      # Should only fire once
+      refute_received {:error_callback, _}
+    end
+
+    test "on_error fires once when all fallbacks fail" do
+      handler = %{
+        on_error: fn _chain, error ->
+          send(self(), {:error_callback, error})
+        end
+      }
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:error, LangChainError.exception(type: "too_many_requests", message: "Too many requests!")}
+      end)
+
+      expect(ChatAnthropic, :call, fn _model, _messages, _tools ->
+        {:error, LangChainError.exception(type: "overloaded", message: "Overloaded")}
+      end)
+
+      {:error, _chain, _reason} =
+        %{llm: ChatOpenAI.new!(%{stream: false}), callbacks: [handler]}
+        |> LLMChain.new!()
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+        |> LLMChain.run(with_fallbacks: [ChatAnthropic.new!(%{stream: false})])
+
+      # on_error fires once with the terminal "all_fallbacks_failed" error
+      assert_received {:error_callback, %LangChainError{type: "all_fallbacks_failed"}}
+      refute_received {:error_callback, _}
+    end
+
+    test "on_error fires when retries are exceeded" do
+      handler = %{
+        on_llm_error: fn _chain, error ->
+          send(self(), {:llm_error_callback, error})
+        end,
+        on_error: fn _chain, error ->
+          send(self(), {:error_callback, error})
+        end
+      }
+
+      # Will be called 2 times (initial + 1 retry before exhausting max_retry_count of 2)
+      fake_messages = [
+        Message.new_assistant!(%{content: "Not valid JSON"})
+      ]
+
+      expect(ChatOpenAI, :call, 2, fn _model, _messages, _tools ->
+        {:ok, fake_messages}
+      end)
+
+      {:error, _chain, reason} =
+        %{
+          llm: ChatOpenAI.new!(%{stream: false}),
+          max_retry_count: 2,
+          callbacks: [handler]
+        }
+        |> LLMChain.new!()
+        |> LLMChain.message_processors([JsonProcessor.new!()])
+        |> LLMChain.add_message(Message.new_user!("Give me JSON"))
+        |> LLMChain.run(mode: :while_needs_response)
+
+      assert reason.type == "exceeded_failure_count"
+
+      # on_error fires once for the terminal failure
+      assert_received {:error_callback, %LangChainError{type: "exceeded_failure_count"}}
+      refute_received {:error_callback, _}
+
+      # on_llm_error should NOT have fired -- the LLM calls themselves succeeded,
+      # it was the message processor that failed
+      refute_received {:llm_error_callback, _}
+    end
+
+    test "on_error fires for rescued LangChainError exceptions" do
+      handler = %{
+        on_error: fn _chain, error ->
+          send(self(), {:error_callback, error})
+        end
+      }
+
+      # Running with no messages raises a LangChainError which is rescued in run/2
+      {:error, _chain, error} =
+        %{llm: ChatOpenAI.new!(%{stream: false}), callbacks: [handler]}
+        |> LLMChain.new!()
+        |> LLMChain.run()
+
+      assert error.message == "LLMChain cannot be run without messages"
+      assert_received {:error_callback, %LangChainError{message: "LLMChain cannot be run without messages"}}
+    end
   end
 
   describe "run_until_tool_used/3" do
@@ -2637,6 +2839,32 @@ defmodule LangChain.Chains.LLMChainTest do
 
       assert error.type == "invalid_tool_name"
       assert error.message == "Tool name 'non_existent_tool' not found in available tools"
+    end
+
+    test "on_error fires on terminal failure in run_until_tool_used", %{greet: greet} do
+      handler = %{
+        on_llm_error: fn _chain, error ->
+          send(self(), {:llm_error_callback, error})
+        end,
+        on_error: fn _chain, error ->
+          send(self(), {:error_callback, error})
+        end
+      }
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:error, LangChainError.exception(type: "server_error", message: "Internal error")}
+      end)
+
+      {:error, _chain, _reason} =
+        %{llm: ChatOpenAI.new!(%{stream: false}), callbacks: [handler]}
+        |> LLMChain.new!()
+        |> LLMChain.add_tools([greet])
+        |> LLMChain.add_message(Message.new_user!("Say hello to Tim."))
+        |> LLMChain.run_until_tool_used("greet")
+
+      assert_received {:llm_error_callback, %LangChainError{type: "server_error"}}
+      assert_received {:error_callback, %LangChainError{type: "server_error"}}
+      refute_received {:error_callback, _}
     end
   end
 

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -788,7 +788,7 @@ defmodule LangChain.Chains.LLMChainTest do
       ]
 
       chain = LLMChain.new!(%{llm: ChatOpenAI.new!()})
-      updated_chain = LLMChain.apply_deltas(chain, deltas)
+      {:ok, updated_chain} = LLMChain.apply_deltas(chain, deltas)
 
       assert updated_chain.delta == nil
       %Message{} = last = updated_chain.last_message
@@ -800,17 +800,10 @@ defmodule LangChain.Chains.LLMChainTest do
       assert %TokenUsage{input: 15, output: 4, raw: %{}} = last.metadata.usage
     end
 
-    test "clears delta when conversion to message fails (empty assistant message)" do
-      # This test verifies that when delta-to-message conversion fails,
-      # the delta is cleared from the chain to prevent it from interfering
-      # with subsequent API calls.
-      #
-      # This can happen with Mistral when the model returns empty streaming
-      # responses (no content, no tool_calls), which violates conversation
-      # flow rules.
-
-      # Create deltas that result in an empty assistant message
-      # (no content, no tool_calls) - this will fail to convert to a message
+    test "empty assistant message converts successfully" do
+      # LLMs can return empty assistant messages (e.g., after processing tool
+      # results with nothing more to say). These are valid and should produce
+      # an empty Message rather than an error.
       empty_deltas = [
         [
           %LangChain.MessageDelta{
@@ -834,25 +827,20 @@ defmodule LangChain.Chains.LLMChainTest do
 
       chain = LLMChain.new!(%{llm: ChatOpenAI.new!()})
 
-      # Apply the empty deltas - this should fail to convert but clear the delta
-      updated_chain = LLMChain.apply_deltas(chain, empty_deltas)
+      {:ok, updated_chain} = LLMChain.apply_deltas(chain, empty_deltas)
 
-      # The delta should be cleared (nil) even though conversion failed
       assert updated_chain.delta == nil
-
-      # No message should have been added since conversion failed
-      assert updated_chain.messages == []
-      assert updated_chain.last_message == nil
+      assert updated_chain.last_message.role == :assistant
+      assert updated_chain.last_message.status == :complete
+      assert updated_chain.last_message.content == []
+      assert updated_chain.last_message.tool_calls == []
+      assert updated_chain.needs_response == false
     end
 
-    test "failed delta does not interfere with subsequent delta processing" do
-      # This test verifies that after a failed delta conversion,
-      # subsequent deltas can be processed correctly without interference
-      # from the previous failed delta.
-
+    test "empty assistant message followed by valid deltas processes correctly" do
       chain = LLMChain.new!(%{llm: ChatOpenAI.new!()})
 
-      # First, apply empty deltas that will fail to convert
+      # First, apply empty deltas - these now succeed as empty messages
       empty_deltas = [
         [
           %LangChain.MessageDelta{
@@ -874,8 +862,8 @@ defmodule LangChain.Chains.LLMChainTest do
         ]
       ]
 
-      chain_after_failure = LLMChain.apply_deltas(chain, empty_deltas)
-      assert chain_after_failure.delta == nil
+      {:ok, chain_after_empty} = LLMChain.apply_deltas(chain, empty_deltas)
+      assert chain_after_empty.delta == nil
 
       # Now apply valid deltas - they should work correctly
       valid_deltas = [
@@ -899,18 +887,110 @@ defmodule LangChain.Chains.LLMChainTest do
         ]
       ]
 
-      final_chain = LLMChain.apply_deltas(chain_after_failure, valid_deltas)
+      {:ok, final_chain} = LLMChain.apply_deltas(chain_after_empty, valid_deltas)
 
-      # The valid deltas should have been processed correctly
       assert final_chain.delta == nil
-      assert final_chain.last_message != nil
       assert final_chain.last_message.role == :assistant
 
-      # Content should be the merged result
       content_text =
         LangChain.Message.ContentPart.parts_to_string(final_chain.last_message.content)
 
       assert content_text == "Hello world!"
+    end
+
+    test "merges empty end-of-turn response with usage metadata" do
+      # Simulates the Anthropic scenario: after processing tool results, the
+      # model responds with only a message_delta containing stop_reason and
+      # usage info but no content or tool calls.
+      empty_deltas_with_usage = [
+        [
+          %LangChain.MessageDelta{
+            content: [],
+            merged_content: [],
+            status: :incomplete,
+            index: nil,
+            role: :assistant,
+            tool_calls: nil,
+            metadata: %{
+              usage: %LangChain.TokenUsage{
+                input: 1,
+                output: 2,
+                raw: %{
+                  "cache_creation_input_tokens" => 221,
+                  "cache_read_input_tokens" => 18890,
+                  "input_tokens" => 1,
+                  "output_tokens" => 2
+                }
+              }
+            }
+          }
+        ],
+        [
+          %LangChain.MessageDelta{
+            content: nil,
+            status: :complete,
+            role: :assistant,
+            tool_calls: nil,
+            metadata: %{
+              usage: %LangChain.TokenUsage{
+                input: 2,
+                output: 4,
+                raw: %{
+                  "cache_creation_input_tokens" => 442,
+                  "cache_read_input_tokens" => 37780,
+                  "input_tokens" => 2,
+                  "output_tokens" => 4
+                }
+              }
+            }
+          }
+        ]
+      ]
+
+      chain = LLMChain.new!(%{llm: ChatOpenAI.new!()})
+      {:ok, updated_chain} = LLMChain.apply_deltas(chain, empty_deltas_with_usage)
+
+      assert updated_chain.delta == nil
+      assert updated_chain.last_message.role == :assistant
+      assert updated_chain.last_message.status == :complete
+      assert updated_chain.last_message.content == []
+      assert updated_chain.last_message.tool_calls == []
+      assert updated_chain.needs_response == false
+
+      # Usage metadata should be preserved on the message
+      assert %LangChain.TokenUsage{input: 3, output: 6} =
+               updated_chain.last_message.metadata.usage
+    end
+
+    test "merges bare end-of-turn response with no additional information" do
+      # Simplest empty response: just "I'm done" with no usage or other metadata.
+      bare_deltas = [
+        [
+          %LangChain.MessageDelta{
+            content: nil,
+            status: :incomplete,
+            role: :assistant,
+            tool_calls: nil
+          }
+        ],
+        [
+          %LangChain.MessageDelta{
+            content: nil,
+            status: :complete,
+            role: :assistant,
+            tool_calls: nil
+          }
+        ]
+      ]
+
+      chain = LLMChain.new!(%{llm: ChatOpenAI.new!()})
+      {:ok, updated_chain} = LLMChain.apply_deltas(chain, bare_deltas)
+
+      assert updated_chain.delta == nil
+      assert updated_chain.last_message.role == :assistant
+      assert updated_chain.last_message.status == :complete
+      assert updated_chain.last_message.content == []
+      assert updated_chain.needs_response == false
     end
 
     test "clears delta when tool call has malformed JSON arguments (issue #443)" do
@@ -966,7 +1046,8 @@ defmodule LangChain.Chains.LLMChainTest do
 
       chain = LLMChain.new!(%{llm: ChatOpenAI.new!()})
 
-      updated_chain = LLMChain.apply_deltas(chain, malformed_tool_deltas)
+      {:error, updated_chain, %LangChainError{type: "delta_conversion_failed"}} =
+        LLMChain.apply_deltas(chain, malformed_tool_deltas)
 
       # Delta must be cleared so it doesn't accumulate garbage on retries
       assert updated_chain.delta == nil
@@ -2473,55 +2554,44 @@ defmodule LangChain.Chains.LLMChainTest do
 
     test "does not loop infinitely when streaming tool call has malformed JSON (issue #443)" do
       # When an LLM returns truncated JSON in tool_call.arguments during streaming,
-      # the chain should clear the delta and retry cleanly rather than appending
-      # new responses to the old garbage and looping forever.
-      call_counter = :counters.new(1, [:atomics])
+      # the chain should return an error rather than silently swallowing the failure.
+      # Previously the delta was silently cleared and appeared as success; now the
+      # error propagates through apply_deltas -> do_run -> run.
 
-      expect(ChatOpenAI, :call, 2, fn _model, _messages, _tools ->
-        call_num = :counters.get(call_counter, 1)
-        :counters.add(call_counter, 1, 1)
-
-        if call_num == 0 do
-          # First call: return truncated/malformed JSON in tool call arguments
-          {:ok,
-           [
-             %MessageDelta{role: :assistant, status: :incomplete, index: 0},
-             %MessageDelta{
-               status: :incomplete,
-               index: 0,
-               tool_calls: [
-                 ToolCall.new!(%{
-                   status: :incomplete,
-                   type: :function,
-                   call_id: "call_bad",
-                   name: "search_web",
-                   arguments: nil,
-                   index: 0
-                 })
-               ]
-             },
-             %MessageDelta{
-               status: :incomplete,
-               index: 0,
-               tool_calls: [
-                 ToolCall.new!(%{
-                   status: :incomplete,
-                   type: :function,
-                   # Truncated JSON - missing closing brace
-                   arguments: "{\"query\": \"test\",\"",
-                   index: 0
-                 })
-               ]
-             },
-             %MessageDelta{status: :complete, index: 0}
-           ]}
-        else
-          # Subsequent call: return a normal text response to end the loop
-          {:ok,
-           [
-             Message.new_assistant!(%{content: "I encountered an error with the tool call."})
-           ]}
-        end
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        # Return truncated/malformed JSON in tool call arguments
+        {:ok,
+         [
+           %MessageDelta{role: :assistant, status: :incomplete, index: 0},
+           %MessageDelta{
+             status: :incomplete,
+             index: 0,
+             tool_calls: [
+               ToolCall.new!(%{
+                 status: :incomplete,
+                 type: :function,
+                 call_id: "call_bad",
+                 name: "search_web",
+                 arguments: nil,
+                 index: 0
+               })
+             ]
+           },
+           %MessageDelta{
+             status: :incomplete,
+             index: 0,
+             tool_calls: [
+               ToolCall.new!(%{
+                 status: :incomplete,
+                 type: :function,
+                 # Truncated JSON - missing closing brace
+                 arguments: "{\"query\": \"test\",\"",
+                 index: 0
+               })
+             ]
+           },
+           %MessageDelta{status: :complete, index: 0}
+         ]}
       end)
 
       search_web =
@@ -2541,18 +2611,61 @@ defmodule LangChain.Chains.LLMChainTest do
         |> LLMChain.add_tools(search_web)
         |> LLMChain.add_message(Message.new_user!("Search for something"))
 
-      # This must complete without hanging - previously it would loop forever
-      task =
-        Task.async(fn ->
-          ExUnit.CaptureLog.capture_log(fn ->
-            LLMChain.run(chain, mode: :while_needs_response)
-          end)
-        end)
+      # The malformed delta should now propagate as an error instead of being
+      # silently swallowed
+      assert {:error, _chain, %LangChainError{type: "delta_conversion_failed"}} =
+               LLMChain.run(chain, mode: :while_needs_response)
+    end
 
-      result = Task.yield(task, 5_000) || Task.shutdown(task, :brutal_kill)
+    test "empty streaming response succeeds in run" do
+      # Return deltas that produce an empty assistant message (no content, no tool_calls).
+      # This is valid -- e.g., LLM has nothing to say after processing tool results.
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok,
+         [
+           MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete}),
+           MessageDelta.new!(%{content: nil, status: :complete})
+         ]}
+      end)
 
-      assert {:ok, log} = result
-      assert log =~ "Error applying delta message"
+      {:ok, chain} =
+        %{llm: ChatOpenAI.new!(%{stream: true})}
+        |> LLMChain.new!()
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+        |> LLMChain.run()
+
+      assert chain.last_message.role == :assistant
+      assert chain.last_message.content == []
+      assert chain.needs_response == false
+    end
+
+    test "streaming error with empty delta produces cancelled message" do
+      # A streaming error occurs while the delta has no content yet.
+      # The cancel_delta path converts it to a cancelled message.
+      handler = %{
+        on_error: fn _chain, error ->
+          send(self(), {:error_callback, error})
+        end
+      }
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok,
+         [
+           MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete}),
+           {:error, LangChainError.exception(type: "overloaded", message: "Server overloaded")}
+         ]}
+      end)
+
+      {:ok, chain} =
+        %{llm: ChatOpenAI.new!(%{stream: true}), callbacks: [handler]}
+        |> LLMChain.new!()
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+        |> LLMChain.run()
+
+      # Empty delta converts successfully to a cancelled message
+      assert chain.last_message.role == :assistant
+      assert chain.last_message.status == :cancelled
+      assert chain.needs_response == false
     end
 
     test "on_llm_error fires on each LLM call failure" do
@@ -2603,7 +2716,8 @@ defmodule LangChain.Chains.LLMChainTest do
       }
 
       expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
-        {:error, LangChainError.exception(type: "too_many_requests", message: "Too many requests!")}
+        {:error,
+         LangChainError.exception(type: "too_many_requests", message: "Too many requests!")}
       end)
 
       expect(ChatAnthropic, :call, fn _model, _messages, _tools ->
@@ -2632,7 +2746,8 @@ defmodule LangChain.Chains.LLMChainTest do
       }
 
       expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
-        {:error, LangChainError.exception(type: "too_many_requests", message: "Too many requests!")}
+        {:error,
+         LangChainError.exception(type: "too_many_requests", message: "Too many requests!")}
       end)
 
       expect(ChatAnthropic, :call, fn _model, _messages, _tools ->
@@ -2681,7 +2796,8 @@ defmodule LangChain.Chains.LLMChainTest do
       }
 
       expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
-        {:error, LangChainError.exception(type: "too_many_requests", message: "Too many requests!")}
+        {:error,
+         LangChainError.exception(type: "too_many_requests", message: "Too many requests!")}
       end)
 
       expect(ChatAnthropic, :call, fn _model, _messages, _tools ->
@@ -2754,7 +2870,9 @@ defmodule LangChain.Chains.LLMChainTest do
         |> LLMChain.run()
 
       assert error.message == "LLMChain cannot be run without messages"
-      assert_received {:error_callback, %LangChainError{message: "LLMChain cannot be run without messages"}}
+
+      assert_received {:error_callback,
+                       %LangChainError{message: "LLMChain cannot be run without messages"}}
     end
   end
 

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -298,6 +298,33 @@ defmodule LangChain.Chains.LLMChainTest do
       new_chain = LLMChain.cancel_delta(chain, :cancelled, error)
       assert new_chain == chain
     end
+
+    test "cancel_delta/3 with empty delta converts to cancelled message" do
+      model = ChatOpenAI.new!(%{temperature: 1, stream: true})
+      chain = LLMChain.new!(%{llm: model, verbose: false})
+
+      # Create a delta with no content and no tool_calls
+      %LLMChain{} =
+        chain_with_empty_delta =
+        chain
+        |> LLMChain.merge_delta(
+          MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete})
+        )
+
+      # Force it to :complete so cancel_delta attempts conversion
+      %MessageDelta{} = delta = chain_with_empty_delta.delta
+      empty_delta = %MessageDelta{delta | status: :complete}
+      chain_with_empty_delta = %LLMChain{chain_with_empty_delta | delta: empty_delta}
+
+      error = LangChainError.exception(type: "overloaded", message: "Server overloaded")
+
+      # Empty deltas now convert successfully, so cancel_delta produces a
+      # cancelled message rather than an error tuple
+      result = LLMChain.cancel_delta(chain_with_empty_delta, :cancelled, error)
+      assert %LLMChain{} = result
+      assert result.delta == nil
+      assert [%LangChain.Message{status: :cancelled}] = result.messages
+    end
   end
 
   describe "JS inspired test" do

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -3901,7 +3901,7 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
       deltas = collect_messages() |> List.flatten()
 
       # apply the deltas to the original chain
-      delta_merged_chain = LLMChain.apply_deltas(original_chain, deltas)
+      {:ok, delta_merged_chain} = LLMChain.apply_deltas(original_chain, deltas)
 
       # the received merged deltas should match the ones assembled by the chain.
       # This is also verifying that we're receiving the token usage via sent

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -3202,6 +3202,37 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
       assert api_citation["cited_text"] == "The sky is blue."
       assert api_citation["document_index"] == 0
     end
+
+    test "raises LangChainError (not KeyError) when :media option is missing for base64 image" do
+      # Previously this raised KeyError which bypassed LangChainError rescue blocks
+      part =
+        ContentPart.new!(%{
+          type: :image,
+          content: "base64encodeddata",
+          options: [source: :base64]
+        })
+
+      assert_raise LangChainError,
+                   ~r/Required :media option missing for base64-encoded image/,
+                   fn ->
+                     ChatAnthropic.content_part_for_api(part)
+                   end
+    end
+
+    test "raises LangChainError (not KeyError) when :media option is missing for base64 document" do
+      part =
+        ContentPart.new!(%{
+          type: :file,
+          content: "base64encodeddata",
+          options: [source: :base64]
+        })
+
+      assert_raise LangChainError,
+                   ~r/Required :media option missing for base64-encoded document/,
+                   fn ->
+                     ChatAnthropic.content_part_for_api(part)
+                   end
+    end
   end
 
   describe "function_for_api/1" do

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -1327,7 +1327,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       deltas = collect_messages() |> List.flatten()
 
       # apply the deltas to the original chain
-      delta_merged_chain = LLMChain.apply_deltas(original_chain, deltas)
+      {:ok, delta_merged_chain} = LLMChain.apply_deltas(original_chain, deltas)
 
       # the received merged deltas should match the ones assembled by the chain.
       # This is also verifying that we're receiving the token usage via sent

--- a/test/chat_models/chat_perplexity_test.exs
+++ b/test/chat_models/chat_perplexity_test.exs
@@ -469,7 +469,7 @@ defmodule LangChain.ChatModels.ChatPerplexityTest do
       assert length(deltas) > 0
 
       # Apply deltas to the original chain (same pattern as Anthropic test)
-      delta_merged_chain = LLMChain.apply_deltas(original_chain, deltas)
+      {:ok, delta_merged_chain} = LLMChain.apply_deltas(original_chain, deltas)
 
       # Check citations on the chain's final message
       all_citations = Message.all_citations(last_message)

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -1502,9 +1502,10 @@ defmodule LangChain.MessageDeltaTest do
       assert length(msg.tool_calls) == 1
     end
 
-    test "rejects empty assistant message with no content and no tool_calls" do
-      # Mistral sometimes returns completely empty assistant messages
-      # which violate conversation flow rules
+    test "converts empty assistant message with no content and no tool_calls" do
+      # LLMs can return empty assistant messages (e.g., after processing tool
+      # results with nothing more to say). This is valid -- downstream code
+      # can use Message.is_empty?/1 to detect this case if needed.
       delta = %LangChain.MessageDelta{
         role: :assistant,
         merged_content: [],
@@ -1512,11 +1513,14 @@ defmodule LangChain.MessageDeltaTest do
         status: :complete
       }
 
-      {:error, reason} = MessageDelta.to_message(delta)
-      assert reason =~ "Empty assistant message"
+      assert {:ok, %Message{} = msg} = MessageDelta.to_message(delta)
+      assert msg.role == :assistant
+      assert msg.content == []
+      assert msg.tool_calls == []
+      assert msg.status == :complete
     end
 
-    test "rejects empty assistant message with nil content and nil tool_calls" do
+    test "converts empty assistant message with nil content and nil tool_calls" do
       delta = %LangChain.MessageDelta{
         role: :assistant,
         merged_content: nil,
@@ -1524,8 +1528,9 @@ defmodule LangChain.MessageDeltaTest do
         status: :complete
       }
 
-      {:error, reason} = MessageDelta.to_message(delta)
-      assert reason =~ "Empty assistant message"
+      assert {:ok, %Message{} = msg} = MessageDelta.to_message(delta)
+      assert msg.role == :assistant
+      assert msg.status == :complete
     end
 
     test "handles merged_content with nil values from index padding" do


### PR DESCRIPTION
## Problem

Errors in the streaming delta pipeline were silently swallowed. When `delta_to_message_when_complete` failed (e.g., malformed tool call JSON, empty deltas from Mistral), the chain logged a warning, cleared the delta, and returned a bare `%LLMChain{}` as if nothing happened. Callers had no way to detect these failures programmatically, leading to intermittent reliability issues that were hard to reproduce and diagnose. Additionally, there was no callback mechanism to observe transient LLM errors (rate limits, overloads) that were recovered via retries or fallbacks -- making fallback behavior invisible to the application ([#298](https://github.com/brainlid/langchain/issues/298)).

## Solution

Propagate errors through the streaming pipeline using `{:ok, chain}` / `{:error, chain, reason}` tuples instead of returning bare structs. Add two new callbacks with distinct semantics:

- **`on_llm_error`** -- fires on **every** individual LLM call failure, including transient ones recovered by retries/fallbacks. The callback receives the chain with `.llm` set to the model that failed, providing full visibility into fallback behavior. For observability (logging, metrics, dashboards). Addresses [#298](https://github.com/brainlid/langchain/issues/298) -- you can now observe which models failed, why, and which one ultimately succeeded (via the returned chain's `.llm`).
- **`on_error`** -- fires **once** when the chain has exhausted all recovery options and is returning a terminal error. For application-level error handling (UI updates, notifications).

Also: accept empty assistant messages as valid (LLMs legitimately return these, e.g., Anthropic after processing tool results with nothing more to say).

## Changes

- `lib/chains/llm_chain.ex` -- `apply_deltas/2`, `merge_deltas/2`, `delta_to_message_when_complete/1` now return ok/error tuples; `do_run/2` and `run_until_tool_used/3` propagate errors and fire `on_error` on terminal failure; `cancel_delta/3` returns error tuple on conversion failure; `on_llm_error` fires on each individual LLM call failure in `do_run`
- `lib/chains/chain_callbacks.ex` -- New `on_llm_error` and `on_error` callback typedocs and type specs
- `lib/message_delta.ex` -- Removed `validate_not_empty/1` so empty assistant messages convert successfully
- `lib/chat_models/chat_anthropic.ex` -- Replaced `Keyword.fetch!(:media)` with `Keyword.get` + `LangChainError` raise (prevents `KeyError` from bypassing error rescue blocks)
- `test/chains/llm_chain_test.exs` -- Extensive new tests: callback firing semantics (transient vs terminal, fallback recovery, retries exceeded, rescued exceptions), empty streaming responses, malformed delta error propagation, `run_until_tool_used` error callbacks
- `test/message_delta_test.exs` -- Updated empty message tests from error assertions to success assertions
- `test/chat_models/chat_anthropic_test.exs` -- Tests for `LangChainError` on missing `:media` option; updated `apply_deltas` call sites
- `test/chat_models/chat_open_ai_test.exs`, `test/chat_models/chat_perplexity_test.exs` -- Updated `apply_deltas` call sites for new tuple return

## Testing

All changes covered by unit tests using Mimic mocks. Key scenarios tested:

- `on_llm_error` fires per-failure during fallbacks with the failing model's chain
- `on_llm_error` fires but `on_error` does not when a fallback model recovers
- `on_error` fires once on terminal failure, once when all fallbacks fail (`type: "all_fallbacks_failed"`)
- `on_error` fires for rescued `LangChainError` exceptions
- Empty streaming deltas (with and without usage metadata) produce valid messages
- Malformed tool call JSON propagates as `{:error, chain, %LangChainError{type: "delta_conversion_failed"}}`
- `cancel_delta` with empty delta produces cancelled message
- `run_until_tool_used` fires both callbacks on failure

Closes #298