### PR TITLE
Include tool_call_id in context during tool execution

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1724,11 +1724,21 @@ defmodule LangChain.Chains.LLMChain do
       async: function.async
     }
 
+    # Enrich the context with the current call's tool_call_id so tool
+    # implementations can correlate side-effects (e.g. spawned sub-processes)
+    # back to the originating tool call without threading it through arguments.
+    enriched_context =
+      case context do
+        nil -> %{tool_call_id: call.call_id}
+        ctx when is_map(ctx) -> Map.put(ctx, :tool_call_id, call.call_id)
+        other -> other
+      end
+
     LangChain.Telemetry.span([:langchain, :tool, :call], metadata, fn ->
       try do
         if verbose, do: IO.inspect(function.name, label: "EXECUTING FUNCTION")
 
-        case Function.execute(function, call.arguments, context) do
+        case Function.execute(function, call.arguments, enriched_context) do
           {:ok, %ToolResult{} = result} ->
             # allow the tool execution to return a ToolResult. Just set the
             # tool_call_id and fallback settings for name and display_text. This


### PR DESCRIPTION
## Problem

When a tool invocation spawns a long-running side-effect (such as a sub-agent running as a child process), the tool implementation has no ergonomic way to correlate that side-effect back to the originating `tool_call_id`. This matters for cancellation: if a sub-agent is cancelled mid-flight, the caller needs the `tool_call_id` to update the corresponding tool call's status in the conversation history. Today, the only way to get it is to thread it through the tool's JSON arguments, which pollutes the schema visible to the LLM and relies on the model to round-trip a value it shouldn't need to reason about.

## Solution

`LLMChain.execute_tool_call/3` now enriches the `context` map passed to `Function.execute/3` with the current `tool_call_id` under the `:tool_call_id` key, before the tool runs. The `context` map is the conventional carrier for invocation-scoped metadata that tools can read but the LLM never sees, so this is the natural place for it.

The merge handles three cases defensively:

- `nil` context — a fresh `%{tool_call_id: call.call_id}` map is created
- map context — `:tool_call_id` is added via `Map.put/3`, preserving any keys the caller already set
- any other shape — passed through unchanged, preserving backward compatibility for non-map contexts

Tool implementations that don't care about the `tool_call_id` are unaffected.

## Changes

- `lib/chains/llm_chain.ex` — In `execute_tool_call/3`, build an `enriched_context` that includes `:tool_call_id` and pass it to `Function.execute/3` instead of the raw `context`

## Testing

No new tests were added for this change directly. The enrichment is straightforward (a three-branch merge before an existing call site) and the behaviour is exercised indirectly by any test that runs a tool through `LLMChain`. The main consumer of this new capability — sub-agent cancellation — will carry its own tests when that work lands.