### PR TITLE
Harden CI config per zizmor recommendations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -44,14 +44,16 @@ jobs:
             lint: lint
 
     steps:
-      - uses: actions/checkout@v5
-
-      - uses: erlef/setup-beam@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          elixir-version: "1.18"
-          otp-version: "28"
+          persist-credentials: false
 
-      - uses: actions/cache@v4
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        with:
+          elixir-version: ${{ matrix.pair.elixir }}
+          otp-version: ${{ matrix.pair.otp }}
+
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}


### PR DESCRIPTION
## Problem

The Elixir CI workflow had two classes of supply-chain weakness that `zizmor` (a GitHub Actions security linter) flags:

- Third-party actions were referenced by mutable version tags (`@v5`, `@v1`, `@v4`), leaving CI exposed to a tag-retargeting attack if one of those action repositories were compromised.
- `actions/checkout` was using its default `persist-credentials: true`, which writes the `GITHUB_TOKEN` into `.git/config` on the runner — unnecessary for a test-only job and broadens the blast radius of any later step that executes untrusted code.

While auditing the workflow, a latent bug also surfaced: the test matrix declared `elixir: 1.17 / otp: 27` and `elixir: 1.19 / otp: 27`, but both `setup-beam` steps hardcoded `elixir-version: "1.18"` / `otp-version: "28"`. The matrix was cosmetic — every job was running the same BEAM versions rather than the ones declared.

## Solution

All three third-party actions are now pinned to full commit SHAs with a trailing version comment for human readability:

- `actions/checkout@93cb6efe… # v5.0.1`
- `erlef/setup-beam@fc68ffb9… # v1.24.0`
- `actions/cache@0057852b… # v4.3.0`

`actions/checkout` is configured with `persist-credentials: false` so the job runs without a persisted `GITHUB_TOKEN` in the checkout.

The `setup-beam` step now consumes the matrix values via `${{ matrix.pair.elixir }}` and `${{ matrix.pair.otp }}`, so the declared `1.17/27` and `1.19/27` pairs are actually exercised on each run.

To keep the SHA-pinned actions from going stale, a `.github/dependabot.yml` is added with `package-ecosystem: github-actions` on a weekly cadence. A 7-day `cooldown.default-days` gives the ecosystem time to catch compromised releases before Dependabot opens an upgrade PR.

## Changes

- `.github/workflows/elixir.yml` — Pinned `actions/checkout`, `erlef/setup-beam`, and `actions/cache` to commit SHAs with version comments
- `.github/workflows/elixir.yml` — Set `persist-credentials: false` on checkout
- `.github/workflows/elixir.yml` — Wired `setup-beam` to the matrix `elixir`/`otp` values (was hardcoded to `1.18`/`28`, so the matrix was previously a no-op)
- `.github/dependabot.yml` — New file enabling weekly Dependabot updates for `github-actions` with a 7-day cooldown

## Testing

No code changes, so no unit tests are affected. Verification happens in-PR: the workflow will run itself on this pull request, so CI going green confirms both the SHA-pinned actions resolve correctly and that the matrix now produces two genuinely distinct Elixir/OTP jobs.