### PR TITLE
Include run count and limit in exceeded_max_runs error message

### DIFF
--- a/lib/chains/llm_chain/mode/steps.ex
+++ b/lib/chains/llm_chain/mode/steps.ex
@@ -81,7 +81,7 @@ defmodule LangChain.Chains.LLMChain.Mode.Steps do
       {:error, chain,
        LangChain.LangChainError.exception(
          type: "exceeded_max_runs",
-         message: "Exceeded maximum number of runs"
+         message: "Exceeded maximum number of runs (#{count}/#{max})"
        )}
     else
       {:continue, chain}

--- a/test/chains/llm_chain/mode/steps_test.exs
+++ b/test/chains/llm_chain/mode/steps_test.exs
@@ -149,6 +149,18 @@ defmodule LangChain.Chains.LLMChain.Mode.StepsTest do
       ok = {:ok, chain}
       assert ^ok = Steps.check_max_runs(ok, max_runs: 25)
     end
+
+    test "includes count and limit in error message", %{chain: chain} do
+      chain =
+        chain
+        |> Steps.ensure_mode_state()
+        |> LLMChain.update_custom_context(%{mode_state: %{run_count: 50}})
+
+      assert {:error, _chain, %LangChainError{message: message}} =
+               Steps.check_max_runs({:continue, chain}, max_runs: 50)
+
+      assert message == "Exceeded maximum number of runs (50/50)"
+    end
   end
 
   describe "check_pause/2" do

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -2970,7 +2970,8 @@ defmodule LangChain.Chains.LLMChainTest do
         |> LLMChain.run_until_tool_used("do_thing", max_runs: 3)
 
       assert error.type == "exceeded_max_runs"
-      assert error.message == "Exceeded maximum number of runs"
+
+      assert error.message == "Exceeded maximum number of runs (3/3)"
     end
 
     test "returns error when tool_name does not exist in available tools", %{greet: greet} do


### PR DESCRIPTION
## Problem

When an LLM chain exceeds the `max_runs` limit, the error message says "Exceeded maximum number of runs" with no indication of what the limit was or how many runs actually occurred. This makes it harder for developers to diagnose and configure the right limit for their use case.

## Solution

Include the actual run count and configured limit in the error message, changing it from a static string to a formatted one: `"Exceeded maximum number of runs (50/50)"`. This tells developers both the count reached and the limit that was hit, making configuration straightforward.

## Changes

- `lib/chains/llm_chain/mode/steps.ex` -- Interpolate `count` and `max` into the `exceeded_max_runs` error message
- `test/chains/llm_chain/mode/steps_test.exs` -- Added test asserting the message includes count and limit
- `test/chains/llm_chain_test.exs` -- Updated existing `run_until_tool_used` max_runs test to match new message format

## Testing

Existing test suite covers the behavior. Added one new unit test for the message format. All 1643 tests + 27 doctests pass.