### PR TITLE
adding support for structured outputs from ollama

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`ChatOllamaAI`: native `:format` (structured outputs) and image support**: Two gaps in the Ollama chat model are now closed.
+  - `:format` accepts either `"json"` (plain JSON mode) or a JSON Schema map, and is forwarded as the request's top-level `format` field. Schema-enforced generation is handled server-side by Ollama, mirroring what `/api/generate` has always supported.
+  - User messages containing `:image` `ContentPart`s now have their base64 payloads split out of the message content and re-attached as Ollama's native top-level `images` array on the message. Multiple image parts are preserved in order. `:image_url` parts raise a clear error because Ollama has no server-side URL fetcher — callers must fetch bytes themselves and pass them as `:image` parts.
+  - Prior behavior dropped image parts silently via `ContentPart.parts_to_string/1` and had no way to request structured output, forcing users to route through `ChatOpenAI` against Ollama's `/v1/chat/completions` endpoint — which doesn't reliably enforce schemas.
+
 ## v0.8.1
 
 A small follow-up to v0.8.0. The headline change is improved sub-agent cancellation: tools that spawn sub-agents (or any other long-running side-effect) now receive the originating `tool_call_id` in their execution context, making it possible to correlate the spawned work back to the tool call and update its status when the user cancels.

--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -88,6 +88,46 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
         endpoint: "http://my-ollama-host:11434/api/chat"
       })
 
+  ## Structured Outputs (`:format`)
+
+  Ollama supports server-side structured output via the request's top-level
+  `format` field. Set the `:format` option to either `"json"` for plain JSON
+  mode, or a JSON Schema map for schema-enforced generation:
+
+      {:ok, chat} = ChatOllamaAI.new(%{
+        model: "llama3.1:latest",
+        format: %{
+          "type" => "object",
+          "required" => ["name", "city"],
+          "properties" => %{
+            "name" => %{"type" => "string"},
+            "city" => %{"type" => "string"}
+          }
+        }
+      })
+
+  See https://github.com/ollama/ollama/blob/main/docs/api.md#request-structured-outputs.
+
+  ## Multimodal (images)
+
+  Ollama accepts images on user messages via a top-level `images` array of
+  base64-encoded strings. Provide image content as `:image` `ContentPart`s
+  on a user message; `ChatOllamaAI` strips them out of the message content
+  and re-attaches them to the `images` field on the wire:
+
+      {:ok, bytes} = File.read("photo.jpg")
+
+      user_msg = Message.new_user!([
+        ContentPart.text!("What's in this picture?"),
+        ContentPart.image!(Base.encode64(bytes), media: :jpg)
+      ])
+
+      ChatOllamaAI.call(chat, [user_msg], [])
+
+  Note: `:image_url` content parts are not supported because the Ollama
+  server has no URL fetcher — they will raise. Fetch the bytes yourself and
+  pass them as `:image` parts.
+
   ## Connection Retry Behavior
 
   The `retry_count` option controls how many times a request is retried when
@@ -139,6 +179,7 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
 
   @create_fields [
     :endpoint,
+    :format,
     :keep_alive,
     :mirostat,
     :mirostat_eta,
@@ -170,6 +211,16 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
   @primary_key false
   embedded_schema do
     field :endpoint, :string, default: "http://localhost:11434/api/chat"
+
+    # Ollama's native structured-output constraint. Forwarded as the
+    # request's top-level `format` field.
+    #
+    # * `"json"` — plain JSON mode (no schema enforcement).
+    # * A JSON Schema map — schema-enforced output. The server will
+    #   constrain generation to match the schema.
+    #
+    # See https://github.com/ollama/ollama/blob/main/docs/api.md#request-structured-outputs
+    field :format, :any, virtual: true
 
     # Change Keep Alive setting for unloading the model from memory.
     # (Default: "5m", set to a negative interval to disable)
@@ -332,6 +383,7 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
         |> Utils.conditionally_add_to_map(:stop, model.stop),
       receive_timeout: model.receive_timeout
     }
+    |> Utils.conditionally_add_to_map(:format, model.format)
     |> Utils.conditionally_add_to_map(:tools, get_tools_for_api(tools))
   end
 
@@ -392,11 +444,20 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
   end
 
   def for_api(%Message{role: :user, content: content} = msg) when is_list(content) do
+    {text_parts, image_parts} =
+      Enum.split_with(content, fn
+        %ContentPart{type: :text} -> true
+        _ -> false
+      end)
+
+    images = Enum.map(image_parts, &image_part_for_api/1)
+
     %{
       "role" => msg.role,
-      "content" => ContentPart.content_to_string(content)
+      "content" => ContentPart.content_to_string(text_parts)
     }
     |> Utils.conditionally_add_to_map("name", msg.name)
+    |> Utils.conditionally_add_to_map("images", images)
   end
 
   # Handle messages with ContentPart content for non-user roles
@@ -411,6 +472,17 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
   # Handle ContentPart structures
   def for_api(%ContentPart{type: :text, content: content}) do
     content
+  end
+
+  # Ollama's native chat API takes images as base64 strings in a top-level
+  # `images` array on the user message. Only `:image` (base64) parts are
+  # supported — `:image_url` is rejected because Ollama has no fetcher.
+  defp image_part_for_api(%ContentPart{type: :image, content: base64}), do: base64
+
+  defp image_part_for_api(%ContentPart{type: :image_url}) do
+    raise LangChainError,
+          "ChatOllamaAI does not support :image_url content parts. Fetch the image " <>
+            "and pass it as a :image (base64) ContentPart instead."
   end
 
   defp get_tools_for_api(nil), do: []
@@ -753,6 +825,7 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
       model,
       [
         :endpoint,
+        :format,
         :keep_alive,
         :model,
         :mirostat,

--- a/test/chat_models/chat_ollama_ai_test.exs
+++ b/test/chat_models/chat_ollama_ai_test.exs
@@ -206,6 +206,84 @@ defmodule ChatModels.ChatOllamaAITest do
       assert user_msg["content"] == "What color is the sky?"
     end
 
+    test "omits :format when not set", %{ollama_ai: ollama_ai} do
+      data = ChatOllamaAI.for_api(ollama_ai, [Message.new_user!("hi")], [])
+      refute Map.has_key?(data, :format)
+    end
+
+    test "passes :format through as a string (json mode)" do
+      ollama = ChatOllamaAI.new!(%{model: "llama3.1:latest", format: "json"})
+      data = ChatOllamaAI.for_api(ollama, [Message.new_user!("hi")], [])
+      assert data.format == "json"
+    end
+
+    test "passes :format through as a JSON Schema map" do
+      schema = %{
+        "type" => "object",
+        "required" => ["name"],
+        "properties" => %{"name" => %{"type" => "string"}}
+      }
+
+      ollama = ChatOllamaAI.new!(%{model: "llama3.1:latest", format: schema})
+      data = ChatOllamaAI.for_api(ollama, [Message.new_user!("hi")], [])
+      assert data.format == schema
+    end
+
+    test "user message with no images has no :images key", %{ollama_ai: ollama_ai} do
+      msg = Message.new_user!([ContentPart.text!("describe the sky")])
+      data = ChatOllamaAI.for_api(ollama_ai, [msg], [])
+
+      assert [user_msg] = data.messages
+      assert user_msg["content"] == "describe the sky"
+      refute Map.has_key?(user_msg, "images")
+    end
+
+    test "user message with an :image ContentPart puts base64 in top-level :images", %{
+      ollama_ai: ollama_ai
+    } do
+      b64 = "iVBORw0KGgoBASE64="
+
+      msg =
+        Message.new_user!([
+          ContentPart.text!("what's in this image?"),
+          ContentPart.image!(b64, media: :png)
+        ])
+
+      data = ChatOllamaAI.for_api(ollama_ai, [msg], [])
+
+      assert [user_msg] = data.messages
+      assert user_msg["role"] == :user
+      assert user_msg["content"] == "what's in this image?"
+      assert user_msg["images"] == [b64]
+    end
+
+    test "user message with multiple :image parts collects them in order", %{
+      ollama_ai: ollama_ai
+    } do
+      msg =
+        Message.new_user!([
+          ContentPart.text!("compare"),
+          ContentPart.image!("AAA=", media: :png),
+          ContentPart.image!("BBB=", media: :jpg)
+        ])
+
+      data = ChatOllamaAI.for_api(ollama_ai, [msg], [])
+
+      assert [%{"images" => ["AAA=", "BBB="]}] = data.messages
+    end
+
+    test "user message with :image_url raises a clear error", %{ollama_ai: ollama_ai} do
+      msg =
+        Message.new_user!([
+          ContentPart.text!("describe"),
+          ContentPart.image_url!("https://example.com/img.png")
+        ])
+
+      assert_raise LangChain.LangChainError, ~r/does not support :image_url/, fn ->
+        ChatOllamaAI.for_api(ollama_ai, [msg], [])
+      end
+    end
+
     test "generates a map for an API call with a tool", %{ollama_ai: ollama_ai} do
       fun =
         Function.new!(%{
@@ -875,6 +953,7 @@ defmodule ChatModels.ChatOllamaAITest do
 
       assert result == %{
                "endpoint" => "http://localhost:11434/api/chat",
+               "format" => nil,
                "keep_alive" => "5m",
                "mirostat" => 0,
                "mirostat_eta" => 0.1,


### PR DESCRIPTION
I am using ollama locally to build stuff using structured outputs via the format param this adds support to the format param to the ollama client in langchain