### PR TITLE
feat: Add ChatAwsMantle provider for AWS Bedrock Mantle (experimental)

### DIFF
--- a/lib/chat_models/chat_aws_mantle.ex
+++ b/lib/chat_models/chat_aws_mantle.ex
@@ -310,7 +310,11 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
         )
 
       not is_nil(credentials) and not is_function(credentials, 0) ->
-        add_error(changeset, :credentials, "must be a zero-arity function returning IAM credentials")
+        add_error(
+          changeset,
+          :credentials,
+          "must be a zero-arity function returning IAM credentials"
+        )
 
       true ->
         changeset
@@ -388,7 +392,10 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
     |> Utils.conditionally_add_to_map(:response_format, response_format(model))
     |> Utils.conditionally_add_to_map(:tools, tools_for_api(model, tools))
     |> Utils.conditionally_add_to_map(:tool_choice, tool_choice_for_api(model))
-    |> Utils.conditionally_add_to_map(:stream_options, stream_options_for_api(model.stream_options))
+    |> Utils.conditionally_add_to_map(
+      :stream_options,
+      stream_options_for_api(model.stream_options)
+    )
   end
 
   # Strip :thinking ContentParts before sending a message back to Mantle.
@@ -479,7 +486,9 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
   end
 
   @impl ChatModel
-  def retry_on_fallback?(%LangChainError{type: type}) when type in ["timeout", "connection"], do: true
+  def retry_on_fallback?(%LangChainError{type: type}) when type in ["timeout", "connection"],
+    do: true
+
   def retry_on_fallback?(_), do: false
 
   @impl ChatModel
@@ -629,7 +638,10 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
 
   @doc false
   # Streaming delta chunk — matched first because each choice has a "delta" key.
-  def do_process_response(%ChatAwsMantle{} = model, %{"choices" => [%{"delta" => _} | _] = choices} = msg) do
+  def do_process_response(
+        %ChatAwsMantle{} = model,
+        %{"choices" => [%{"delta" => _} | _] = choices} = msg
+      ) do
     choices
     |> Enum.flat_map(&process_stream_choice(model, &1, msg))
     |> case do

--- a/lib/chat_models/chat_aws_mantle.ex
+++ b/lib/chat_models/chat_aws_mantle.ex
@@ -1,0 +1,822 @@
+defmodule LangChain.ChatModels.ChatAwsMantle do
+  @moduledoc """
+  Represents a chat model hosted by AWS Bedrock's **Mantle** endpoint — the
+  OpenAI-compatible gateway AWS introduced for third-party models such as
+  Moonshot AI's Kimi K2 family and OpenAI's gpt-oss series.
+
+  Mantle accepts standard OpenAI Chat Completions requests, so much of the
+  wire format mirrors `LangChain.ChatModels.ChatOpenAI`. This module exists as
+  a separate chat model because Mantle has several differences that warrant
+  dedicated handling:
+
+  - **Region-aware URL building** — `https://bedrock-mantle.{region}.api.aws/v1/chat/completions`
+  - **Two auth modes** — Bedrock API key (Bearer) **or** AWS IAM (SigV4)
+  - **Reasoning extraction** — Mantle returns model reasoning at `message.reasoning`
+    (or `delta.reasoning` when streaming), which `ChatOpenAI` silently drops
+  - **Higher default `receive_timeout`** — Mantle exhibits intermittent slow
+    starts of 60s+, so the default is 120s here vs OpenAI's 60s
+  - **Bounded default `max_tokens: 4096`** — Kimi occasionally falls into
+    token-repetition loops; streaming keeps the HTTP layer alive as chunks
+    arrive, so an uncapped request can run indefinitely. Override as needed
+    when reasoning budgets require more
+  - **Per-model quirks** — Kimi prepends a leading space to text content; uses
+    `functions.NAME:N` for `call_id` shape; narrates before tool calls
+
+  ## Available Models (as of writing)
+
+  | Model ID                         | Vendor    | Notes                                  |
+  | -------------------------------- | --------- | -------------------------------------- |
+  | `moonshotai.kimi-k2-thinking`    | Moonshot  | Reasoning by default, 128K ctx         |
+  | `moonshotai.kimi-k2.5`           | Moonshot  | Multimodal, hybrid thinking via `:reasoning_effort` |
+  | `openai.gpt-oss-120b`            | OpenAI    | Open-source GPT, hosted by AWS         |
+
+  More models may be available — call `GET /v1/models` against the Mantle
+  endpoint to discover what's currently published.
+
+  ## Authentication
+
+  Two mutually-exclusive auth modes:
+
+  ### Bearer (Bedrock API key) — simplest
+
+  Generate a long-term Bedrock API key in the AWS console
+  ([Bedrock API keys](https://console.aws.amazon.com/bedrock/home#/api-keys/long-term/create))
+  and set it as the `:api_key`:
+
+      ChatAwsMantle.new!(%{
+        model: "moonshotai.kimi-k2.5",
+        region: "us-east-1",
+        api_key: System.fetch_env!("AWS_BEARER_TOKEN_BEDROCK")
+      })
+
+  ### AWS SigV4 (IAM credentials) — production-friendly
+
+  Pass a zero-arity function returning IAM credentials. Useful when the host
+  already has IAM-based credentials available (e.g. ExAws):
+
+      ChatAwsMantle.new!(%{
+        model: "moonshotai.kimi-k2.5",
+        region: "us-east-1",
+        credentials: fn ->
+          ExAws.Config.new(:s3)
+          |> Map.take([:access_key_id, :secret_access_key])
+          |> Map.to_list()
+        end
+      })
+
+  ## Reasoning / Thinking
+
+  K2.5 is a hybrid thinking model — pass OpenAI's standard `:reasoning_effort`
+  to enable structured reasoning:
+
+      ChatAwsMantle.new!(%{
+        model: "moonshotai.kimi-k2.5",
+        region: "us-east-1",
+        api_key: System.fetch_env!("AWS_BEARER_TOKEN_BEDROCK"),
+        reasoning_effort: "high"
+      })
+
+  When reasoning is active, the response message will include a `ContentPart`
+  of `type: :thinking` containing the model's chain of thought, alongside the
+  normal `:text` content parts.
+
+  K2 Thinking always reasons (it's the model's default mode); the field is
+  populated regardless of `:reasoning_effort`.
+
+  ## Sampling controls
+
+  Standard OpenAI sampling parameters are supported and passed through to
+  Mantle unchanged:
+
+  - `:temperature` — 0.0 to 2.0 (default `1.0`)
+  - `:top_p` — 0.0 to 1.0 nucleus sampling cutoff. OpenAI recommends tuning
+    this *or* temperature, not both
+  - `:frequency_penalty` — -2.0 to 2.0. Positive values discourage reuse of
+    tokens proportional to how often they've already appeared. **Kimi K2.5
+    on Mantle has been observed to occasionally lock into single-token
+    repetition loops (e.g. streams of "!"); `frequency_penalty: 0.5` is a
+    reasonable starting defense.**
+  - `:presence_penalty` — -2.0 to 2.0. Binary variant of frequency_penalty
+    (penalizes any token that has appeared at all)
+
+  ## Streaming
+
+  Set `stream: true` to receive incremental `MessageDelta` updates via the
+  `on_llm_new_delta` callback. Mantle emits standard OpenAI SSE chunks for
+  content and tool calls, and adds a sibling `delta.reasoning` field when
+  reasoning is active. `ChatAwsMantle` extracts those into `:thinking`
+  ContentParts so the merged final message carries `[thinking_part, text_part]`
+  in order.
+
+  ## Multimodal (K2.5 vision)
+
+  Kimi K2.5 is natively multimodal. Send images via standard LangChain
+  `ContentPart` structs — `ChatAwsMantle` delegates serialization to
+  `ChatOpenAI.content_part_for_api/2`, which emits Mantle's expected
+  `{"type": "image_url", "image_url": {"url": "data:<media>;base64,..."}}`
+  shape:
+
+      {:ok, bytes} = File.read("photo.jpg")
+
+      Message.new_user!([
+        ContentPart.text!("What's in this image?"),
+        ContentPart.image!(Base.encode64(bytes), media: :jpeg)
+      ])
+      |> then(&ChatAwsMantle.call(model, [&1]))
+
+  Mantle runs images through an upstream sanitizer that rejects degenerate
+  inputs (tiny or unusual images may return a 400 with
+  `"Failed to sanitize image"`). Use real photographs or reasonably-sized
+  source images. Vision tokens add meaningfully to `prompt_tokens` — a
+  1200×675 JPG consumes roughly 1100 prompt tokens.
+
+  ## Open Notes
+
+  Streaming and tool-calling support follow the same wire format as
+  `ChatOpenAI` — see the smoke tests for verified behavior.
+  """
+  use Ecto.Schema
+  require Logger
+  import Ecto.Changeset
+  alias __MODULE__
+  alias LangChain.ChatModels.ChatModel
+  alias LangChain.ChatModels.ChatOpenAI
+  alias LangChain.Config
+  alias LangChain.LangChainError
+  alias LangChain.Message
+  alias LangChain.Message.ContentPart
+  alias LangChain.MessageDelta
+  alias LangChain.Callbacks
+  alias LangChain.Utils
+
+  @behaviour ChatModel
+
+  @default_receive_timeout 120_000
+  # Kimi K2.5 has been observed to fall into degenerate token-repetition loops
+  # ("!!!!!!" runs) on a small fraction of requests. Streaming keeps the HTTP
+  # layer's receive_timeout alive because chunks keep arriving, so without a
+  # max_tokens cap a degenerate run can stream indefinitely. 4096 is enough
+  # for normal agent turns (including `reasoning_effort: "medium"`) and caps
+  # runaway generation at a small, bounded cost. Override when reasoning
+  # needs more headroom.
+  @default_max_tokens 4096
+
+  @primary_key false
+  embedded_schema do
+    field :model, :string
+    field :region, :string
+
+    # Optional explicit endpoint override; default is derived from :region.
+    field :endpoint, :string
+
+    # Auth: exactly one of :api_key or :credentials must be set.
+    field :api_key, :string, redact: true
+    # Zero-arity fn returning a keyword list with :access_key_id, :secret_access_key,
+    # and optionally :token. Used to build SigV4 signing options for Req.
+    field :credentials, :any, virtual: true
+
+    # Standard OpenAI-shaped knobs
+    field :temperature, :float, default: 1.0
+    field :max_tokens, :integer, default: @default_max_tokens
+    field :stream, :boolean, default: false
+
+    # Nucleus sampling (0.0–1.0). OpenAI docs recommend altering *either* this
+    # or :temperature, not both. Default nil → Mantle uses its own default.
+    field :top_p, :float
+
+    # Discourage reuse of tokens already seen in the generation. Positive
+    # values (0.1–2.0) reduce repetition; useful for Kimi K2.5 which has
+    # exhibited occasional token-repetition loops ("!!!!!" runs).
+    field :frequency_penalty, :float
+
+    # Discourage reuse of tokens that have appeared at all (binary rather
+    # than frequency-weighted). Positive values encourage topic diversity.
+    field :presence_penalty, :float
+
+    # OpenAI-standard reasoning control. Passed through to Mantle, which
+    # translates into the upstream model's thinking mode (verified working
+    # for Kimi K2.5).
+    field :reasoning_effort, :string
+
+    # Tool choice option, mirrors ChatOpenAI's shape
+    field :tool_choice, :map
+
+    # Structured response format
+    field :json_response, :boolean, default: false
+    field :json_schema, :map
+
+    # Mantle-specific: longer default than ChatOpenAI. Mantle has intermittent
+    # 60s+ slow starts; 120s gives those a chance to resolve.
+    field :receive_timeout, :integer, default: @default_receive_timeout
+
+    # Stream options (e.g. include_usage)
+    field :stream_options, :map, default: nil
+
+    # Callback handlers (treated as internal — not part of API request)
+    field :callbacks, {:array, :map}, default: []
+
+    # Debug helper — prints raw request/response when true
+    field :verbose_api, :boolean, default: false
+
+    # Req options to merge into the request
+    field :req_config, :map, default: %{}
+  end
+
+  @type t :: %ChatAwsMantle{}
+
+  @create_fields [
+    :model,
+    :region,
+    :endpoint,
+    :api_key,
+    :credentials,
+    :temperature,
+    :max_tokens,
+    :stream,
+    :top_p,
+    :frequency_penalty,
+    :presence_penalty,
+    :reasoning_effort,
+    :tool_choice,
+    :json_response,
+    :json_schema,
+    :receive_timeout,
+    :stream_options,
+    :verbose_api,
+    :req_config
+  ]
+  @required_fields [:model]
+
+  @valid_reasoning_efforts ~w(low medium high)
+
+  @doc """
+  Build a new `ChatAwsMantle` instance from attributes.
+  """
+  @spec new(attrs :: map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def new(attrs \\ %{}) do
+    %ChatAwsMantle{}
+    |> cast(attrs, @create_fields)
+    |> common_validation()
+    |> apply_action(:insert)
+  end
+
+  @doc """
+  Build a new `ChatAwsMantle` instance, raising on validation failure.
+  """
+  @spec new!(attrs :: map()) :: t() | no_return()
+  def new!(attrs \\ %{}) do
+    case new(attrs) do
+      {:ok, model} ->
+        model
+
+      {:error, changeset} ->
+        raise LangChainError, changeset
+    end
+  end
+
+  defp common_validation(changeset) do
+    changeset
+    |> validate_required(@required_fields)
+    |> validate_inclusion(:reasoning_effort, @valid_reasoning_efforts,
+      message: "must be one of: #{Enum.join(@valid_reasoning_efforts, ", ")}"
+    )
+    |> validate_number(:temperature, greater_than_or_equal_to: 0, less_than_or_equal_to: 2)
+    |> validate_number(:top_p, greater_than_or_equal_to: 0, less_than_or_equal_to: 1)
+    |> validate_number(:frequency_penalty, greater_than_or_equal_to: -2, less_than_or_equal_to: 2)
+    |> validate_number(:presence_penalty, greater_than_or_equal_to: -2, less_than_or_equal_to: 2)
+    |> validate_number(:receive_timeout, greater_than_or_equal_to: 0)
+    |> validate_auth()
+    |> validate_endpoint_resolvable()
+  end
+
+  # Exactly one of :api_key or :credentials must be set.
+  defp validate_auth(changeset) do
+    api_key = get_field(changeset, :api_key)
+    credentials = get_field(changeset, :credentials)
+
+    cond do
+      is_binary(api_key) and is_function(credentials, 0) ->
+        add_error(
+          changeset,
+          :api_key,
+          "cannot set both :api_key and :credentials — pick one auth mode"
+        )
+
+      is_nil(api_key) and is_nil(credentials) ->
+        add_error(
+          changeset,
+          :api_key,
+          "must set either :api_key (Bearer) or :credentials (SigV4)"
+        )
+
+      not is_nil(credentials) and not is_function(credentials, 0) ->
+        add_error(changeset, :credentials, "must be a zero-arity function returning IAM credentials")
+
+      true ->
+        changeset
+    end
+  end
+
+  # Either :endpoint is set explicitly, or :region is set (so we can build one).
+  defp validate_endpoint_resolvable(changeset) do
+    endpoint = get_field(changeset, :endpoint)
+    region = get_field(changeset, :region)
+
+    if is_binary(endpoint) or is_binary(region) do
+      changeset
+    else
+      add_error(
+        changeset,
+        :region,
+        "must set :region (or override :endpoint) so the Mantle URL can be built"
+      )
+    end
+  end
+
+  # Build the request URL for this model. Prefer :endpoint override; otherwise
+  # build from :region.
+  @doc false
+  def url(%ChatAwsMantle{endpoint: endpoint}) when is_binary(endpoint), do: endpoint
+
+  def url(%ChatAwsMantle{region: region}) when is_binary(region) do
+    "https://bedrock-mantle.#{region}.api.aws/v1/chat/completions"
+  end
+
+  # Resolve the auth header / signing options for a Req call. Returns a keyword
+  # list of options to merge into Req.new/1.
+  @doc false
+  def auth_opts(%ChatAwsMantle{api_key: api_key}) when is_binary(api_key) do
+    [auth: {:bearer, api_key}]
+  end
+
+  def auth_opts(%ChatAwsMantle{credentials: credentials, region: region})
+      when is_function(credentials, 0) and is_binary(region) do
+    sigv4 =
+      credentials.()
+      |> Keyword.merge(region: region, service: :bedrock)
+
+    [aws_sigv4: sigv4]
+  end
+
+  @doc """
+  Format the request body for the Mantle API. Reuses `ChatOpenAI`'s per-message
+  formatting (since the wire format is OpenAI-shaped), but assembles the
+  top-level body with Mantle-relevant fields only.
+  """
+  @spec for_api(t(), [Message.t()], [LangChain.Function.t()]) :: %{atom() => any()}
+  def for_api(%ChatAwsMantle{} = model, messages, tools) do
+    %{
+      model: model.model,
+      stream: model.stream,
+      messages:
+        messages
+        |> Enum.map(&strip_thinking_parts/1)
+        |> Enum.reduce([], fn m, acc ->
+          case ChatOpenAI.for_api(model, m) do
+            %{} = data -> [data | acc]
+            data when is_list(data) -> Enum.reverse(data) ++ acc
+          end
+        end)
+        |> Enum.reverse()
+    }
+    |> Utils.conditionally_add_to_map(:temperature, model.temperature)
+    |> Utils.conditionally_add_to_map(:max_tokens, model.max_tokens)
+    |> Utils.conditionally_add_to_map(:top_p, model.top_p)
+    |> Utils.conditionally_add_to_map(:frequency_penalty, model.frequency_penalty)
+    |> Utils.conditionally_add_to_map(:presence_penalty, model.presence_penalty)
+    |> Utils.conditionally_add_to_map(:reasoning_effort, model.reasoning_effort)
+    |> Utils.conditionally_add_to_map(:response_format, response_format(model))
+    |> Utils.conditionally_add_to_map(:tools, tools_for_api(model, tools))
+    |> Utils.conditionally_add_to_map(:tool_choice, tool_choice_for_api(model))
+    |> Utils.conditionally_add_to_map(:stream_options, stream_options_for_api(model.stream_options))
+  end
+
+  # Strip :thinking ContentParts before sending a message back to Mantle.
+  # Mantle's wire format (OpenAI Chat Completions) has no representation for
+  # reasoning blocks — they're a response-side artifact we surface for UI
+  # display. `ChatOpenAI.content_part_for_api/2` has no clause for :thinking
+  # and will crash if one round-trips, so we filter them here.
+  @spec strip_thinking_parts(Message.t()) :: Message.t()
+  defp strip_thinking_parts(%Message{content: content} = msg) when is_list(content) do
+    cleaned = Enum.reject(content, &match?(%ContentPart{type: :thinking}, &1))
+    %{msg | content: cleaned}
+  end
+
+  defp strip_thinking_parts(msg), do: msg
+
+  defp response_format(%ChatAwsMantle{json_response: true, json_schema: schema})
+       when not is_nil(schema) do
+    %{"type" => "json_schema", "json_schema" => schema}
+  end
+
+  defp response_format(%ChatAwsMantle{json_response: true}), do: %{"type" => "json_object"}
+  defp response_format(%ChatAwsMantle{json_response: false}), do: nil
+
+  defp tools_for_api(_model, nil), do: []
+  defp tools_for_api(_model, []), do: []
+
+  defp tools_for_api(%ChatAwsMantle{} = model, tools) do
+    Enum.map(tools, fn %LangChain.Function{} = function ->
+      %{"type" => "function", "function" => ChatOpenAI.for_api(model, function)}
+    end)
+  end
+
+  defp tool_choice_for_api(%ChatAwsMantle{tool_choice: nil}), do: nil
+  defp tool_choice_for_api(%ChatAwsMantle{tool_choice: choice}), do: choice
+
+  defp stream_options_for_api(nil), do: nil
+
+  defp stream_options_for_api(%{} = data) do
+    %{"include_usage" => Map.get(data, :include_usage, Map.get(data, "include_usage"))}
+  end
+
+  # ---------------------------------------------------------------------------
+  # ChatModel behavior
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Make a call to the Mantle API. Returns `{:ok, [%Message{}]}` on success or
+  `{:error, %LangChainError{}}` on failure.
+  """
+  @impl ChatModel
+  def call(model, prompt, tools \\ [])
+
+  def call(%ChatAwsMantle{} = model, prompt, tools) when is_binary(prompt) do
+    call(model, [Message.new_user!(prompt)], tools)
+  end
+
+  def call(%ChatAwsMantle{} = model, messages, tools) when is_list(messages) do
+    metadata = %{
+      model: model.model,
+      message_count: length(messages),
+      tools_count: length(tools)
+    }
+
+    LangChain.Telemetry.span([:langchain, :llm, :call], metadata, fn ->
+      try do
+        LangChain.Telemetry.llm_prompt(
+          %{system_time: System.system_time()},
+          %{model: model.model, messages: messages}
+        )
+
+        case do_api_request(model, messages, tools) do
+          {:error, %LangChainError{} = err} ->
+            {:error, err}
+
+          parsed ->
+            LangChain.Telemetry.llm_response(
+              %{system_time: System.system_time()},
+              %{model: model.model, response: parsed}
+            )
+
+            {:ok, parsed}
+        end
+      rescue
+        err in LangChainError ->
+          {:error, err}
+      end
+    end)
+  end
+
+  @impl ChatModel
+  def retry_on_fallback?(%LangChainError{type: type}) when type in ["timeout", "connection"], do: true
+  def retry_on_fallback?(_), do: false
+
+  @impl ChatModel
+  def serialize_config(%ChatAwsMantle{} = model) do
+    Map.from_struct(model)
+    |> Map.drop([:credentials, :callbacks, :api_key])
+    |> Map.put(:module, Atom.to_string(__MODULE__))
+    |> Map.put(:version, 1)
+    |> stringify_keys()
+  end
+
+  @impl ChatModel
+  def restore_from_map(%{"version" => 1} = data) do
+    attrs = data |> Map.delete("module") |> Map.delete("version") |> atomize_keys()
+    new(attrs)
+  end
+
+  def restore_from_map(_other), do: {:error, "Unsupported ChatAwsMantle config version"}
+
+  defp stringify_keys(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {to_string(k), v} end)
+  end
+
+  defp atomize_keys(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {String.to_existing_atom(to_string(k)), v} end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # HTTP request — non-streaming for now. Streaming added in a follow-up.
+  # ---------------------------------------------------------------------------
+
+  @doc false
+  def do_api_request(%ChatAwsMantle{stream: false} = model, messages, tools) do
+    body = for_api(model, messages, tools)
+
+    if model.verbose_api do
+      IO.inspect(body, label: "RAW DATA BEING SUBMITTED (Mantle)")
+    end
+
+    req_opts =
+      [
+        url: url(model),
+        json: body,
+        receive_timeout: model.receive_timeout,
+        retry: :transient,
+        max_retries: 2,
+        retry_delay: fn attempt -> 500 * attempt end
+      ] ++ auth_opts(model)
+
+    req = Req.new(req_opts)
+
+    req
+    |> Req.merge(model.req_config |> Keyword.new())
+    |> Req.post()
+    |> case do
+      {:ok, %Req.Response{status: status, body: body} = response} when status in 200..299 ->
+        if model.verbose_api do
+          IO.inspect(response, label: "RAW REQ RESPONSE (Mantle)")
+        end
+
+        Callbacks.fire(model.callbacks, :on_llm_response_headers, [response.headers])
+        do_process_response(model, body)
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error,
+         LangChainError.exception(
+           type: "api_error",
+           message: "Mantle returned HTTP #{status}: #{inspect(body)}"
+         )}
+
+      {:error, %Req.TransportError{reason: reason}} ->
+        {:error,
+         LangChainError.exception(
+           type: "connection",
+           message: "Mantle connection error: #{inspect(reason)}"
+         )}
+
+      {:error, error} ->
+        {:error, LangChainError.exception(type: "unknown", message: inspect(error))}
+    end
+  end
+
+  def do_api_request(%ChatAwsMantle{stream: true} = model, messages, tools) do
+    body = for_api(model, messages, tools)
+
+    if model.verbose_api do
+      IO.inspect(body, label: "RAW DATA BEING SUBMITTED (Mantle stream)")
+    end
+
+    req_opts =
+      [
+        url: url(model),
+        json: body,
+        receive_timeout: model.receive_timeout
+      ] ++ auth_opts(model)
+
+    Req.new(req_opts)
+    |> Req.merge(model.req_config |> Keyword.new())
+    |> Req.post(
+      into:
+        Utils.handle_stream_fn(
+          model,
+          &ChatOpenAI.decode_stream/1,
+          &do_process_response(model, &1)
+        )
+    )
+    |> case do
+      {:ok, %Req.Response{status: status, body: data} = response} when status in 200..299 ->
+        Callbacks.fire(model.callbacks, :on_llm_response_headers, [response.headers])
+        data
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error,
+         LangChainError.exception(
+           type: "api_error",
+           message: "Mantle returned HTTP #{status}: #{inspect(body)}"
+         )}
+
+      {:error, %LangChainError{} = error} ->
+        {:error, error}
+
+      {:error, %Req.TransportError{reason: :timeout} = err} ->
+        {:error,
+         LangChainError.exception(type: "timeout", message: "Request timed out", original: err)}
+
+      {:error, %Req.TransportError{reason: reason}} ->
+        {:error,
+         LangChainError.exception(
+           type: "connection",
+           message: "Mantle stream connection error: #{inspect(reason)}"
+         )}
+
+      other ->
+        {:error,
+         LangChainError.exception(
+           type: "unexpected_response",
+           message: "Unexpected streamed response: #{inspect(other)}"
+         )}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Response parsing — delegates the OpenAI-shaped bits to ChatOpenAI then
+  # extracts the Mantle-specific `message.reasoning` field into a thinking
+  # ContentPart.
+  # ---------------------------------------------------------------------------
+
+  @doc false
+  # Streaming delta chunk — matched first because each choice has a "delta" key.
+  def do_process_response(%ChatAwsMantle{} = model, %{"choices" => [%{"delta" => _} | _] = choices} = msg) do
+    choices
+    |> Enum.flat_map(&process_stream_choice(model, &1, msg))
+    |> case do
+      [] -> :skip
+      [single] -> single
+      many -> many
+    end
+  end
+
+  # Non-streaming complete response — every choice carries a fully-formed "message".
+  def do_process_response(%ChatAwsMantle{} = model, %{"choices" => choices} = body)
+      when is_list(choices) and choices != [] do
+    choices
+    |> Enum.map(&process_choice(model, &1, body))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  # Usage-only terminal event (when stream_options.include_usage is set, Mantle
+  # sends a final chunk with empty `choices` and a `usage` map).
+  def do_process_response(_model, %{"choices" => [], "usage" => _} = _msg) do
+    :skip
+  end
+
+  def do_process_response(_model, %{"error" => %{"message" => message}} = body) do
+    {:error,
+     LangChainError.exception(
+       type: Map.get(body, "code") || "api_error",
+       message: message
+     )}
+  end
+
+  def do_process_response(_model, other) do
+    {:error,
+     LangChainError.exception(
+       type: "unexpected_response",
+       message: "Unexpected response shape: #{inspect(other)}"
+     )}
+  end
+
+  defp process_choice(model, %{"message" => message_data} = choice, body) do
+    # Hand off to ChatOpenAI's parser for the standard OpenAI-shaped fields
+    # (content, tool_calls, role, etc.), then layer reasoning extraction on top.
+    case ChatOpenAI.do_process_response(model, choice) do
+      %Message{} = msg ->
+        msg
+        |> maybe_add_reasoning(message_data)
+        |> attach_usage(body)
+
+      other ->
+        other
+    end
+  end
+
+  defp process_choice(_model, _choice, _body), do: nil
+
+  # Per-choice streaming delta processing. Returns a list of MessageDelta
+  # structs (zero, one, or two). The list form lets one SSE event emit both
+  # a thinking delta and a content/tool_calls delta when they co-occur.
+  #
+  # Positioning policy: thinking fragments land at MessageDelta.index 0;
+  # text fragments land at index 1. That maps directly to merged_content
+  # positions during merge so the final message reads [thinking, text].
+  defp process_stream_choice(model, %{"delta" => delta_body} = choice, _msg) do
+    role = role_for_delta(delta_body)
+    finish_reason = Map.get(choice, "finish_reason")
+    status = finish_reason_to_status(finish_reason)
+    reasoning = Map.get(delta_body, "reasoning")
+    content = Map.get(delta_body, "content")
+    tool_calls_raw = Map.get(delta_body, "tool_calls")
+
+    deltas =
+      []
+      |> maybe_reasoning_delta(reasoning, role, status)
+      |> maybe_content_delta(content, role, status)
+      |> maybe_tool_calls_delta(model, tool_calls_raw, role, status)
+
+    case deltas do
+      [] ->
+        # Role-only / keep-alive / terminal delta with no payload.
+        if role == :assistant or status in [:complete, :length] do
+          [build_delta(%{role: role, status: status, index: 0})]
+        else
+          []
+        end
+
+      _ ->
+        deltas
+    end
+  end
+
+  defp process_stream_choice(_model, _choice, _msg), do: []
+
+  defp maybe_reasoning_delta(acc, nil, _role, _status), do: acc
+  defp maybe_reasoning_delta(acc, "", _role, _status), do: acc
+
+  defp maybe_reasoning_delta(acc, reasoning, role, status) when is_binary(reasoning) do
+    acc ++
+      [
+        build_delta(%{
+          content: ContentPart.thinking!(reasoning),
+          role: role,
+          status: status,
+          index: 0
+        })
+      ]
+  end
+
+  defp maybe_content_delta(acc, nil, _role, _status), do: acc
+  defp maybe_content_delta(acc, "", _role, _status), do: acc
+
+  defp maybe_content_delta(acc, content, role, status) when is_binary(content) do
+    acc ++
+      [
+        build_delta(%{
+          content: content,
+          role: role,
+          status: status,
+          index: 1
+        })
+      ]
+  end
+
+  defp maybe_tool_calls_delta(acc, _model, nil, _role, _status), do: acc
+  defp maybe_tool_calls_delta(acc, _model, [], _role, _status), do: acc
+
+  defp maybe_tool_calls_delta(acc, model, tool_calls_raw, role, status)
+       when is_list(tool_calls_raw) do
+    tool_calls = Enum.map(tool_calls_raw, &ChatOpenAI.do_process_response(model, &1))
+
+    acc ++
+      [
+        build_delta(%{
+          role: role,
+          status: status,
+          index: 0,
+          tool_calls: tool_calls
+        })
+      ]
+  end
+
+  defp build_delta(attrs) do
+    attrs =
+      attrs
+      |> Map.put_new(:role, :unknown)
+      |> Map.put_new(:status, :incomplete)
+
+    struct!(MessageDelta, attrs)
+  end
+
+  defp role_for_delta(%{"role" => "assistant"}), do: :assistant
+  defp role_for_delta(_), do: :unknown
+
+  defp finish_reason_to_status(nil), do: :incomplete
+  defp finish_reason_to_status("stop"), do: :complete
+  defp finish_reason_to_status("tool_calls"), do: :complete
+  defp finish_reason_to_status("content_filter"), do: :complete
+  defp finish_reason_to_status("length"), do: :length
+  defp finish_reason_to_status("max_tokens"), do: :length
+  defp finish_reason_to_status(_other), do: nil
+
+  # If Mantle returned `message.reasoning`, add it as a leading thinking
+  # ContentPart on the message.
+  defp maybe_add_reasoning(%Message{} = msg, %{"reasoning" => reasoning})
+       when is_binary(reasoning) and byte_size(reasoning) > 0 do
+    thinking_part = ContentPart.thinking!(reasoning)
+    %{msg | content: [thinking_part | msg.content || []]}
+  end
+
+  defp maybe_add_reasoning(%Message{} = msg, _), do: msg
+
+  defp attach_usage(%Message{} = msg, %{"usage" => usage}) when is_map(usage) do
+    token_usage = %LangChain.TokenUsage{
+      input: Map.get(usage, "prompt_tokens"),
+      output: Map.get(usage, "completion_tokens"),
+      raw: usage
+    }
+
+    metadata = Map.merge(msg.metadata || %{}, %{usage: token_usage})
+    %{msg | metadata: metadata}
+  end
+
+  defp attach_usage(%Message{} = msg, _), do: msg
+
+  # Resolve API key from struct or app config. Currently unused (auth_opts/1
+  # uses the struct field directly), kept for future config-based auth.
+  @doc false
+  @spec get_api_key(t()) :: String.t() | nil
+  def get_api_key(%ChatAwsMantle{api_key: api_key}) when is_binary(api_key), do: api_key
+  def get_api_key(%ChatAwsMantle{}), do: Config.resolve(:aws_bearer_token_bedrock, nil)
+end

--- a/lib/message/content_part.ex
+++ b/lib/message/content_part.ex
@@ -323,9 +323,14 @@ defmodule LangChain.Message.ContentPart do
       iex> parts_to_string([])
       nil
   """
-  @spec parts_to_string([t()], type :: atom()) :: nil | String.t()
+  @spec parts_to_string([t() | nil], type :: atom()) :: nil | String.t()
   def parts_to_string(parts, type \\ :text) when is_list(parts) do
+    # Streaming `MessageDelta.merged_content` may contain nil entries when
+    # the index-based merge pads around an unfilled position (see
+    # `MessageDelta.merge_content_part_at_index/3`). Filter those before
+    # inspecting `.type` so callers don't need to sanitize first.
     parts
+    |> Enum.reject(&is_nil/1)
     |> Enum.filter(fn part -> part.type == type end)
     |> Enum.map_join("\n\n", fn part -> part.content end)
     |> case do

--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -363,19 +363,27 @@ defmodule LangChain.MessageDelta do
     %MessageDelta{primary | merged_content: updated_list}
   end
 
-  # Merge tool call delta by matching on index value (not list position).
-  # Anthropic's index differentiates calls but doesn't correspond to list offset.
+  # Merge tool call deltas by matching on each fragment's index value (not
+  # list position). The incoming delta may carry any number of tool_call
+  # fragments per chunk — OpenAI's spec allows an SSE event's `tool_calls`
+  # array to hold multiple argument fragments bound for the same `index`.
+  # gpt-oss-120b on AWS Mantle batches fragments this way; most providers
+  # emit one per chunk. Fold each fragment in turn so the accumulation is
+  # correct regardless of batching style.
   @spec merge_tool_calls(t(), t()) :: t()
-  defp merge_tool_calls(%MessageDelta{tool_calls: primary_calls} = primary, %MessageDelta{
-         tool_calls: [delta_call]
-       }) do
-    calls = primary_calls || []
-    initial = Enum.find(calls, &(&1.index == delta_call.index))
-    merged_call = ToolCall.merge(initial, delta_call)
-    %MessageDelta{primary | tool_calls: upsert_by_index(calls, merged_call)}
+  defp merge_tool_calls(%MessageDelta{} = primary, %MessageDelta{tool_calls: new_calls})
+       when is_list(new_calls) and new_calls != [] do
+    Enum.reduce(new_calls, primary, &merge_one_tool_call/2)
   end
 
   defp merge_tool_calls(%MessageDelta{} = primary, %MessageDelta{}), do: primary
+
+  defp merge_one_tool_call(%ToolCall{} = delta_call, %MessageDelta{tool_calls: primary_calls} = acc) do
+    calls = primary_calls || []
+    initial = Enum.find(calls, &(&1.index == delta_call.index))
+    merged_call = ToolCall.merge(initial, delta_call)
+    %MessageDelta{acc | tool_calls: upsert_by_index(calls, merged_call)}
+  end
 
   @spec update_index(t(), t()) :: t()
   defp update_index(%MessageDelta{} = primary, %MessageDelta{index: idx}) when is_number(idx) do

--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -378,7 +378,10 @@ defmodule LangChain.MessageDelta do
 
   defp merge_tool_calls(%MessageDelta{} = primary, %MessageDelta{}), do: primary
 
-  defp merge_one_tool_call(%ToolCall{} = delta_call, %MessageDelta{tool_calls: primary_calls} = acc) do
+  defp merge_one_tool_call(
+         %ToolCall{} = delta_call,
+         %MessageDelta{tool_calls: primary_calls} = acc
+       ) do
     calls = primary_calls || []
     initial = Enum.find(calls, &(&1.index == delta_call.index))
     merged_call = ToolCall.merge(initial, delta_call)

--- a/test/chat_models/chat_aws_mantle_test.exs
+++ b/test/chat_models/chat_aws_mantle_test.exs
@@ -193,7 +193,9 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
       refute Map.has_key?(body, :reasoning_effort)
     end
 
-    test "passes :top_p, :frequency_penalty, :presence_penalty through to the body when set", %{model: m} do
+    test "passes :top_p, :frequency_penalty, :presence_penalty through to the body when set", %{
+      model: m
+    } do
       updated = %{m | top_p: 0.9, frequency_penalty: 0.5, presence_penalty: 0.2}
       body = ChatAwsMantle.for_api(updated, [Message.new_user!("hi")], [])
       assert body.top_p == 0.9
@@ -232,7 +234,9 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
       body = ChatAwsMantle.for_api(m, history, [])
 
       assistant_serialized = Enum.at(body.messages, 1)
-      content = Map.get(assistant_serialized, "content") || Map.get(assistant_serialized, :content)
+
+      content =
+        Map.get(assistant_serialized, "content") || Map.get(assistant_serialized, :content)
 
       # Thinking was stripped; text survived.
       assert [%{"type" => "text", "text" => "I'm gpt-oss-120b."}] = content
@@ -291,7 +295,10 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
       assert msg.role == :assistant
 
       assert [
-               %ContentPart{type: :thinking, content: "100 mod 7 = 2, so Wednesday + 2 = Friday."},
+               %ContentPart{
+                 type: :thinking,
+                 content: "100 mod 7 = 2, so Wednesday + 2 = Friday."
+               },
                %ContentPart{type: :text, content: "The answer is Friday."}
              ] = msg.content
 
@@ -317,7 +324,9 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
 
     test "returns an error tuple on Mantle error envelope", %{model: m} do
       body = %{"error" => %{"message" => "bad token", "type" => "auth_error"}}
-      assert {:error, %LangChainError{message: "bad token"}} = ChatAwsMantle.do_process_response(m, body)
+
+      assert {:error, %LangChainError{message: "bad token"}} =
+               ChatAwsMantle.do_process_response(m, body)
     end
   end
 
@@ -501,7 +510,9 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
       %{model: m}
     end
 
-    test "reasoning chunks followed by content chunks produce [thinking, text] message", %{model: m} do
+    test "reasoning chunks followed by content chunks produce [thinking, text] message", %{
+      model: m
+    } do
       # Simulate Mantle's observed streaming shape:
       #   role → reasoning fragments → content fragments → terminal stop
       chunks = [
@@ -543,6 +554,7 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
         |> List.flatten()
 
       merged = MessageDelta.merge_deltas(deltas)
+
       assert {:ok, %Message{content: [%ContentPart{type: :text, content: "pong"}]}} =
                MessageDelta.to_message(merged)
     end
@@ -616,7 +628,8 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
   describe "live: streaming through ChatAwsMantle" do
     # Callbacks are not part of the cast fields (library convention — they're
     # runtime handlers, not config). Set via struct update after new!/1.
-    defp with_callbacks(%ChatAwsMantle{} = m, handlers), do: %ChatAwsMantle{m | callbacks: handlers}
+    defp with_callbacks(%ChatAwsMantle{} = m, handlers),
+      do: %ChatAwsMantle{m | callbacks: handlers}
 
     defp delta_capture_handler(test_pid) do
       %{

--- a/test/chat_models/chat_aws_mantle_test.exs
+++ b/test/chat_models/chat_aws_mantle_test.exs
@@ -1,0 +1,811 @@
+defmodule LangChain.ChatModels.ChatAwsMantleTest do
+  use LangChain.BaseCase
+
+  alias LangChain.ChatModels.ChatAwsMantle
+  alias LangChain.Function
+  alias LangChain.FunctionParam
+  alias LangChain.LangChainError
+  alias LangChain.Message
+  alias LangChain.Message.ContentPart
+  alias LangChain.Message.ToolCall
+  alias LangChain.MessageDelta
+  alias LangChain.TokenUsage
+
+  @kimi_model "moonshotai.kimi-k2.5"
+
+  describe "new/1 — schema and validation" do
+    test "succeeds with model + region + api_key (Bearer auth)" do
+      assert {:ok, %ChatAwsMantle{} = m} =
+               ChatAwsMantle.new(%{
+                 model: @kimi_model,
+                 region: "us-east-1",
+                 api_key: "test-key"
+               })
+
+      assert m.model == @kimi_model
+      assert m.region == "us-east-1"
+      assert m.api_key == "test-key"
+      assert m.credentials == nil
+      assert m.receive_timeout == 120_000
+      assert m.temperature == 1.0
+      assert m.stream == false
+    end
+
+    test "succeeds with model + region + credentials (SigV4 auth)" do
+      creds_fn = fn ->
+        [access_key_id: "AKIA...", secret_access_key: "secret"]
+      end
+
+      assert {:ok, %ChatAwsMantle{} = m} =
+               ChatAwsMantle.new(%{
+                 model: @kimi_model,
+                 region: "us-east-1",
+                 credentials: creds_fn
+               })
+
+      assert m.credentials == creds_fn
+      assert m.api_key == nil
+    end
+
+    test "fails when neither api_key nor credentials is set" do
+      assert {:error, changeset} =
+               ChatAwsMantle.new(%{model: @kimi_model, region: "us-east-1"})
+
+      assert {"must set either :api_key (Bearer) or :credentials (SigV4)", _} =
+               changeset.errors[:api_key]
+    end
+
+    test "fails when both api_key and credentials are set" do
+      assert {:error, changeset} =
+               ChatAwsMantle.new(%{
+                 model: @kimi_model,
+                 region: "us-east-1",
+                 api_key: "k",
+                 credentials: fn -> [] end
+               })
+
+      assert {"cannot set both :api_key and :credentials" <> _, _} =
+               changeset.errors[:api_key]
+    end
+
+    test "fails when neither :endpoint nor :region is set" do
+      assert {:error, changeset} =
+               ChatAwsMantle.new(%{model: @kimi_model, api_key: "k"})
+
+      assert {_, _} = changeset.errors[:region]
+    end
+
+    test "succeeds with :endpoint override and no :region" do
+      assert {:ok, %ChatAwsMantle{}} =
+               ChatAwsMantle.new(%{
+                 model: @kimi_model,
+                 endpoint: "https://example.com/v1/chat/completions",
+                 api_key: "k"
+               })
+    end
+
+    test "rejects an invalid :reasoning_effort value" do
+      assert {:error, changeset} =
+               ChatAwsMantle.new(%{
+                 model: @kimi_model,
+                 region: "us-east-1",
+                 api_key: "k",
+                 reasoning_effort: "extreme"
+               })
+
+      assert {"must be one of: low, medium, high", _} = changeset.errors[:reasoning_effort]
+    end
+
+    test "accepts valid reasoning_effort values" do
+      for effort <- ~w(low medium high) do
+        assert {:ok, %ChatAwsMantle{reasoning_effort: ^effort}} =
+                 ChatAwsMantle.new(%{
+                   model: @kimi_model,
+                   region: "us-east-1",
+                   api_key: "k",
+                   reasoning_effort: effort
+                 })
+      end
+    end
+
+    test "new!/1 raises on validation failure" do
+      assert_raise LangChainError, fn -> ChatAwsMantle.new!(%{}) end
+    end
+  end
+
+  describe "url/1" do
+    test "builds the Mantle URL from :region when no endpoint override" do
+      m = ChatAwsMantle.new!(%{model: @kimi_model, region: "us-west-2", api_key: "k"})
+
+      assert ChatAwsMantle.url(m) ==
+               "https://bedrock-mantle.us-west-2.api.aws/v1/chat/completions"
+    end
+
+    test "honors :endpoint override" do
+      m =
+        ChatAwsMantle.new!(%{
+          model: @kimi_model,
+          endpoint: "https://custom.example/v1/chat",
+          api_key: "k"
+        })
+
+      assert ChatAwsMantle.url(m) == "https://custom.example/v1/chat"
+    end
+  end
+
+  describe "auth_opts/1" do
+    test "returns Bearer auth when api_key is set" do
+      m = ChatAwsMantle.new!(%{model: @kimi_model, region: "us-east-1", api_key: "secret"})
+
+      assert [auth: {:bearer, "secret"}] = ChatAwsMantle.auth_opts(m)
+    end
+
+    test "returns SigV4 keyword list when credentials are set" do
+      creds = fn ->
+        [access_key_id: "AKIA", secret_access_key: "S", token: "T"]
+      end
+
+      m = ChatAwsMantle.new!(%{model: @kimi_model, region: "ap-south-1", credentials: creds})
+
+      assert [aws_sigv4: opts] = ChatAwsMantle.auth_opts(m)
+      assert opts[:region] == "ap-south-1"
+      assert opts[:service] == :bedrock
+      assert opts[:access_key_id] == "AKIA"
+      assert opts[:secret_access_key] == "S"
+      assert opts[:token] == "T"
+    end
+  end
+
+  describe "for_api/3" do
+    setup do
+      m =
+        ChatAwsMantle.new!(%{
+          model: @kimi_model,
+          region: "us-east-1",
+          api_key: "k",
+          temperature: 0.0,
+          max_tokens: 64
+        })
+
+      %{model: m}
+    end
+
+    test "produces an OpenAI-shaped request body", %{model: m} do
+      body = ChatAwsMantle.for_api(m, [Message.new_user!("hi")], [])
+
+      assert body.model == @kimi_model
+      assert body.stream == false
+      assert body.temperature == 0.0
+      assert body.max_tokens == 64
+      assert is_list(body.messages)
+      assert [%{} = msg] = body.messages
+      assert msg["role"] == :user
+    end
+
+    test "includes :reasoning_effort when set", %{model: %ChatAwsMantle{} = m} do
+      m_with_reasoning = %ChatAwsMantle{m | reasoning_effort: "high"}
+      body = ChatAwsMantle.for_api(m_with_reasoning, [Message.new_user!("hi")], [])
+      assert body.reasoning_effort == "high"
+    end
+
+    test "omits :reasoning_effort when not set", %{model: m} do
+      body = ChatAwsMantle.for_api(m, [Message.new_user!("hi")], [])
+      refute Map.has_key?(body, :reasoning_effort)
+    end
+
+    test "passes :top_p, :frequency_penalty, :presence_penalty through to the body when set", %{model: m} do
+      updated = %{m | top_p: 0.9, frequency_penalty: 0.5, presence_penalty: 0.2}
+      body = ChatAwsMantle.for_api(updated, [Message.new_user!("hi")], [])
+      assert body.top_p == 0.9
+      assert body.frequency_penalty == 0.5
+      assert body.presence_penalty == 0.2
+    end
+
+    test "omits the sampling knobs when not set", %{model: m} do
+      body = ChatAwsMantle.for_api(m, [Message.new_user!("hi")], [])
+      refute Map.has_key?(body, :top_p)
+      refute Map.has_key?(body, :frequency_penalty)
+      refute Map.has_key?(body, :presence_penalty)
+    end
+
+    test "strips :thinking ContentParts from assistant messages before serialization", %{model: m} do
+      # Mantle's wire format has no representation for thinking blocks.
+      # ChatAwsMantle surfaces them from delta.reasoning for UI display, but
+      # on the way back out (when a multi-turn conversation re-sends the
+      # assistant message as history), they must be filtered or ChatOpenAI's
+      # content_part_for_api/2 crashes (no clause for :thinking).
+      history = [
+        Message.new_user!("What model are you?"),
+        %Message{
+          role: :assistant,
+          status: :complete,
+          content: [
+            ContentPart.thinking!("I should answer with my model name. Let me think..."),
+            ContentPart.text!("I'm gpt-oss-120b.")
+          ]
+        },
+        Message.new_user!("Great, what files do I have?")
+      ]
+
+      # Should not raise — crashes pre-fix because the assistant message has
+      # a thinking part that ChatOpenAI can't serialize.
+      body = ChatAwsMantle.for_api(m, history, [])
+
+      assistant_serialized = Enum.at(body.messages, 1)
+      content = Map.get(assistant_serialized, "content") || Map.get(assistant_serialized, :content)
+
+      # Thinking was stripped; text survived.
+      assert [%{"type" => "text", "text" => "I'm gpt-oss-120b."}] = content
+    end
+  end
+
+  describe "new/1 — sampling knob validation" do
+    test "rejects out-of-range :frequency_penalty" do
+      assert {:error, changeset} =
+               ChatAwsMantle.new(%{
+                 model: @kimi_model,
+                 region: "us-east-1",
+                 api_key: "k",
+                 frequency_penalty: 3.0
+               })
+
+      assert changeset.errors[:frequency_penalty]
+    end
+
+    test "rejects out-of-range :top_p" do
+      assert {:error, changeset} =
+               ChatAwsMantle.new(%{
+                 model: @kimi_model,
+                 region: "us-east-1",
+                 api_key: "k",
+                 top_p: 1.5
+               })
+
+      assert changeset.errors[:top_p]
+    end
+  end
+
+  describe "do_process_response/2 — reasoning extraction" do
+    setup do
+      m = ChatAwsMantle.new!(%{model: @kimi_model, region: "us-east-1", api_key: "k"})
+      %{model: m}
+    end
+
+    test "extracts message.reasoning into a leading thinking ContentPart", %{model: m} do
+      body = %{
+        "choices" => [
+          %{
+            "finish_reason" => "stop",
+            "index" => 0,
+            "message" => %{
+              "role" => "assistant",
+              "content" => "The answer is Friday.",
+              "reasoning" => "100 mod 7 = 2, so Wednesday + 2 = Friday."
+            }
+          }
+        ],
+        "usage" => %{"prompt_tokens" => 49, "completion_tokens" => 30, "total_tokens" => 79}
+      }
+
+      assert [%Message{} = msg] = ChatAwsMantle.do_process_response(m, body)
+      assert msg.role == :assistant
+
+      assert [
+               %ContentPart{type: :thinking, content: "100 mod 7 = 2, so Wednesday + 2 = Friday."},
+               %ContentPart{type: :text, content: "The answer is Friday."}
+             ] = msg.content
+
+      assert %TokenUsage{input: 49, output: 30} = msg.metadata.usage
+    end
+
+    test "leaves messages without reasoning unchanged", %{model: m} do
+      body = %{
+        "choices" => [
+          %{
+            "finish_reason" => "stop",
+            "index" => 0,
+            "message" => %{"role" => "assistant", "content" => "Hi!"}
+          }
+        ],
+        "usage" => %{"prompt_tokens" => 5, "completion_tokens" => 2, "total_tokens" => 7}
+      }
+
+      assert [%Message{} = msg] = ChatAwsMantle.do_process_response(m, body)
+      assert [%ContentPart{type: :text, content: "Hi!"}] = msg.content
+      refute Enum.any?(msg.content, &(&1.type == :thinking))
+    end
+
+    test "returns an error tuple on Mantle error envelope", %{model: m} do
+      body = %{"error" => %{"message" => "bad token", "type" => "auth_error"}}
+      assert {:error, %LangChainError{message: "bad token"}} = ChatAwsMantle.do_process_response(m, body)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Live integration smoke test — exercises the full module against Mantle.
+  # Mirrors the first smoke test from aws_mantle_smoke_test.exs but routed
+  # through ChatAwsMantle to prove the new module works end-to-end.
+  # ---------------------------------------------------------------------------
+  describe "live: end-to-end through ChatAwsMantle" do
+    @tag live_call: true, live_aws_mantle: true, timeout: 180_000
+    test "non-streaming completion returns expected text" do
+      api_key = System.fetch_env!("AWS_BEARER_TOKEN_BEDROCK")
+
+      model =
+        ChatAwsMantle.new!(%{
+          model: @kimi_model,
+          region: "us-east-1",
+          api_key: api_key,
+          temperature: 0.0,
+          max_tokens: 32,
+          verbose_api: true
+        })
+
+      assert {:ok, [%Message{role: :assistant, content: content} = msg]} =
+               ChatAwsMantle.call(model, [Message.new_user!("Reply with the single word 'pong'.")])
+
+      IO.inspect(msg, label: "ChatAwsMantle MESSAGE")
+
+      text = ContentPart.parts_to_string(content)
+      assert text =~ ~r/pong/i
+      assert %TokenUsage{} = msg.metadata.usage
+    end
+
+    @tag live_call: true, live_aws_mantle: true, timeout: 180_000
+    test "with reasoning_effort: high, response includes a thinking ContentPart" do
+      api_key = System.fetch_env!("AWS_BEARER_TOKEN_BEDROCK")
+
+      model =
+        ChatAwsMantle.new!(%{
+          model: @kimi_model,
+          region: "us-east-1",
+          api_key: api_key,
+          temperature: 1.0,
+          max_tokens: 512,
+          reasoning_effort: "high",
+          verbose_api: true
+        })
+
+      assert {:ok, [%Message{role: :assistant} = msg]} =
+               ChatAwsMantle.call(model, [
+                 Message.new_user!(
+                   "If today is Wednesday, what day is it in 100 days? Show your work."
+                 )
+               ])
+
+      IO.inspect(msg.content, label: "ChatAwsMantle MULTIPART CONTENT")
+
+      thinking_parts = Enum.filter(msg.content, &(&1.type == :thinking))
+      text_parts = Enum.filter(msg.content, &(&1.type == :text))
+
+      assert length(thinking_parts) >= 1, "expected at least one :thinking content part"
+      assert length(text_parts) >= 1, "expected at least one :text content part"
+
+      [thinking | _] = thinking_parts
+      assert is_binary(thinking.content)
+      assert String.length(thinking.content) > 20
+
+      text = ContentPart.parts_to_string(text_parts)
+      assert text =~ ~r/friday/i
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Unit tests — streaming delta parsing. No network calls; we feed raw SSE
+  # JSON structures through do_process_response/2 and verify the MessageDelta
+  # structures produced (and the merged Message after running the full delta
+  # sequence through MessageDelta.merge_deltas/1).
+  # ---------------------------------------------------------------------------
+  describe "do_process_response/2 — streaming delta parsing" do
+    setup do
+      m = ChatAwsMantle.new!(%{model: @kimi_model, region: "us-east-1", api_key: "k"})
+      %{model: m}
+    end
+
+    test "role-only opening delta produces a role MessageDelta", %{model: m} do
+      chunk = %{
+        "choices" => [
+          %{"delta" => %{"role" => "assistant", "content" => nil}, "index" => 0}
+        ]
+      }
+
+      assert %MessageDelta{role: :assistant, status: :incomplete, content: nil} =
+               ChatAwsMantle.do_process_response(m, chunk)
+    end
+
+    test "content delta places text at index 1", %{model: m} do
+      chunk = %{
+        "choices" => [%{"delta" => %{"content" => "Hello"}, "index" => 0}]
+      }
+
+      assert %MessageDelta{content: "Hello", index: 1, status: :incomplete} =
+               ChatAwsMantle.do_process_response(m, chunk)
+    end
+
+    test "reasoning delta becomes a thinking ContentPart at index 0", %{model: m} do
+      chunk = %{
+        "choices" => [%{"delta" => %{"reasoning" => "hmm, thinking"}, "index" => 0}]
+      }
+
+      assert %MessageDelta{
+               content: %ContentPart{type: :thinking, content: "hmm, thinking"},
+               index: 0,
+               status: :incomplete
+             } = ChatAwsMantle.do_process_response(m, chunk)
+    end
+
+    test "combined reasoning + content in one chunk emits two deltas in order", %{model: m} do
+      chunk = %{
+        "choices" => [
+          %{"delta" => %{"reasoning" => "r", "content" => "c"}, "index" => 0}
+        ]
+      }
+
+      assert [
+               %MessageDelta{
+                 content: %ContentPart{type: :thinking, content: "r"},
+                 index: 0
+               },
+               %MessageDelta{content: "c", index: 1}
+             ] = ChatAwsMantle.do_process_response(m, chunk)
+    end
+
+    test "terminal delta with finish_reason: stop produces :complete status", %{model: m} do
+      chunk = %{
+        "choices" => [%{"delta" => %{}, "finish_reason" => "stop", "index" => 0}]
+      }
+
+      assert %MessageDelta{status: :complete} = ChatAwsMantle.do_process_response(m, chunk)
+    end
+
+    test "usage-only terminal event is :skip", %{model: m} do
+      chunk = %{
+        "choices" => [],
+        "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 5, "total_tokens" => 15}
+      }
+
+      assert :skip = ChatAwsMantle.do_process_response(m, chunk)
+    end
+
+    test "tool_call delta carries a ToolCall in the MessageDelta.tool_calls field", %{model: m} do
+      chunk = %{
+        "choices" => [
+          %{
+            "delta" => %{
+              "tool_calls" => [
+                %{
+                  "index" => 0,
+                  "id" => "call_abc",
+                  "type" => "function",
+                  "function" => %{"name" => "get_weather", "arguments" => ""}
+                }
+              ]
+            },
+            "index" => 0
+          }
+        ]
+      }
+
+      assert %MessageDelta{tool_calls: [%ToolCall{} = tc]} =
+               ChatAwsMantle.do_process_response(m, chunk)
+
+      assert tc.name == "get_weather"
+      assert tc.call_id == "call_abc"
+      assert tc.index == 0
+    end
+  end
+
+  describe "streaming integration — merging a simulated stream" do
+    setup do
+      m = ChatAwsMantle.new!(%{model: @kimi_model, region: "us-east-1", api_key: "k"})
+      %{model: m}
+    end
+
+    test "reasoning chunks followed by content chunks produce [thinking, text] message", %{model: m} do
+      # Simulate Mantle's observed streaming shape:
+      #   role → reasoning fragments → content fragments → terminal stop
+      chunks = [
+        %{"choices" => [%{"delta" => %{"role" => "assistant"}, "index" => 0}]},
+        %{"choices" => [%{"delta" => %{"reasoning" => "100 mod 7 = 2. "}, "index" => 0}]},
+        %{"choices" => [%{"delta" => %{"reasoning" => "So Wed + 2 = Fri."}, "index" => 0}]},
+        %{"choices" => [%{"delta" => %{"content" => "The answer "}, "index" => 0}]},
+        %{"choices" => [%{"delta" => %{"content" => "is Friday."}, "index" => 0}]},
+        %{"choices" => [%{"delta" => %{}, "finish_reason" => "stop", "index" => 0}]}
+      ]
+
+      deltas =
+        chunks
+        |> Enum.map(&ChatAwsMantle.do_process_response(m, &1))
+        |> List.flatten()
+
+      merged = MessageDelta.merge_deltas(deltas)
+      assert {:ok, %Message{} = msg} = MessageDelta.to_message(merged)
+
+      assert [
+               %ContentPart{type: :thinking, content: "100 mod 7 = 2. So Wed + 2 = Fri."},
+               %ContentPart{type: :text, content: "The answer is Friday."}
+             ] = msg.content
+
+      assert msg.role == :assistant
+      assert msg.status == :complete
+    end
+
+    test "content-only stream (no reasoning) still merges into a single text part", %{model: m} do
+      chunks = [
+        %{"choices" => [%{"delta" => %{"role" => "assistant"}, "index" => 0}]},
+        %{"choices" => [%{"delta" => %{"content" => "pong"}, "index" => 0}]},
+        %{"choices" => [%{"delta" => %{}, "finish_reason" => "stop", "index" => 0}]}
+      ]
+
+      deltas =
+        chunks
+        |> Enum.map(&ChatAwsMantle.do_process_response(m, &1))
+        |> List.flatten()
+
+      merged = MessageDelta.merge_deltas(deltas)
+      assert {:ok, %Message{content: [%ContentPart{type: :text, content: "pong"}]}} =
+               MessageDelta.to_message(merged)
+    end
+
+    test "streaming tool_calls accumulate across chunks into a complete ToolCall", %{model: m} do
+      # Mirrors Mantle's tool-call stream: role → call init → fragmented args → stop.
+      chunks = [
+        %{"choices" => [%{"delta" => %{"role" => "assistant"}, "index" => 0}]},
+        %{
+          "choices" => [
+            %{
+              "delta" => %{
+                "tool_calls" => [
+                  %{
+                    "index" => 0,
+                    "id" => "functions.get_weather:0",
+                    "type" => "function",
+                    "function" => %{"name" => "get_weather", "arguments" => ""}
+                  }
+                ]
+              },
+              "index" => 0
+            }
+          ]
+        },
+        %{
+          "choices" => [
+            %{
+              "delta" => %{
+                "tool_calls" => [
+                  %{"index" => 0, "function" => %{"arguments" => "{\"city\":"}}
+                ]
+              },
+              "index" => 0
+            }
+          ]
+        },
+        %{
+          "choices" => [
+            %{
+              "delta" => %{
+                "tool_calls" => [
+                  %{"index" => 0, "function" => %{"arguments" => "\"Moab\",\"state\":\"UT\"}"}}
+                ]
+              },
+              "index" => 0
+            }
+          ]
+        },
+        %{"choices" => [%{"delta" => %{}, "finish_reason" => "tool_calls", "index" => 0}]}
+      ]
+
+      deltas =
+        chunks
+        |> Enum.map(&ChatAwsMantle.do_process_response(m, &1))
+        |> List.flatten()
+
+      merged = MessageDelta.merge_deltas(deltas)
+      assert {:ok, %Message{} = msg} = MessageDelta.to_message(merged)
+      assert [%ToolCall{} = call] = msg.tool_calls
+      assert call.name == "get_weather"
+      assert call.call_id == "functions.get_weather:0"
+      assert call.arguments == %{"city" => "Moab", "state" => "UT"}
+      assert call.status == :complete
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Live streaming tests — end-to-end through ChatAwsMantle against Mantle.
+  # ---------------------------------------------------------------------------
+  describe "live: streaming through ChatAwsMantle" do
+    # Callbacks are not part of the cast fields (library convention — they're
+    # runtime handlers, not config). Set via struct update after new!/1.
+    defp with_callbacks(%ChatAwsMantle{} = m, handlers), do: %ChatAwsMantle{m | callbacks: handlers}
+
+    defp delta_capture_handler(test_pid) do
+      %{
+        on_llm_new_delta: fn deltas when is_list(deltas) ->
+          Enum.each(deltas, fn %MessageDelta{} = d -> send(test_pid, {:delta, d}) end)
+        end
+      }
+    end
+
+    @tag live_call: true, live_aws_mantle: true, timeout: 180_000
+    test "basic streaming yields deltas that merge into a non-empty text message" do
+      # Tests the streaming wire format end-to-end: deltas arrive via callback,
+      # accumulate, and merge to a Message with text content. Intentionally
+      # does not assert on Kimi's specific wording — the model is occasionally
+      # flaky on exact outputs. The structural assertions are what matter here.
+      model =
+        ChatAwsMantle.new!(%{
+          model: @kimi_model,
+          region: "us-east-1",
+          api_key: System.fetch_env!("AWS_BEARER_TOKEN_BEDROCK"),
+          stream: true,
+          temperature: 0.2,
+          max_tokens: 128
+        })
+        |> with_callbacks([delta_capture_handler(self())])
+
+      assert {:ok, result} =
+               ChatAwsMantle.call(model, [
+                 Message.new_user!("Say hello in three words or less.")
+               ])
+
+      deltas = List.flatten(result)
+      assert length(deltas) >= 2
+      assert Enum.all?(deltas, &match?(%MessageDelta{}, &1))
+      assert_received {:delta, %MessageDelta{}}
+
+      merged = MessageDelta.merge_deltas(deltas)
+      {:ok, %Message{role: :assistant} = msg} = MessageDelta.to_message(merged)
+
+      text = ContentPart.parts_to_string(msg.content)
+      assert is_binary(text)
+      assert String.length(text) > 0
+    end
+
+    @tag live_call: true, live_aws_mantle: true, timeout: 180_000
+    test "streaming with reasoning_effort: high yields a merged message with thinking + text" do
+      model =
+        ChatAwsMantle.new!(%{
+          model: @kimi_model,
+          region: "us-east-1",
+          api_key: System.fetch_env!("AWS_BEARER_TOKEN_BEDROCK"),
+          stream: true,
+          temperature: 1.0,
+          # Reasoning can consume the full budget on hard prompts; allot enough
+          # headroom for the model to finish thinking AND emit visible content.
+          max_tokens: 2048,
+          reasoning_effort: "high"
+        })
+        |> with_callbacks([delta_capture_handler(self())])
+
+      assert {:ok, result} =
+               ChatAwsMantle.call(model, [
+                 Message.new_user!(
+                   "If today is Wednesday, what day is it in 100 days? Answer briefly."
+                 )
+               ])
+
+      deltas = List.flatten(result)
+      assert length(deltas) >= 2
+
+      thinking_deltas =
+        Enum.filter(deltas, fn
+          %MessageDelta{content: %ContentPart{type: :thinking}} -> true
+          _ -> false
+        end)
+
+      assert length(thinking_deltas) >= 1,
+             "expected at least one thinking ContentPart in streamed deltas"
+
+      merged = MessageDelta.merge_deltas(deltas)
+      {:ok, %Message{} = msg} = MessageDelta.to_message(merged)
+
+      thinking_parts = Enum.filter(msg.content, &(&1.type == :thinking))
+      text_parts = Enum.filter(msg.content, &(&1.type == :text))
+
+      assert length(thinking_parts) >= 1
+      assert length(text_parts) >= 1
+
+      [thinking | _] = thinking_parts
+      assert String.length(thinking.content) > 20
+
+      text = ContentPart.parts_to_string(text_parts)
+      assert text =~ ~r/friday/i
+    end
+
+    @tag live_call: true, live_aws_mantle: true, timeout: 180_000
+    test "streaming with tool calls accumulates into a complete tool_call message" do
+      weather =
+        Function.new!(%{
+          name: "get_weather",
+          description: "Get the current weather in a given US location",
+          parameters: [
+            FunctionParam.new!(%{name: "city", type: "string", required: true}),
+            FunctionParam.new!(%{name: "state", type: "string", required: true})
+          ],
+          function: fn _args, _ctx -> {:ok, "75 degrees and sunny"} end
+        })
+
+      model =
+        ChatAwsMantle.new!(%{
+          model: @kimi_model,
+          region: "us-east-1",
+          api_key: System.fetch_env!("AWS_BEARER_TOKEN_BEDROCK"),
+          stream: true,
+          temperature: 0.2,
+          max_tokens: 256
+        })
+        |> with_callbacks([delta_capture_handler(self())])
+
+      {:ok, result} =
+        ChatAwsMantle.call(
+          model,
+          [Message.new_user!("What's the weather in Moab, Utah?")],
+          [weather]
+        )
+
+      deltas = List.flatten(result)
+      assert length(deltas) >= 2
+      assert_received {:delta, %MessageDelta{}}
+
+      tool_call_deltas =
+        Enum.filter(deltas, fn d -> d.tool_calls not in [nil, []] end)
+
+      assert length(tool_call_deltas) > 0
+
+      merged = MessageDelta.merge_deltas(deltas)
+      {:ok, %Message{} = msg} = MessageDelta.to_message(merged)
+
+      assert [%ToolCall{} = call] = msg.tool_calls
+      assert call.name == "get_weather"
+      assert call.status == :complete
+      # Kimi sometimes returns "UT" and sometimes "Utah" for state — accept either.
+      assert %{"city" => "Moab", "state" => state} = call.arguments
+      assert state =~ ~r/^(UT|Utah)$/i
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Live multimodal — K2.5 is a natively multimodal model. This test verifies
+  # end-to-end image input through the library: Message with text + image
+  # ContentParts → for_api serialization via ChatOpenAI helpers → Mantle →
+  # vision-aware response.
+  # ---------------------------------------------------------------------------
+  describe "live: multimodal through ChatAwsMantle" do
+    @tag live_call: true, live_aws_mantle: true, timeout: 180_000
+    test "K2.5 recognizes the subject of a real JPG via base64 image ContentPart" do
+      image_path = Path.expand("../support/images/barn_owl.jpg", __DIR__)
+      {:ok, image_bytes} = File.read(image_path)
+      image_b64 = Base.encode64(image_bytes)
+
+      model =
+        ChatAwsMantle.new!(%{
+          model: @kimi_model,
+          region: "us-east-1",
+          api_key: System.fetch_env!("AWS_BEARER_TOKEN_BEDROCK"),
+          temperature: 0.2,
+          max_tokens: 128
+        })
+
+      user_message =
+        Message.new_user!([
+          ContentPart.text!("What kind of bird is in this image? Reply in one or two words."),
+          ContentPart.image!(image_b64, media: :jpeg)
+        ])
+
+      assert {:ok, [%Message{role: :assistant, content: content} = msg]} =
+               ChatAwsMantle.call(model, [user_message])
+
+      text = ContentPart.parts_to_string(content)
+      IO.inspect(text, label: "ChatAwsMantle MULTIMODAL RESPONSE")
+      assert is_binary(text)
+      assert String.length(text) > 0
+
+      # Owl recognition is the functional proof that Kimi actually saw the image.
+      # Accept either "owl" (most likely) or "barn owl" (more specific) so the
+      # test isn't overly sensitive to Kimi's wording.
+      assert text =~ ~r/owl/i
+
+      assert %TokenUsage{} = msg.metadata.usage
+    end
+  end
+end

--- a/test/message/content_part_test.exs
+++ b/test/message/content_part_test.exs
@@ -252,6 +252,17 @@ defmodule LangChain.Message.ContentPartTest do
       assert ContentPart.parts_to_string(parts) == "Hello\n\nworld\n\nhow are you"
     end
 
+    test "tolerates nil entries (as produced by MessageDelta index-padded merges)" do
+      # MessageDelta.merge_content_part_at_index/3 pads positions with nil when
+      # a ContentPart is merged at an index beyond the current list length.
+      # parts_to_string must not crash on those nils.
+      parts = [nil, ContentPart.text!("Hello"), nil, ContentPart.text!("world")]
+      assert ContentPart.parts_to_string(parts) == "Hello\n\nworld"
+
+      assert ContentPart.parts_to_string([nil]) == nil
+      assert ContentPart.parts_to_string([nil, nil]) == nil
+    end
+
     test "matches on content type and can return thinking blocks" do
       parts = [
         ContentPart.new!(%{type: :thinking, content: "Let's think about this..."}),

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -200,6 +200,53 @@ defmodule LangChain.MessageDeltaTest do
       assert merged == expected
     end
 
+    test "merges multiple tool_call fragments carried in a single delta" do
+      # OpenAI's streaming spec allows an SSE event's `tool_calls` array to
+      # carry any number of argument fragments bound for the same `index`.
+      # Most providers emit one per chunk, but gpt-oss-120b on AWS Mantle
+      # batches fragments more aggressively and can send 3+ in one delta.
+      # Each fragment must accumulate into the same ToolCall.
+      initial =
+        %MessageDelta{
+          role: :assistant,
+          index: 0,
+          status: :incomplete,
+          tool_calls: [
+            %ToolCall{
+              status: :incomplete,
+              type: :function,
+              call_id: "call_abc",
+              name: "read_file",
+              arguments: "{\n",
+              index: 0
+            }
+          ]
+        }
+
+      multi_fragment_delta =
+        %MessageDelta{
+          role: :unknown,
+          index: 0,
+          status: :incomplete,
+          tool_calls: [
+            %ToolCall{status: :incomplete, type: :function, call_id: nil, name: nil, arguments: " \"", index: 0},
+            %ToolCall{status: :incomplete, type: :function, call_id: nil, name: nil, arguments: "file_path\":", index: 0},
+            %ToolCall{status: :incomplete, type: :function, call_id: nil, name: nil, arguments: " \"/Memories/dad_jokes.txt\"}", index: 0}
+          ]
+        }
+
+      merged = MessageDelta.merge_delta(initial, multi_fragment_delta)
+
+      assert [
+               %ToolCall{
+                 call_id: "call_abc",
+                 name: "read_file",
+                 arguments: "{\n \"file_path\": \"/Memories/dad_jokes.txt\"}",
+                 index: 0
+               }
+             ] = merged.tool_calls
+    end
+
     test "correctly merges assistant content with a tool_call" do
       merged = delta_content_with_function_call() |> List.flatten() |> MessageDelta.merge_deltas()
 

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -229,9 +229,30 @@ defmodule LangChain.MessageDeltaTest do
           index: 0,
           status: :incomplete,
           tool_calls: [
-            %ToolCall{status: :incomplete, type: :function, call_id: nil, name: nil, arguments: " \"", index: 0},
-            %ToolCall{status: :incomplete, type: :function, call_id: nil, name: nil, arguments: "file_path\":", index: 0},
-            %ToolCall{status: :incomplete, type: :function, call_id: nil, name: nil, arguments: " \"/Memories/dad_jokes.txt\"}", index: 0}
+            %ToolCall{
+              status: :incomplete,
+              type: :function,
+              call_id: nil,
+              name: nil,
+              arguments: " \"",
+              index: 0
+            },
+            %ToolCall{
+              status: :incomplete,
+              type: :function,
+              call_id: nil,
+              name: nil,
+              arguments: "file_path\":",
+              index: 0
+            },
+            %ToolCall{
+              status: :incomplete,
+              type: :function,
+              call_id: nil,
+              name: nil,
+              arguments: " \"/Memories/dad_jokes.txt\"}",
+              index: 0
+            }
           ]
         }
 


### PR DESCRIPTION
## Problem

AWS recently introduced Bedrock **Mantle**, an OpenAI-compatible gateway hosting third-party models including Moonshot AI's Kimi K2 family and OpenAI's gpt-oss series. LangChain had no first-class way to talk to this endpoint. Routing through `ChatOpenAI` works for basic completions but silently drops Mantle-specific fields (notably `reasoning`), and doesn't handle Mantle's region-aware URLs, dual auth modes, or per-model quirks.

## Solution

A new `ChatAwsMantle` chat model that mirrors the `ChatOpenAI` wire format — since Mantle is OpenAI-compatible — but adds the Mantle-specific handling:

- **Region-aware URL building** — `https://bedrock-mantle.{region}.api.aws/v1/chat/completions`
- **Two auth modes** — Bedrock API key (Bearer) *or* AWS IAM via SigV4, selectable per instance
- **Reasoning extraction** — Mantle returns model reasoning at `message.reasoning` (or `delta.reasoning` when streaming). `ChatAwsMantle` splits that into a `:thinking` `ContentPart` alongside the `:text` part, so the merged `Message` carries `[thinking_part, text_part]` in order
- **Mantle-appropriate defaults** — 120s `receive_timeout` (Mantle exhibits intermittent 60s+ cold starts) and a bounded `max_tokens: 4096` (Kimi K2.5 can lock into token-repetition loops, and streaming keeps the HTTP layer alive indefinitely without a cap)
- **Per-model notes** in `@moduledoc` covering Kimi's leading-space text quirk, its `functions.NAME:N` call_id shape, and gpt-oss-120b's batched tool-call fragments

Because Mantle is a single gateway across many models, this one module unlocks the whole catalog — `moonshotai.kimi-k2-thinking`, `moonshotai.kimi-k2.5`, `openai.gpt-oss-120b`, and any future models AWS publishes via Mantle — with no additional provider code required.

Two supporting fixes to shared message-handling code were required to make multi-model streaming work cleanly:

- **`MessageDelta.merge_tool_calls/2`** previously assumed each SSE chunk carried exactly one tool-call fragment. OpenAI's spec permits multiple fragments per chunk, and gpt-oss-120b on Mantle actually does this. Changed to fold each fragment in turn via `Enum.reduce`, preserving the single-fragment behavior of existing providers.
- **`ContentPart.parts_to_string/2`** now tolerates `nil` entries. The index-based delta merge (`merge_content_part_at_index/3`) can leave `nil` holes when a position isn't filled yet — e.g. when reasoning lands at index 0 but content lands at index 1 in a streaming response with no reasoning. The function filters nils before inspecting `.type` so callers don't need to pre-sanitize.

## Changes

- `lib/chat_models/chat_aws_mantle.ex` — new provider module implementing the `ChatModel` behavior: dual-auth (Bearer + SigV4), streaming and non-streaming paths, reasoning extraction, and extensive `@moduledoc` covering auth, reasoning, sampling caveats, streaming, and multimodal usage
- `lib/message_delta.ex` — generalize `merge_tool_calls/2` to handle multi-fragment chunks via `Enum.reduce` (needed for gpt-oss-120b; a no-op for existing providers)
- `lib/message/content_part.ex` — make `parts_to_string/2` nil-tolerant to match what index-based streaming merges can emit
- `test/chat_models/chat_aws_mantle_test.exs` — 29 unit tests including complete simulated stream → merge → `Message` flows for content-only, reasoning+content, and tool-calls; plus live tests against K2.5 for non-streaming, streaming, `reasoning_effort: "high"`, tool calls, and multimodal (base64 image)
- `test/message_delta_test.exs` — regression tests for multi-fragment tool-call chunks
- `test/message/content_part_test.exs` — regression test for nil-tolerant `parts_to_string`

## Testing

- **Unit tests**: `mix test` passes across the library including the 29 new `ChatAwsMantle` tests and the two regression tests in the shared `MessageDelta` / `ContentPart` modules.
- **Live tests** (tagged `live_call`, require `AWS_BEARER_TOKEN_BEDROCK`): non-streaming completion, streaming, `reasoning_effort: "high"`, streaming + tool calls, and multimodal (K2.5 vision via base64 image) validated end-to-end against Mantle.
- **Experimental status** is called out in the commit message and the module's `@moduledoc`. SigV4 live verification against a real IAM environment and multi-model verification against gpt-oss-120b and Kimi K2 Thinking are staged for a follow-up — the Bearer path and K2.5 target are exercised here.