### PR TITLE
Fix cross-model message serialization for thinking and unsupported content parts

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -1819,7 +1819,9 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   def content_parts_for_api(nil), do: []
 
   def content_parts_for_api(contents) when is_list(contents) do
-    Enum.map(contents, &content_part_for_api/1)
+    contents
+    |> Enum.map(&content_part_for_api/1)
+    |> Enum.reject(&is_nil/1)
   end
 
   def content_parts_for_api(content) when is_binary(content) do

--- a/lib/chat_models/chat_aws_mantle.ex
+++ b/lib/chat_models/chat_aws_mantle.ex
@@ -404,7 +404,13 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
   # and will crash if one round-trips, so we filter them here.
   @spec strip_thinking_parts(Message.t()) :: Message.t()
   defp strip_thinking_parts(%Message{content: content} = msg) when is_list(content) do
-    cleaned = Enum.reject(content, &match?(%ContentPart{type: :thinking}, &1))
+    cleaned =
+      Enum.reject(content, fn
+        %ContentPart{type: :thinking} -> true
+        %ContentPart{type: :unsupported} -> true
+        _ -> false
+      end)
+
     %{msg | content: cleaned}
   end
 

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -2771,6 +2771,36 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
       assert expected == ChatAnthropic.message_for_api(msg)
     end
 
+    test "strips thinking ContentParts without a signature from assistant messages with tool calls" do
+      # When a conversation crosses models (e.g. Kimi K2 → Claude), the history
+      # may include assistant messages whose :thinking ContentParts have no
+      # Anthropic signature. content_part_for_api/1 returns nil for those, and
+      # they must not appear in the serialized content array or Anthropic rejects
+      # the request with "Input should be a valid dictionary or object to extract
+      # fields from" (the exact error seen in production logs).
+      msg = %Message{
+        role: :assistant,
+        status: :complete,
+        content: [
+          %ContentPart{
+            type: :thinking,
+            content: "Let me look that up.",
+            options: []
+          }
+        ],
+        tool_calls: [
+          ToolCall.new!(%{call_id: "toolu_abc", name: "web_lookup", arguments: %{"query" => "elixir"}})
+        ]
+      }
+
+      result = ChatAnthropic.message_for_api(msg)
+
+      assert result["role"] == "assistant"
+      # The nil produced by the signatureless thinking part must be gone;
+      # only the tool_use block should remain.
+      assert [%{"type" => "tool_use", "id" => "toolu_abc"}] = result["content"]
+    end
+
     test "turns a tool message into expected JSON format" do
       tool_success_result =
         Message.new_tool_result!(%{

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -2789,7 +2789,11 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
           }
         ],
         tool_calls: [
-          ToolCall.new!(%{call_id: "toolu_abc", name: "web_lookup", arguments: %{"query" => "elixir"}})
+          ToolCall.new!(%{
+            call_id: "toolu_abc",
+            name: "web_lookup",
+            arguments: %{"query" => "elixir"}
+          })
         ]
       }
 

--- a/test/chat_models/chat_aws_mantle_test.exs
+++ b/test/chat_models/chat_aws_mantle_test.exs
@@ -241,6 +241,44 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
       # Thinking was stripped; text survived.
       assert [%{"type" => "text", "text" => "I'm gpt-oss-120b."}] = content
     end
+
+    test "strips :unsupported ContentParts (e.g. redacted_thinking) from assistant messages before serialization",
+         %{model: m} do
+      # Anthropic returns `redacted_thinking` blocks when extended thinking is
+      # enabled but the content is encrypted. LangChain stores these as
+      # %ContentPart{type: :unsupported, options: [type: "redacted_thinking"]}.
+      # If such a message is sent back to Mantle as history, the :unsupported
+      # part must be stripped — ChatOpenAI.content_part_for_api/2 has no clause
+      # for it and will crash.
+      redacted_thinking = %ContentPart{
+        type: :unsupported,
+        content: "<encrypted_thinking_data>",
+        options: [type: "redacted_thinking"]
+      }
+
+      history = [
+        Message.new_user!("Think hard about this."),
+        %Message{
+          role: :assistant,
+          status: :complete,
+          content: [
+            redacted_thinking,
+            ContentPart.text!("The answer is 42.")
+          ]
+        },
+        Message.new_user!("Are you sure?")
+      ]
+
+      body = ChatAwsMantle.for_api(m, history, [])
+
+      assistant_serialized = Enum.at(body.messages, 1)
+
+      content =
+        Map.get(assistant_serialized, "content") || Map.get(assistant_serialized, :content)
+
+      # :unsupported was stripped; text survived.
+      assert [%{"type" => "text", "text" => "The answer is 42."}] = content
+    end
   end
 
   describe "new/1 — sampling knob validation" do


### PR DESCRIPTION
## Problem

When conversations cross model providers (e.g. a Claude response with extended thinking is replayed to an AWS Mantle/OpenAI-compatible endpoint, or a non-Claude model's thinking history is sent back to Anthropic), the message history can contain `ContentPart` types that the receiving model's serializer doesn't know how to handle. This caused two distinct failures:

1. **ChatAnthropic**: An assistant message whose `:thinking` `ContentPart` has no Anthropic signature (e.g. from a model that doesn't set one) causes `content_part_for_api/1` to return `nil`. That `nil` would land in the content array and Anthropic rejects the request with `"Input should be a valid dictionary or object to extract fields from"`.

2. **ChatAwsMantle**: Anthropic's `redacted_thinking` blocks are stored as `%ContentPart{type: :unsupported}`. When such a message is forwarded to Mantle as conversation history, `ChatOpenAI.content_part_for_api/2` has no clause for `:unsupported` and crashes.

## Solution

Both fixes are minimal, defensive filters at the serialization boundary:

- **`ChatAnthropic.content_parts_for_api/1`** now pipes through `Enum.reject(&is_nil/1)` after mapping, so any `nil` produced by an unrecognised or unsigned content part is silently dropped before the API call.
- **`ChatAwsMantle.strip_thinking_parts/1`** expands its filter from only `:thinking` to also cover `:unsupported` parts, using a multi-clause anonymous function for clarity.

## Changes

- `lib/chat_models/chat_anthropic.ex` — `content_parts_for_api/1` filters out `nil` entries from the mapped content list
- `lib/chat_models/chat_aws_mantle.ex` — `strip_thinking_parts/1` also strips `:unsupported` ContentParts (e.g. `redacted_thinking`)
- `test/chat_models/chat_anthropic_test.exs` — Test covering a signatureless `:thinking` part in a cross-model assistant message with tool calls
- `test/chat_models/chat_aws_mantle_test.exs` — Test covering a `redacted_thinking` (`:unsupported`) part being stripped before Mantle serialization

## Testing

Two new unit tests added, one per fix. Each test constructs the exact message structure that triggered the production failure and asserts the serialized output contains only the expected content blocks. Tests run without external API calls (`mix test`).