### PR TITLE
OpenAI Responses - Multimodal Tool Outputs

### DIFF
--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -765,13 +765,11 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     Enum.map(tool_calls, &for_api(model, &1))
   end
 
-  def for_api(%ChatOpenAIResponses{} = _model, %ToolResult{type: :function} = result) do
-    # a ToolResult becomes a stand-alone %Message{role: :tool} response.
-    [%ContentPart{type: :text, content: output, options: []}] = result.content
-
+  def for_api(%ChatOpenAIResponses{} = model, %ToolResult{type: :function} = result) do
+    # a ToolResult becomes a stand-alone function_call_output item.
     %{
       "call_id" => result.tool_call_id,
-      "output" => output,
+      "output" => tool_result_output_for_api(model, result.content),
       "type" => "function_call_output"
     }
   end
@@ -789,6 +787,21 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
 
   def for_api(%ChatOpenAIResponses{} = _model, %PromptTemplate{} = _template) do
     raise LangChainError, "PromptTemplates must be converted to messages."
+  end
+
+  defp tool_result_output_for_api(_model, nil), do: ""
+
+  defp tool_result_output_for_api(_model, content) when is_binary(content), do: content
+
+  defp tool_result_output_for_api(_model, [
+         %ContentPart{type: :text, content: output, options: []}
+       ]) do
+    output
+  end
+
+  defp tool_result_output_for_api(%ChatOpenAIResponses{} = model, content_parts)
+       when is_list(content_parts) do
+    content_parts_for_api(model, content_parts)
   end
 
   def native_tool_calls_for_api(%ChatOpenAIResponses{} = model, content_parts)

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -667,6 +667,54 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       assert output["output"] == "Result: 42"
     end
 
+    test "converts multimodal tool result to function_call_output content array" do
+      tool_result =
+        LangChain.Message.ToolResult.new!(%{
+          tool_call_id: "call_123",
+          content: [
+            LangChain.Message.ContentPart.text!(~s({"status":"ok"})),
+            LangChain.Message.ContentPart.image!("base64-image-data",
+              media: "image/jpeg",
+              display_name: "preview.jpg"
+            )
+          ]
+        })
+
+      msg = LangChain.Message.new_tool_result!(%{tool_results: [tool_result]})
+      result = ChatOpenAIResponses.for_api(ChatOpenAIResponses.new!(), msg)
+
+      assert [%{"type" => "function_call_output", "output" => content}] = result
+
+      assert [
+               %{"type" => "input_text", "text" => ~s({"status":"ok"})},
+               %{
+                 "type" => "input_image",
+                 "image_url" => "data:image/jpeg;base64,base64-image-data"
+               }
+             ] = content
+    end
+
+    test "converts multi-text tool result to function_call_output content array" do
+      tool_result =
+        LangChain.Message.ToolResult.new!(%{
+          tool_call_id: "call_123",
+          content: [
+            LangChain.Message.ContentPart.text!("First"),
+            LangChain.Message.ContentPart.text!("Second")
+          ]
+        })
+
+      msg = LangChain.Message.new_tool_result!(%{tool_results: [tool_result]})
+      result = ChatOpenAIResponses.for_api(ChatOpenAIResponses.new!(), msg)
+
+      assert [%{"type" => "function_call_output", "output" => content}] = result
+
+      assert content == [
+               %{"type" => "input_text", "text" => "First"},
+               %{"type" => "input_text", "text" => "Second"}
+             ]
+    end
+
     test "handles assistant message with both content and tool calls" do
       msg =
         LangChain.Message.new_assistant!(%{


### PR DESCRIPTION
## Summary

Adds support for multimodal tool results in `ChatOpenAIResponses` when serializing function tool outputs for the OpenAI Responses API.

Previously, `ToolResult` serialization assumed a single text content part and emitted that text directly as the `function_call_output.output`. This update preserves the existing single-text behavior while allowing tool results with multiple content parts, including images, to serialize as Responses-compatible content arrays.

## Changes

- Update `ChatOpenAIResponses.for_api/2` for function `ToolResult`s to support:
  - `nil` content as an empty string
  - raw binary content
  - existing single text content as a string
  - multiple content parts as a serialized content array
- Reuse existing `content_parts_for_api/2` serialization for multimodal tool outputs.
- Add tests for:
  - multimodal tool result output containing text + image content
  - multi-text tool result output preserving multiple content parts
  - existing single-text tool result behavior