### PR TITLE
Add :on_tool_pre_execution callback for per-tool process context

### DIFF
--- a/lib/chains/chain_callbacks.ex
+++ b/lib/chains/chain_callbacks.ex
@@ -159,6 +159,11 @@ defmodule LangChain.Chains.ChainCallbacks do
   This fires immediately before tool execution starts, allowing UIs to show
   real-time feedback like "Searching the web..." or "Creating file...".
 
+  Note: This callback fires in the **parent chain process**, before any per-tool
+  async Task is spawned. For code that must run *inside* the per-tool process
+  (e.g. propagating tenancy/OTel/Sentry context across the async boundary), use
+  `:on_tool_pre_execution` instead.
+
   - First argument: LLMChain.t()
   - Second argument: ToolCall struct being executed
   - Third argument: Function struct for the tool (includes display_text)
@@ -166,6 +171,31 @@ defmodule LangChain.Chains.ChainCallbacks do
   The handler's return value is discarded.
   """
   @type chain_tool_execution_started :: (LLMChain.t(), ToolCall.t(), Function.t() -> any())
+
+  @typedoc """
+  Executed inside the process that will run the tool, immediately before the
+  tool function is invoked.
+
+  Unlike `:on_tool_execution_started` (which fires in the parent chain process
+  before any async Task is spawned), `:on_tool_pre_execution` fires in whichever
+  process actually runs the tool:
+
+  - For `async: true` tools — fires inside the spawned `Task.async/1`.
+  - For `async: false` tools — fires in the chain's own process.
+  - For tools executed via `execute_tool_calls_with_decisions/3` — fires in
+    the chain's own process.
+
+  This is the correct hook for code that depends on per-process state — for
+  example, re-applying tenant/observability context that lives in the process
+  dictionary across an async Task boundary.
+
+  - First argument: LLMChain.t()
+  - Second argument: ToolCall struct about to be executed
+  - Third argument: Function struct for the tool
+
+  The handler's return value is discarded.
+  """
+  @type chain_tool_pre_execution :: (LLMChain.t(), ToolCall.t(), Function.t() -> any())
 
   @typedoc """
   Executed when a single tool execution completes successfully.
@@ -308,6 +338,7 @@ defmodule LangChain.Chains.ChainCallbacks do
           optional(:on_error_message_created) => chain_error_message_created(),
           optional(:on_tool_call_identified) => chain_tool_call_identified(),
           optional(:on_tool_execution_started) => chain_tool_execution_started(),
+          optional(:on_tool_pre_execution) => chain_tool_pre_execution(),
           optional(:on_tool_execution_completed) => chain_tool_execution_completed(),
           optional(:on_tool_execution_failed) => chain_tool_execution_failed(),
           optional(:on_tool_interrupted) => chain_tool_interrupted(),

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1419,6 +1419,9 @@ defmodule LangChain.Chains.LLMChain do
         grouped[:async]
         |> Enum.map(fn {call, func} ->
           Task.async(fn ->
+            # Fires inside the spawned Task so handlers (e.g. tenancy/OTel
+            # propagation) can re-apply per-process state before the tool runs.
+            Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [chain, call, func])
             result = execute_tool_call(call, func, verbose: verbose, context: use_context)
             {call, func, result}
           end)
@@ -1449,6 +1452,7 @@ defmodule LangChain.Chains.LLMChain do
       # Execute sync tools with immediate callbacks
       sync_tool_results =
         Enum.map(grouped[:sync], fn {call, func} ->
+          Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [chain, call, func])
           result = execute_tool_call(call, func, verbose: verbose, context: use_context)
 
           # Fire completed/failed callback immediately after execution
@@ -1573,6 +1577,12 @@ defmodule LangChain.Chains.LLMChain do
                   func
                 ])
 
+                Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [
+                  chain,
+                  tool_call,
+                  func
+                ])
+
                 result =
                   execute_tool_call(tool_call, func, verbose: verbose, context: use_context)
 
@@ -1625,6 +1635,12 @@ defmodule LangChain.Chains.LLMChain do
 
                 # Fire started callback before execution
                 Callbacks.fire(chain.callbacks, :on_tool_execution_started, [
+                  chain,
+                  edited_call,
+                  func
+                ])
+
+                Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [
                   chain,
                   edited_call,
                   func

--- a/test/chains/llm_chain_tool_callbacks_test.exs
+++ b/test/chains/llm_chain_tool_callbacks_test.exs
@@ -590,4 +590,247 @@ defmodule LangChain.Chains.LLMChainToolCallbacksTest do
       refute_received {:identified, _}
     end
   end
+
+  describe ":on_tool_pre_execution callback" do
+    test "fires inside the per-tool Task for async tools" do
+      test_pid = self()
+      chain_pid = self()
+
+      tool =
+        Function.new!(%{
+          name: "async_marker",
+          description: "Reports the PID it ran in",
+          async: true,
+          parameters_schema: %{type: "object", properties: %{}},
+          function: fn _args, _ctx ->
+            send(test_pid, {:tool_ran_in, self()})
+            {:ok, "ok"}
+          end
+        })
+
+      callbacks = %{
+        on_tool_pre_execution: fn _chain, tool_call, _function ->
+          send(test_pid, {:pre_execution_in, tool_call.name, self()})
+        end
+      }
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: [callbacks]
+        })
+
+      message =
+        Message.new_assistant!(%{
+          content: nil,
+          tool_calls: [
+            ToolCall.new!(%{call_id: "call_async", name: "async_marker", arguments: %{}})
+          ]
+        })
+
+      chain = LLMChain.add_message(chain, message)
+      _ = LLMChain.execute_tool_calls(chain)
+
+      assert_received {:pre_execution_in, "async_marker", pre_pid}
+      assert_received {:tool_ran_in, run_pid}
+
+      # The decisive assertion: callback ran in the same process as the tool,
+      # NOT in the chain's parent process.
+      assert pre_pid == run_pid
+      refute pre_pid == chain_pid
+    end
+
+    test "fires in the chain's process for sync tools" do
+      test_pid = self()
+      chain_pid = self()
+
+      tool =
+        Function.new!(%{
+          name: "sync_marker",
+          description: "Reports the PID it ran in",
+          async: false,
+          parameters_schema: %{type: "object", properties: %{}},
+          function: fn _args, _ctx ->
+            send(test_pid, {:tool_ran_in, self()})
+            {:ok, "ok"}
+          end
+        })
+
+      callbacks = %{
+        on_tool_pre_execution: fn _chain, tool_call, _function ->
+          send(test_pid, {:pre_execution_in, tool_call.name, self()})
+        end
+      }
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: [callbacks]
+        })
+
+      message =
+        Message.new_assistant!(%{
+          content: nil,
+          tool_calls: [
+            ToolCall.new!(%{call_id: "call_sync", name: "sync_marker", arguments: %{}})
+          ]
+        })
+
+      chain = LLMChain.add_message(chain, message)
+      _ = LLMChain.execute_tool_calls(chain)
+
+      assert_received {:pre_execution_in, "sync_marker", pre_pid}
+      assert_received {:tool_ran_in, run_pid}
+
+      # Sync path runs in the chain's own process.
+      assert pre_pid == run_pid
+      assert pre_pid == chain_pid
+    end
+
+    test "fires before :on_tool_execution_completed" do
+      test_pid = self()
+
+      tool =
+        Function.new!(%{
+          name: "ordered_tool",
+          description: "Ordering check",
+          async: true,
+          parameters_schema: %{type: "object", properties: %{}},
+          function: fn _args, _ctx -> {:ok, "ok"} end
+        })
+
+      callbacks = %{
+        on_tool_pre_execution: fn _chain, _tc, _f -> send(test_pid, :pre) end,
+        on_tool_execution_completed: fn _chain, _tc, _r -> send(test_pid, :completed) end
+      }
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: [callbacks]
+        })
+
+      message =
+        Message.new_assistant!(%{
+          content: nil,
+          tool_calls: [
+            ToolCall.new!(%{call_id: "call_order", name: "ordered_tool", arguments: %{}})
+          ]
+        })
+
+      chain = LLMChain.add_message(chain, message)
+      _ = LLMChain.execute_tool_calls(chain)
+
+      assert_received :pre
+      assert_received :completed
+    end
+
+    test "is optional - chain runs normally without a handler" do
+      tool =
+        Function.new!(%{
+          name: "plain_tool",
+          description: "No callback registered",
+          parameters_schema: %{type: "object", properties: %{}},
+          function: fn _args, _ctx -> {:ok, "ok"} end
+        })
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: []
+        })
+
+      message =
+        Message.new_assistant!(%{
+          content: nil,
+          tool_calls: [
+            ToolCall.new!(%{call_id: "call_plain", name: "plain_tool", arguments: %{}})
+          ]
+        })
+
+      chain = LLMChain.add_message(chain, message)
+      updated_chain = LLMChain.execute_tool_calls(chain)
+
+      # Last message should be the tool result, no errors raised.
+      assert %Message{role: :tool} = List.last(updated_chain.messages)
+    end
+
+    test "fires for tools executed via execute_tool_calls_with_decisions/3" do
+      test_pid = self()
+
+      tool =
+        Function.new!(%{
+          name: "decided_tool",
+          description: "Run via decisions path",
+          parameters_schema: %{type: "object", properties: %{}},
+          function: fn _args, _ctx -> {:ok, "ok"} end
+        })
+
+      callbacks = %{
+        on_tool_pre_execution: fn _chain, tool_call, _function ->
+          send(test_pid, {:pre, tool_call.name, tool_call.arguments})
+        end
+      }
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: [callbacks]
+        })
+
+      tool_call =
+        ToolCall.new!(%{call_id: "call_dec", name: "decided_tool", arguments: %{"x" => 1}})
+
+      _ =
+        LLMChain.execute_tool_calls_with_decisions(
+          chain,
+          [tool_call],
+          [%{type: :approve}]
+        )
+
+      assert_received {:pre, "decided_tool", %{"x" => 1}}
+    end
+
+    test "fires with edited arguments in the :edit decision path" do
+      test_pid = self()
+
+      tool =
+        Function.new!(%{
+          name: "decided_tool",
+          description: "Run via decisions path with edits",
+          parameters_schema: %{type: "object", properties: %{}},
+          function: fn _args, _ctx -> {:ok, "ok"} end
+        })
+
+      callbacks = %{
+        on_tool_pre_execution: fn _chain, tool_call, _function ->
+          send(test_pid, {:pre, tool_call.arguments})
+        end
+      }
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: [callbacks]
+        })
+
+      tool_call =
+        ToolCall.new!(%{call_id: "call_edit", name: "decided_tool", arguments: %{"x" => 1}})
+
+      _ =
+        LLMChain.execute_tool_calls_with_decisions(
+          chain,
+          [tool_call],
+          [%{type: :edit, arguments: %{"x" => 99}}]
+        )
+
+      assert_received {:pre, %{"x" => 99}}
+    end
+  end
 end


### PR DESCRIPTION
## Problem

The existing `:on_tool_execution_started` callback fires in the **parent chain process**, before any per-tool `Task.async/1` is spawned for async tools. That makes it the right hook for UI feedback ("Searching the web..."), but the wrong hook for anything that depends on per-process state — tenancy context, OpenTelemetry spans, Sentry scope, Logger metadata — none of which cross the async Task boundary automatically. Integrators had no clean place to re-apply that state inside the process that actually runs the tool.

## Solution

Adds a complementary callback, `:on_tool_pre_execution`, which fires **inside whichever process will run the tool function**, immediately before invocation:

- For `async: true` tools — inside the spawned `Task.async/1`.
- For `async: false` tools — in the chain's own process.
- For tools executed via `execute_tool_calls_with_decisions/3` (HITL approval flow) — in the chain's own process, including the `:edit` decision path that runs the tool with edited arguments.

The new hook is purely additive: `:on_tool_execution_started` keeps its current "fire in the parent, before any spawning" semantics, and `:on_tool_pre_execution` is the per-execution-process counterpart. Documentation on both typespecs explicitly contrasts the two so integrators can pick the right one.

## Changes

- `lib/chains/chain_callbacks.ex` — Added `chain_tool_pre_execution` typespec with documentation contrasting it against `:on_tool_execution_started`; registered it in the `callbacks` map type. Updated the `:on_tool_execution_started` doc to point users at the new hook for context-propagation use cases.
- `lib/chains/llm_chain.ex` — Fired `:on_tool_pre_execution` at all four tool-execution sites: the async branch and sync branch of `execute_tool_calls/2`, and both branches (original call and `:edit`-decision call) inside `execute_tool_calls_with_decisions/3`.
- `test/chains/llm_chain_tool_callbacks_test.exs` — Added a dedicated `describe \":on_tool_pre_execution callback\"` block with six tests verifying: it fires inside the per-tool Task for async tools, in the chain's process for sync tools, before `:on_tool_execution_completed`, is optional, fires through `execute_tool_calls_with_decisions/3`, and fires with edited arguments in the `:edit` decision path.

## Testing

Six new unit tests exercise each execution path. The async-vs-sync process-identity assertions are made by capturing `self()` from inside the handler and comparing against the chain process's PID, so the tests genuinely confirm the callback runs in the right process and not just that it's invoked.