### PR TITLE
DataExtractionChain: normalize single-object extraction tool results to a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- **`DataExtractionChain` accepts a single object in the extraction tool `info` argument**: The tool schema describes `info` as a JSON array of rows, but some models return one object when a single entity is extracted, which previously surfaced as `{:error, "Unexpected response…"}`. `run/4` now normalises a lone map to a one-element list so callers consistently receive `{:ok, [row | rows]}`. Adds public `normalize_extraction_info/1` for coercion (and unit tests) without mocking the LLM.
+- **`DataExtractionChain` normalises single-object `info` tool payloads**: The schema describes `info` as a JSON array, but some models return one object for a single row; that previously failed the `run/4` pattern match and returned `{:error, LangChainError.exception("Unexpected response...")}`. A lone map is now wrapped in a list. Adds `normalize_extraction_info/1` for coercion and unit tests without a live LLM. https://github.com/brainlid/langchain/pull/533
 
 ## v0.8.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## v0.8.6
+## vNEXT
 
-### Fixed
+### Changed
 
 - **`DataExtractionChain` normalises single-object `info` tool payloads**: The schema describes `info` as a JSON array, but some models return one object for a single row; that previously failed the `run/4` pattern match and returned `{:error, LangChainError.exception("Unexpected response...")}`. A lone map is now wrapped in a list. Adds `normalize_extraction_info/1` for coercion and unit tests without a live LLM. https://github.com/brainlid/langchain/pull/533
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.8.6
+
+### Fixed
+
+- **`DataExtractionChain` accepts a single object in the extraction tool `info` argument**: The tool schema describes `info` as a JSON array of rows, but some models return one object when a single entity is extracted, which previously surfaced as `{:error, "Unexpected response…"}`. `run/4` now normalises a lone map to a one-element list so callers consistently receive `{:ok, [row | rows]}`. Adds public `normalize_extraction_info/1` for coercion (and unit tests) without mocking the LLM.
+
 ## v0.8.5
 
 A small reliability and observability release. Streaming runs now recover from delta-conversion errors instead of failing the chain outright, and a new tool callback fires inside the per-tool process so per-process context (tenancy, OTel, Sentry) can be re-applied across the async Task boundary.

--- a/lib/chains/data_extraction_chain.ex
+++ b/lib/chains/data_extraction_chain.ex
@@ -6,6 +6,10 @@ defmodule LangChain.Chains.DataExtractionChain do
   though there are 0 to many instances of the data structure being described so
   information is returned as an array.
 
+  The result is always a list. If the LLM returns a single map instead of an
+  array, it is automatically wrapped in a list so callers can rely on a
+  consistent return type.
+
   Originally based on:
   - https://github.com/langchain-ai/langchainjs/blob/main/langchain/src/chains/openai_functions/extraction.ts#L43
 
@@ -52,6 +56,18 @@ defmodule LangChain.Chains.DataExtractionChain do
         }
       ]
 
+  If the LLM returns a single map (e.g. when only one entity is found), it is
+  wrapped in a list automatically:
+
+      # Single-entity result normalised to a list
+      [
+        %{
+          "person_name" => "Alex",
+          "person_age" => nil,
+          ...
+        }
+      ]
+
   The `schema_parameters` in the previous example can also be expressed using a
   list of `LangChain.FunctionParam` structs. An equivalent version looks like
   this:
@@ -82,6 +98,21 @@ defmodule LangChain.Chains.DataExtractionChain do
 
 Passage:
 <%= @input %>"
+
+  @doc """
+  Coerces the extraction tool's `info` argument to a list of rows.
+
+  Models sometimes return one JSON object instead of a one-element array; `run/4`
+  uses this so callers always get `{:ok, list}`.
+  """
+  @spec normalize_extraction_info(term()) :: {:ok, [any()]} | {:error, LangChainError.t()}
+  def normalize_extraction_info(info) when is_list(info), do: {:ok, info}
+
+  def normalize_extraction_info(info) when is_map(info), do: {:ok, [info]}
+
+  def normalize_extraction_info(other) do
+    {:error, LangChainError.exception("Unexpected response. #{inspect(other)}")}
+  end
 
   @doc """
   Run the data extraction chain.
@@ -119,12 +150,8 @@ Passage:
                }
              ]
            }
-         }}
-        when is_list(info) ->
-          {:ok, info}
-
-        other ->
-          {:error, LangChainError.exception("Unexpected response. #{inspect(other)}")}
+         }} ->
+          normalize_extraction_info(info)
       end
     rescue
       exception ->

--- a/lib/chains/data_extraction_chain.ex
+++ b/lib/chains/data_extraction_chain.ex
@@ -111,7 +111,8 @@ Passage:
   def normalize_extraction_info(info) when is_map(info), do: {:ok, [info]}
 
   def normalize_extraction_info(other) do
-    {:error, LangChainError.exception("Unexpected response. #{inspect(other)}")}
+    {:error,
+     LangChainError.exception("Extracted data must be a list or map, got: #{inspect(other)}")}
   end
 
   @doc """
@@ -152,6 +153,9 @@ Passage:
            }
          }} ->
           normalize_extraction_info(info)
+
+        other ->
+          {:error, LangChainError.exception("Unexpected response. #{inspect(other)}")}
       end
     rescue
       exception ->

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule LangChain.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/brainlid/langchain"
-  @version "0.8.6"
+  @version "0.8.5"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule LangChain.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/brainlid/langchain"
-  @version "0.8.5"
+  @version "0.8.6"
 
   def project do
     [

--- a/test/chains/data_extraction_chain_test.exs
+++ b/test/chains/data_extraction_chain_test.exs
@@ -47,6 +47,34 @@ defmodule LangChain.Chains.DataExtractionChainTest do
     end
   end
 
+  describe "normalize_extraction_info/1" do
+    test "wraps a single map as one row (models sometimes omit the JSON array)" do
+      single_map = %{
+        "person_name" => "Alex",
+        "person_age" => nil,
+        "person_hair_color" => "blonde",
+        "pet_dog_name" => "Frosty",
+        "pet_dog_breed" => "labrador"
+      }
+
+      assert {:ok, [^single_map]} = DataExtractionChain.normalize_extraction_info(single_map)
+    end
+
+    test "leaves a list of maps unchanged" do
+      rows = [
+        %{"person_name" => "Alex"},
+        %{"person_name" => "Claudia"}
+      ]
+
+      assert {:ok, ^rows} = DataExtractionChain.normalize_extraction_info(rows)
+    end
+
+    test "returns error for non-list non-map info" do
+      assert {:error, %LangChain.LangChainError{}} =
+               DataExtractionChain.normalize_extraction_info("not a row")
+    end
+  end
+
   # Extraction - https://js.langchain.com/docs/modules/chains/openai_functions/extraction
   @tag live_call: true, live_open_ai: true
   test "data extraction chain" do


### PR DESCRIPTION
### Summary

Some models return a **single JSON object** for the `information_extraction` tool’s `info` argument instead of a **JSON array** of objects, even though the schema describes `info` as an array. This mostly happens when there is only one entity extracted. Without this, we would get an `Unexpected response` error, despite the fact that the LLM has returned absolutely good useable results.

This PR normalizes that case so **`run/4` always succeeds with `{:ok, [rows…]}`** when the tool call shape matches, and `info` is either a list or a map.

### Changes

- **`normalize_extraction_info/1`**: Public helper that returns `{:ok, rows}` for a list (unchanged) or a map (wrapped as a one-element list), and `{:error, %LangChain.LangChainError{}}` for any other `info` type.
- **`run/4`**: After a successful extraction tool call, delegates to `normalize_extraction_info/1` instead of assuming `info` is always a list.
- **Docs**: `@moduledoc` notes the list guarantee and single-entity behaviour.
- **Tests**: Unit tests for `normalize_extraction_info/1` (map, list, invalid type). Existing live extraction test unchanged.

### Behaviour / compatibility

- **Fix / tightening**: Callers that previously got `{:error, "Unexpected response…"}` when the model returned a lone object should now get `{:ok, [map]}`.
- **Public API**: Adds `normalize_extraction_info/1` for reuse and focused tests without mocking the LLM.

### Checklist

- [x] `mix test test/chains/data_extraction_chain_test.exs --exclude live_call`
- [x] `mix precommit`
- [x] Added a **CHANGELOG** line under the next release for clarity.