### PR TITLE
Handle nil interrupt_data in Steps.extract_interrupt_data/1

### DIFF
--- a/lib/chains/llm_chain/mode/steps.ex
+++ b/lib/chains/llm_chain/mode/steps.ex
@@ -148,7 +148,8 @@ defmodule LangChain.Chains.LLMChain.Mode.Steps do
   end
 
   defp extract_interrupt_data([single]) do
-    Map.put(single.interrupt_data, :tool_call_id, single.tool_call_id)
+    data = single.interrupt_data || %{}
+    Map.put(data, :tool_call_id, single.tool_call_id)
   end
 
   defp extract_interrupt_data(multiple) do
@@ -156,7 +157,8 @@ defmodule LangChain.Chains.LLMChain.Mode.Steps do
       type: :multiple_interrupts,
       interrupts:
         Enum.map(multiple, fn result ->
-          Map.merge(result.interrupt_data, %{tool_call_id: result.tool_call_id})
+          data = result.interrupt_data || %{}
+          Map.merge(data, %{tool_call_id: result.tool_call_id})
         end)
     }
   end

--- a/test/chains/llm_chain/mode/steps_test.exs
+++ b/test/chains/llm_chain/mode/steps_test.exs
@@ -378,7 +378,9 @@ defmodule LangChain.Chains.LLMChain.Mode.StepsTest do
       assert returned_data == %{tool_call_id: "call_1"}
     end
 
-    test "does not crash when multiple interrupted results have nil interrupt_data", %{chain: chain} do
+    test "does not crash when multiple interrupted results have nil interrupt_data", %{
+      chain: chain
+    } do
       result1 =
         ToolResult.new!(%{
           tool_call_id: "call_1",

--- a/test/chains/llm_chain/mode/steps_test.exs
+++ b/test/chains/llm_chain/mode/steps_test.exs
@@ -355,6 +355,60 @@ defmodule LangChain.Chains.LLMChain.Mode.StepsTest do
       pause = {:pause, chain}
       assert ^pause = Steps.check_tool_interrupts(pause, [])
     end
+
+    test "does not crash when single interrupted result has nil interrupt_data", %{chain: chain} do
+      # Simulates a ToolResult restored from persistence: `interrupt_data` is a
+      # virtual field, so it always comes back as nil. Without the guard,
+      # extract_interrupt_data/1 would raise BadMapError on Map.put(nil, ...).
+      tool_result =
+        ToolResult.new!(%{
+          tool_call_id: "call_1",
+          name: "ask_user",
+          content: "Waiting for user response...",
+          is_interrupt: true,
+          interrupt_data: nil
+        })
+
+      tool_message = Message.new_tool_result!(%{content: nil, tool_results: [tool_result]})
+      chain = LLMChain.add_message(chain, tool_message)
+
+      assert {:interrupt, ^chain, returned_data} =
+               Steps.check_tool_interrupts({:continue, chain}, [])
+
+      assert returned_data == %{tool_call_id: "call_1"}
+    end
+
+    test "does not crash when multiple interrupted results have nil interrupt_data", %{chain: chain} do
+      result1 =
+        ToolResult.new!(%{
+          tool_call_id: "call_1",
+          name: "ask_user",
+          content: "Interrupted",
+          is_interrupt: true,
+          interrupt_data: nil
+        })
+
+      result2 =
+        ToolResult.new!(%{
+          tool_call_id: "call_2",
+          name: "ask_user",
+          content: "Interrupted",
+          is_interrupt: true,
+          interrupt_data: nil
+        })
+
+      tool_message =
+        Message.new_tool_result!(%{content: nil, tool_results: [result1, result2]})
+
+      chain = LLMChain.add_message(chain, tool_message)
+
+      assert {:interrupt, ^chain, data} =
+               Steps.check_tool_interrupts({:continue, chain}, [])
+
+      assert data.type == :multiple_interrupts
+      assert Enum.at(data.interrupts, 0) == %{tool_call_id: "call_1"}
+      assert Enum.at(data.interrupts, 1) == %{tool_call_id: "call_2"}
+    end
   end
 
   describe "end-to-end pipeline" do


### PR DESCRIPTION
## Problem

`ToolResult.interrupt_data` is a virtual Ecto field, so it is not persisted. When an agent's state is restored from storage and the chain re-evaluates an interrupted tool result, `interrupt_data` comes back as `nil`. `Steps.extract_interrupt_data/1` then calls `Map.put(nil, ...)` (or `Map.merge(nil, ...)` in the multiple-interrupt branch), which raises `BadMapError` and crashes the resume path.

## Solution

Coerce `interrupt_data` to an empty map before merging the `tool_call_id` in. The fix is applied in both branches of `extract_interrupt_data/1` — the single-result branch and the multi-result branch — since either can be hit when resuming from persisted state.

## Changes

- [lib/chains/llm_chain/mode/steps.ex](lib/chains/llm_chain/mode/steps.ex) — Guard `interrupt_data` with `|| %{}` in both `extract_interrupt_data/1` clauses so a nil value (typical after restoring from persistence) no longer raises `BadMapError`.
- [test/chains/llm_chain/mode/steps_test.exs](test/chains/llm_chain/mode/steps_test.exs) — Added two regression tests covering the single-interrupt and multiple-interrupt paths when `interrupt_data` is `nil`, asserting the chain pauses cleanly and the returned data still carries the `tool_call_id`(s).

## Testing

Added focused unit tests that reproduce the original `BadMapError` (without the fix they crash, with the fix they assert the expected `{:interrupt, chain, data}` shape). Run with:

```
mix test test/chains/llm_chain/mode/steps_test.exs
```