### PR TITLE
add a missing typespec return

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -589,6 +589,7 @@ defmodule LangChain.Chains.LLMChain do
           {:ok, t()}
           | {:ok, t(), term()}
           | {:pause, t()}
+          | {:interrupt, t(), term()}
           | {:error, t(), LangChainError.t()}
   def run(chain, opts \\ [])
 


### PR DESCRIPTION
LLMChain.run was missing the `{:interrupt, t(), term()}` possible return value in the typespec.