### PR TITLE
Make sure the tool name is always provided to ToolResult

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1480,7 +1480,12 @@ defmodule LangChain.Chains.LLMChain do
           # Fire failed callback for invalid tools
           Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [chain, call, text])
 
-          ToolResult.new!(%{tool_call_id: call.call_id, content: text, is_error: true})
+          ToolResult.new!(%{
+            tool_call_id: call.call_id,
+            name: call.name,
+            content: text,
+            is_error: true
+          })
         end)
 
       combined_results = async_tool_results ++ sync_tool_results ++ invalid_calls
@@ -1837,6 +1842,7 @@ defmodule LangChain.Chains.LLMChain do
 
           ToolResult.new!(%{
             tool_call_id: call.call_id,
+            name: function.name,
             content: "ERROR executing tool: #{inspect(err)}",
             is_error: true
           })

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -3445,6 +3445,46 @@ defmodule LangChain.Chains.LLMChainTest do
              ]
 
       assert result.is_error == true
+      assert result.name == "go_time"
+    end
+
+    test "outer rescue in execute_tool_call/2 produces a ToolResult tagged with the function name" do
+      # Function.execute/3 has its own inner rescue, so the outer rescue in
+      # execute_tool_call/2 only fires if Function.execute/3 itself raises.
+      # Stub it to raise so we exercise that defensive branch and verify the
+      # produced ToolResult carries the function's name
+      tool =
+        Function.new!(%{
+          name: "go_time",
+          description: "Tool that we'll cause to raise outside its inner rescue.",
+          function: fn _args, _context -> :unreachable end
+        })
+
+      Mimic.expect(Function, :execute, fn _function, _args, _context ->
+        raise RuntimeError, "boom outside inner rescue"
+      end)
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatOpenAI.new!(%{stream: false}),
+          custom_context: %{count: 1}
+        })
+        |> LLMChain.add_tools(tool)
+        |> LLMChain.add_message(Message.new_system!())
+        |> LLMChain.add_message(Message.new_user!("It's go time!"))
+        |> LLMChain.add_message(new_function_call!("call_fake123", "go_time", "{}"))
+
+      updated_chain = LLMChain.execute_tool_calls(chain)
+
+      assert updated_chain.last_message.role == :tool
+      [%ToolResult{} = result] = updated_chain.last_message.tool_results
+      assert result.tool_call_id == "call_fake123"
+      assert result.name == "go_time"
+      assert result.is_error == true
+
+      assert [%ContentPart{type: :text, content: text}] = result.content
+      assert text =~ "ERROR executing tool:"
+      assert text =~ "boom outside inner rescue"
     end
 
     test "returns error tool result when tool_call is a hallucination" do
@@ -3469,6 +3509,8 @@ defmodule LangChain.Chains.LLMChainTest do
       assert result.content == [ContentPart.text!("Tool call made to greet but tool not found")]
       # tool response is linked to original call
       assert result.tool_call_id == "call_fake123"
+      # name is preserved from the original tool call
+      assert result.name == "greet"
       assert result.is_error == true
     end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -43,6 +43,7 @@ Mimic.copy(LangChain.ChatModels.ChatVertexAI)
 Mimic.copy(LangChain.ChatModels.ChatGoogleAI)
 Mimic.copy(LangChain.ChatModels.ChatGrok)
 Mimic.copy(LangChain.WebSocket)
+Mimic.copy(LangChain.Function)
 
 if Code.ensure_loaded?(ReqLLM) do
   Mimic.copy(ReqLLM)


### PR DESCRIPTION
Sometimes I was getting the following error with Gemini models

```elixir
%LangChain.LangChainError{
  type: "invalid_argument", 
  message: "* GenerateContentRequest.contents[2].parts[0].function_response.name: Name cannot be empty.\n", 
  original: %{
    "error" => %{
      "code" => 400, 
       "message" => "*GenerateContentRequest.contents[2].parts[0].function_response.name: Name cannot be empty.\n",
       "status" => "INVALID_ARGUMENT"
    }
  }
}
```

I found a couple of places where `name` was not provided to `ToolResult`.

This PR aims to fix that.