### PR TITLE
ChatOpenAIResponses: Fix streaming parser for SSE event boundary splitting

### DIFF
--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -1222,7 +1222,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
   # Unlike the Chat Completions API, we do not get a [DONE] token at the end of the stream.
 
   @spec decode_stream({String.t(), String.t()}) :: {[map()], String.t()}
-  def decode_stream({raw_data, buffer}, done \\ []) do
+  def decode_stream({raw_data, buffer}) do
     combined = buffer <> raw_data
 
     segments = String.split(combined, "\n\n")
@@ -1251,7 +1251,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
         end
       end)
 
-    {done ++ parsed, maybe_incomplete}
+    {parsed, maybe_incomplete}
   end
 
   # Parse a new message response

--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -1221,55 +1221,37 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
 
   # Unlike the Chat Completions API, we do not get a [DONE] token at the end of the stream.
 
-  @spec decode_stream({String.t(), String.t()}, list()) ::
-          {[%{String.t() => any()}], String.t()}
+  @spec decode_stream({String.t(), String.t()}) :: {[map()], String.t()}
   def decode_stream({raw_data, buffer}, done \\ []) do
-    raw_data
-    |> String.split(~r/event: /)
-    |> Enum.map(fn
-      <<"event: ", rest::binary>> -> rest
-      other -> other
-    end)
-    |> Enum.flat_map(fn chunk ->
-      case String.split(chunk, ~r/\ndata: /, parts: 2) do
-        [_event, json] -> [json]
-        [json_only] -> [json_only]
-        _ -> []
-      end
-    end)
-    |> Enum.reduce({done, buffer}, fn str, {done, incomplete} = acc ->
-      str
-      |> String.trim()
-      |> case do
-        "" ->
-          acc
+    combined = buffer <> raw_data
 
-        json ->
-          parse_combined_data(incomplete, json, done)
-      end
-    end)
-  end
+    segments = String.split(combined, "\n\n")
 
-  defp parse_combined_data("", json, done) do
-    json
-    |> Jason.decode()
-    |> case do
-      {:ok, parsed} ->
-        {done ++ [parsed], ""}
+    {complete_segments, [maybe_incomplete]} = Enum.split(segments, -1)
 
-      {:error, _reason} ->
-        {done, json}
-    end
-  end
+    parsed =
+      complete_segments
+      |> Enum.flat_map(fn segment ->
+        segment
+        |> String.split("\n")
+        |> Enum.find_value(fn
+          "data: " <> json -> json
+          "data:" <> json -> String.trim_leading(json)
+          _ -> nil
+        end)
+        |> case do
+          nil ->
+            []
 
-  defp parse_combined_data(incomplete, json, done) do
-    # combine with any previous incomplete data
-    starting_json = incomplete <> json
+          json ->
+            case Jason.decode(json) do
+              {:ok, parsed} -> [parsed]
+              {:error, _} -> []
+            end
+        end
+      end)
 
-    # recursively call decode_stream so that the combined message data is split on "data: " again.
-    # the combined data may need re-splitting if the last message ended in the middle of the "data: " key.
-    # i.e. incomplete ends with "dat" and the new message starts with "a: {".
-    decode_stream({starting_json, ""}, done)
+    {done ++ parsed, maybe_incomplete}
   end
 
   # Parse a new message response

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -1564,6 +1564,43 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       assert parsed == %{"delta" => "test"}
       assert buffer2 == ""
     end
+
+    test "handles event line and data line split across chunks" do
+      chunk1 = "event: response.output_text.done\n"
+      chunk2 = "data: {\"type\":\"response.output_text.done\",\"text\":\"Hello\"}\n\n"
+
+      {[], buffer1} = ChatOpenAIResponses.decode_stream({chunk1, ""})
+
+      {[parsed], buffer2} = ChatOpenAIResponses.decode_stream({chunk2, buffer1})
+      assert parsed["type"] == "response.output_text.done"
+      assert parsed["text"] == "Hello"
+      assert buffer2 == ""
+    end
+
+    test "handles multiple complete events followed by more events" do
+      chunk1 =
+        "event: response.created\ndata: {\"type\":\"response.created\"}\n\n" <>
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\"}\n\n"
+
+      chunk2 =
+        "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"text\":\"Hi!\"}\n\n"
+
+      {parsed1, buffer1} = ChatOpenAIResponses.decode_stream({chunk1, ""})
+      assert length(parsed1) == 2
+      assert buffer1 == ""
+
+      {[parsed2], buffer2} = ChatOpenAIResponses.decode_stream({chunk2, buffer1})
+      assert parsed2["text"] == "Hi!"
+      assert buffer2 == ""
+    end
+
+    test "handles data line without space after colon" do
+      raw = "event: response.output_text.delta\ndata:{\"delta\":\"Hi\"}\n\n"
+
+      {[parsed], buffer} = ChatOpenAIResponses.decode_stream({raw, ""})
+      assert parsed == %{"delta" => "Hi"}
+      assert buffer == ""
+    end
   end
 
   describe "serialize and restore" do


### PR DESCRIPTION
Streaming responses from OpenAI's Responses API started failing — typically only the first delta arrived before all subsequent events stopped parsing, no further callbacks fired, and chains hung indefinitely. Non-streaming mode was unaffected.

Root cause: decode_stream/2 used regex splitting on "event: " which assumed event and data lines always arrived in the same TCP chunk. A change in OpenAI's TCP chunking behavior broke this assumption, causing the event name to become an invalid JSON fragment in the buffer that cascaded to corrupt all subsequent event parsing.

Rewrote to split on "\n\n" (the actual SSE event boundary), then extract the "data:" line from each complete event block. This handles all chunking patterns: split events, multiple events per chunk, and incomplete JSON across chunks.