### PR TITLE
LLMChain: Improve error handling for unexpected response formats in do_run/1

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -946,6 +946,11 @@ defmodule LangChain.Chains.LLMChain do
                "This can happen with thinking/reasoning models during streaming."
          )}
 
+      {:ok, [[error: %LangChainError{} = reason] | _]} ->
+        if chain.verbose, do: IO.inspect(reason, label: "ERROR")
+        Logger.error("Error during chat call. Reason: #{inspect(reason)}")
+        {:error, chain, reason}
+
       {:ok, unexpected} ->
         Logger.warning("Unexpected LLM response format: #{inspect(unexpected)}")
 
@@ -953,6 +958,15 @@ defmodule LangChain.Chains.LLMChain do
          LangChainError.exception(
            type: "unexpected_response",
            message: "Unexpected response format from LLM: #{inspect(unexpected)}"
+         )}
+
+      {:error, reason} ->
+        Logger.error("Error during chat call. Reason: #{inspect(reason)}")
+
+        {:error, chain,
+         LangChainError.exception(
+           type: "unknown_error",
+           message: "LLM error: #{inspect(reason)}"
          )}
     end
   end

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -2552,6 +2552,30 @@ defmodule LangChain.Chains.LLMChainTest do
       assert error.type == "unexpected_response"
     end
 
+    test "handles overloaded_error wrapped in :ok tuple", %{chain: chain} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok,
+         [[error: LangChainError.exception(type: "overloaded_error", message: "Overloaded")]]}
+      end)
+
+      chain = LLMChain.add_message(chain, Message.new_user!("Hi"))
+
+      assert {:error, _chain, %LangChainError{} = reason} = LLMChain.run(chain)
+      assert reason.type == "overloaded_error"
+      assert reason.message == "Overloaded"
+    end
+
+    test "handles non-standard error shapes gracefully", %{chain: chain} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:error, %{status: 500, body: "Internal Server Error"}}
+      end)
+
+      chain = LLMChain.add_message(chain, Message.new_user!("Hi"))
+
+      assert {:error, _chain, %LangChainError{} = reason} = LLMChain.run(chain)
+      assert reason.type == "unknown_error"
+    end
+
     test "does not loop infinitely when streaming tool call has malformed JSON (issue #443)" do
       # When an LLM returns truncated JSON in tool_call.arguments during streaming,
       # the chain should return an error rather than silently swallowing the failure.


### PR DESCRIPTION
Added catch-all clauses in do_run/1 to handle edge cases that previously caused crashes or confusing errors:

- {:ok, [[error: %LangChainError{}] | _]} — API errors wrapped in an :ok tuple (e.g., Anthropic overloaded_error during streaming)
- {:error, reason} — non-string, non-LangChainError error reasons

Each case now returns a structured {:error, chain, reason} tuple with an appropriate error type and message.