### PR TITLE
ToolCall: Fix crash when merging binary arguments into already-decoded map

### DIFF
--- a/lib/message/tool_call.ex
+++ b/lib/message/tool_call.ex
@@ -239,11 +239,25 @@ defmodule LangChain.Message.ToolCall do
     %ToolCall{primary | arguments: new_arguments}
   end
 
-  defp append_arguments(%ToolCall{} = primary, %ToolCall{
+  defp append_arguments(%ToolCall{arguments: existing} = primary, %ToolCall{
          arguments: new_arguments
        })
-       when is_binary(new_arguments) do
-    %ToolCall{primary | arguments: (primary.arguments || "") <> new_arguments}
+       when is_binary(new_arguments) and (is_binary(existing) or is_nil(existing)) do
+    %ToolCall{primary | arguments: (existing || "") <> new_arguments}
+  end
+
+  # Once a complete delta with map arguments has been merged (via the clause
+  # above), the primary's arguments are a decoded map. Some providers then send
+  # trailing deltas that still carry binary JSON fragments for the same tool
+  # call. Appending a binary to a map would crash with an ArgumentError on <>.
+  # The complete arguments are already present, so the fragment is safely
+  # discarded — there is no meaningful way to merge a partial JSON string into
+  # an already-decoded map.
+  defp append_arguments(%ToolCall{arguments: existing} = primary, %ToolCall{
+         arguments: new_arguments
+       })
+       when is_map(existing) and is_binary(new_arguments) do
+    primary
   end
 
   defp append_arguments(%ToolCall{} = primary, %ToolCall{} = _delta_part) do

--- a/test/message/tool_call_test.exs
+++ b/test/message/tool_call_test.exs
@@ -476,5 +476,27 @@ defmodule LangChain.Message.ToolCallTest do
 
       assert result.arguments == "{\"code\": \"def my_function(x):\n    return x + 1\"}"
     end
+
+    test "handles binary arguments delta when primary arguments is already a map" do
+      primary = %ToolCall{
+        status: :complete,
+        call_id: "call_123",
+        name: "my_tool",
+        arguments: %{"key" => "value"},
+        index: 0
+      }
+
+      delta = %ToolCall{
+        status: :incomplete,
+        call_id: "call_123",
+        name: "my_tool",
+        arguments: "{\"key\":",
+        index: 0
+      }
+
+      result = ToolCall.merge(primary, delta)
+      assert result.arguments == %{"key" => "value"}
+      assert result.status == :complete
+    end
   end
 end


### PR DESCRIPTION
During streaming, merge/2 calls append_arguments before update_status. When a delta arrives with status: :complete and a decoded map for arguments, append_arguments replaces the primary's binary arguments with the map. update_status then marks the primary as :complete. If the provider sends a trailing delta with a binary JSON fragment for the same tool call, append_arguments tried to concatenate the binary onto the map via <>, which crashes with an ArgumentError.

We observed this in production — some providers send overlapping or trailing deltas after the tool call is already complete. Since the arguments are already fully decoded, there is no meaningful way to merge a partial JSON string into the map. The fragment is safely discarded.

Added a guard clause that detects map arguments with an incoming binary and returns the primary unchanged, preventing the crash.