### PR TITLE
Add MessageDelta streaming tool-call status helpers

### DIFF
--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -531,4 +531,188 @@ defmodule LangChain.MessageDelta do
   def migrate_to_content_parts(%MessageDelta{} = delta) do
     delta
   end
+
+  @doc """
+  Insert a `ToolCall` into the delta's `tool_calls` list, or merge its
+  non-nil fields onto an existing `ToolCall` with the same `call_id`.
+
+  Intended for streaming pipelines that learn about a tool call across
+  several events: the first event creates the call, later events fill in
+  fields like `display_text` or update `metadata`.
+
+  Merge rules when a `ToolCall` with the same `call_id` already exists:
+
+  - Non-nil scalar fields on the incoming call overwrite the existing value
+    (`name`, `arguments`, `display_text`).
+  - `status` is only promoted forward — an incoming `:complete` overwrites
+    an existing `:incomplete`, but never the other way around.
+  - `metadata` is shallow-merged, with incoming keys winning per-key.
+
+  A call with `call_id: nil` is ignored and the delta is returned unchanged
+  (there is no key to upsert against).
+
+  ## Examples
+
+      iex> alias LangChain.Message.ToolCall
+      iex> delta = %LangChain.MessageDelta{role: :assistant, tool_calls: []}
+      iex> tc = %ToolCall{call_id: "abc", name: "search"}
+      iex> updated = LangChain.MessageDelta.upsert_tool_call(delta, tc)
+      iex> updated.tool_calls
+      [%ToolCall{call_id: "abc", name: "search"}]
+
+  """
+  @spec upsert_tool_call(t(), ToolCall.t()) :: t()
+  def upsert_tool_call(%MessageDelta{} = delta, %ToolCall{call_id: nil}), do: delta
+
+  def upsert_tool_call(%MessageDelta{tool_calls: tool_calls} = delta, %ToolCall{} = new_call) do
+    calls = tool_calls || []
+
+    updated_calls =
+      case Enum.find_index(calls, &(&1.call_id == new_call.call_id)) do
+        nil -> calls ++ [new_call]
+        pos -> List.update_at(calls, pos, &merge_tool_call_fields(&1, new_call))
+      end
+
+    %MessageDelta{delta | tool_calls: updated_calls}
+  end
+
+  @doc """
+  Find the `ToolCall` with the matching `call_id` and update its
+  `"execution_status"` metadata. Delegates to
+  `LangChain.Message.ToolCall.set_execution_status/2`.
+
+  Intended for callers like Phoenix LiveView and Sagents that track the
+  lifecycle of a streaming tool call (identified → executing →
+  completed/failed) and need to drive the UI as the agent progresses.
+
+  Returns the delta unchanged if no tool call matches the given `call_id`.
+
+  ## Examples
+
+      iex> alias LangChain.Message.ToolCall
+      iex> delta = %LangChain.MessageDelta{
+      ...>   role: :assistant,
+      ...>   tool_calls: [%ToolCall{call_id: "abc", name: "search"}]
+      ...> }
+      iex> updated = LangChain.MessageDelta.set_tool_execution_status(delta, "abc", "executing")
+      iex> hd(updated.tool_calls).metadata
+      %{"execution_status" => "executing"}
+
+  """
+  @spec set_tool_execution_status(t(), String.t(), String.t()) :: t()
+  def set_tool_execution_status(%MessageDelta{} = delta, call_id, status)
+      when is_binary(call_id) and is_binary(status) do
+    update_matching_tool_call(delta, call_id, &ToolCall.set_execution_status(&1, status))
+  end
+
+  @doc """
+  Set the `display_text` on the `ToolCall` with the matching `call_id`.
+
+  A non-nil incoming value overwrites the existing one. As a tool executes
+  and the caller learns more, it is reasonable to refine the display from
+  `"Reading file"` to `"Reading \"outline.md\" (lines 60–100)"`, and this
+  helper supports that flow.
+
+  A `nil` incoming value is a no-op and leaves the existing `display_text`
+  alone, so the UI never goes from showing something to showing nothing.
+
+  Returns the delta unchanged if no tool call matches the given `call_id`.
+
+  ## Examples
+
+      iex> alias LangChain.Message.ToolCall
+      iex> delta = %LangChain.MessageDelta{
+      ...>   role: :assistant,
+      ...>   tool_calls: [%ToolCall{call_id: "abc", name: "search"}]
+      ...> }
+      iex> updated = LangChain.MessageDelta.set_tool_display_text(delta, "abc", "Searching")
+      iex> hd(updated.tool_calls).display_text
+      "Searching"
+
+  """
+  @spec set_tool_display_text(t(), String.t(), String.t() | nil) :: t()
+  def set_tool_display_text(%MessageDelta{} = delta, _call_id, nil), do: delta
+
+  def set_tool_display_text(%MessageDelta{} = delta, call_id, display_text)
+      when is_binary(call_id) and is_binary(display_text) do
+    update_matching_tool_call(delta, call_id, &%{&1 | display_text: display_text})
+  end
+
+  @doc """
+  Check whether every `ToolCall` in the delta has reached a terminal
+  execution status. Returns `true` only when there is at least one tool
+  call AND every call has `metadata["execution_status"]` set to
+  `"completed"` or `"failed"`.
+
+  Returns `false` for `nil` or empty `tool_calls` — there is nothing to
+  gate on yet.
+
+  Intended for UI flows that keep a streaming delta visible while any
+  tool is still mid-execution and only clear it once all tools have
+  terminated, so sibling tool calls don't lose their UI state when one
+  finishes before another.
+
+  ## Examples
+
+      iex> alias LangChain.Message.ToolCall
+      iex> done = %ToolCall{call_id: "a", metadata: %{"execution_status" => "completed"}}
+      iex> running = %ToolCall{call_id: "b", metadata: %{"execution_status" => "executing"}}
+      iex> LangChain.MessageDelta.all_tools_terminal?(%LangChain.MessageDelta{tool_calls: [done]})
+      true
+      iex> LangChain.MessageDelta.all_tools_terminal?(%LangChain.MessageDelta{tool_calls: [done, running]})
+      false
+
+  """
+  @spec all_tools_terminal?(t()) :: boolean()
+  def all_tools_terminal?(%MessageDelta{tool_calls: tool_calls})
+      when is_list(tool_calls) and tool_calls != [] do
+    Enum.all?(tool_calls, fn
+      %ToolCall{metadata: %{"execution_status" => status}}
+      when status in ["completed", "failed"] ->
+        true
+
+      _other ->
+        false
+    end)
+  end
+
+  def all_tools_terminal?(%MessageDelta{}), do: false
+
+  # Shared updater for set_tool_execution_status/3 and set_tool_display_text/3.
+  defp update_matching_tool_call(%MessageDelta{tool_calls: nil} = delta, _call_id, _fun),
+    do: delta
+
+  defp update_matching_tool_call(%MessageDelta{tool_calls: []} = delta, _call_id, _fun),
+    do: delta
+
+  defp update_matching_tool_call(%MessageDelta{tool_calls: tool_calls} = delta, call_id, fun) do
+    updated =
+      Enum.map(tool_calls, fn
+        %ToolCall{call_id: ^call_id} = tc -> fun.(tc)
+        other -> other
+      end)
+
+    %MessageDelta{delta | tool_calls: updated}
+  end
+
+  defp merge_tool_call_fields(%ToolCall{} = existing, %ToolCall{} = incoming) do
+    %ToolCall{
+      existing
+      | name: incoming.name || existing.name,
+        arguments: incoming.arguments || existing.arguments,
+        display_text: incoming.display_text || existing.display_text,
+        status: promote_status(existing.status, incoming.status),
+        metadata: merge_metadata(existing.metadata, incoming.metadata)
+    }
+  end
+
+  defp promote_status(_existing, :complete), do: :complete
+  defp promote_status(existing, _other), do: existing
+
+  defp merge_metadata(nil, nil), do: nil
+  defp merge_metadata(existing, nil), do: existing
+  defp merge_metadata(nil, incoming), do: incoming
+
+  defp merge_metadata(existing, incoming) when is_map(existing) and is_map(incoming),
+    do: Map.merge(existing, incoming)
 end

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -1819,8 +1819,14 @@ defmodule LangChain.MessageDeltaTest do
         tool_calls: [%ToolCall{call_id: "abc", display_text: "Reading file"}]
       }
 
-      assert %MessageDelta{tool_calls: [%ToolCall{display_text: "Reading outline.md (lines 60-100)"}]} =
-               MessageDelta.set_tool_display_text(delta, "abc", "Reading outline.md (lines 60-100)")
+      assert %MessageDelta{
+               tool_calls: [%ToolCall{display_text: "Reading outline.md (lines 60-100)"}]
+             } =
+               MessageDelta.set_tool_display_text(
+                 delta,
+                 "abc",
+                 "Reading outline.md (lines 60-100)"
+               )
     end
 
     test "is a no-op when display_text is nil so the UI never loses a value" do

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -1683,4 +1683,202 @@ defmodule LangChain.MessageDeltaTest do
              }
     end
   end
+
+  describe "upsert_tool_call/2" do
+    test "appends a new tool call when no matching call_id exists" do
+      delta = %MessageDelta{role: :assistant, tool_calls: []}
+      tc = %ToolCall{call_id: "abc", name: "search"}
+
+      assert %MessageDelta{tool_calls: [%ToolCall{call_id: "abc", name: "search"}]} =
+               MessageDelta.upsert_tool_call(delta, tc)
+    end
+
+    test "treats nil tool_calls list as empty" do
+      delta = %MessageDelta{role: :assistant, tool_calls: nil}
+      tc = %ToolCall{call_id: "abc", name: "search"}
+
+      assert %MessageDelta{tool_calls: [%ToolCall{call_id: "abc"}]} =
+               MessageDelta.upsert_tool_call(delta, tc)
+    end
+
+    test "merges non-nil incoming fields onto existing call with the same call_id" do
+      existing = %ToolCall{call_id: "abc", name: "search", display_text: "Searching"}
+      delta = %MessageDelta{role: :assistant, tool_calls: [existing]}
+
+      incoming = %ToolCall{call_id: "abc", arguments: %{"q" => "elixir"}}
+
+      assert %MessageDelta{tool_calls: [merged]} = MessageDelta.upsert_tool_call(delta, incoming)
+      assert merged.call_id == "abc"
+      assert merged.name == "search"
+      assert merged.display_text == "Searching"
+      assert merged.arguments == %{"q" => "elixir"}
+    end
+
+    test "shallow-merges metadata, with incoming keys winning per-key" do
+      existing = %ToolCall{call_id: "abc", metadata: %{"a" => 1, "b" => 2}}
+      delta = %MessageDelta{role: :assistant, tool_calls: [existing]}
+      incoming = %ToolCall{call_id: "abc", metadata: %{"b" => 99, "c" => 3}}
+
+      assert %MessageDelta{tool_calls: [%ToolCall{metadata: metadata}]} =
+               MessageDelta.upsert_tool_call(delta, incoming)
+
+      assert metadata == %{"a" => 1, "b" => 99, "c" => 3}
+    end
+
+    test "promotes status from :incomplete to :complete but never the other way" do
+      complete = %ToolCall{call_id: "abc", status: :complete}
+      delta = %MessageDelta{role: :assistant, tool_calls: [complete]}
+
+      assert %MessageDelta{tool_calls: [%ToolCall{status: :complete}]} =
+               MessageDelta.upsert_tool_call(delta, %ToolCall{call_id: "abc", status: :incomplete})
+
+      incomplete = %ToolCall{call_id: "abc", status: :incomplete}
+      delta = %MessageDelta{role: :assistant, tool_calls: [incomplete]}
+
+      assert %MessageDelta{tool_calls: [%ToolCall{status: :complete}]} =
+               MessageDelta.upsert_tool_call(delta, %ToolCall{call_id: "abc", status: :complete})
+    end
+
+    test "ignores incoming calls with nil call_id" do
+      existing = %ToolCall{call_id: "abc", name: "search"}
+      delta = %MessageDelta{role: :assistant, tool_calls: [existing]}
+
+      assert ^delta = MessageDelta.upsert_tool_call(delta, %ToolCall{call_id: nil, name: "x"})
+    end
+  end
+
+  describe "set_tool_execution_status/3" do
+    test "writes execution_status metadata on the matching tool_call" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [%ToolCall{call_id: "abc", name: "search"}]
+      }
+
+      assert %MessageDelta{
+               tool_calls: [%ToolCall{metadata: %{"execution_status" => "executing"}}]
+             } =
+               MessageDelta.set_tool_execution_status(delta, "abc", "executing")
+    end
+
+    test "leaves non-matching calls untouched and merges metadata on a match" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [
+          %ToolCall{call_id: "a", metadata: %{"keep" => true}},
+          %ToolCall{call_id: "b"}
+        ]
+      }
+
+      assert %MessageDelta{tool_calls: [a, b]} =
+               MessageDelta.set_tool_execution_status(delta, "a", "completed")
+
+      assert a.metadata == %{"keep" => true, "execution_status" => "completed"}
+      assert b.metadata == nil
+    end
+
+    test "returns delta unchanged when no call_id matches" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [%ToolCall{call_id: "abc"}]
+      }
+
+      assert ^delta = MessageDelta.set_tool_execution_status(delta, "nope", "executing")
+    end
+
+    test "is a no-op for nil and empty tool_calls" do
+      assert %MessageDelta{tool_calls: nil} =
+               MessageDelta.set_tool_execution_status(
+                 %MessageDelta{role: :assistant, tool_calls: nil},
+                 "abc",
+                 "executing"
+               )
+
+      assert %MessageDelta{tool_calls: []} =
+               MessageDelta.set_tool_execution_status(
+                 %MessageDelta{role: :assistant, tool_calls: []},
+                 "abc",
+                 "executing"
+               )
+    end
+  end
+
+  describe "set_tool_display_text/3" do
+    test "sets display_text when currently nil" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [%ToolCall{call_id: "abc"}]
+      }
+
+      assert %MessageDelta{tool_calls: [%ToolCall{display_text: "Searching"}]} =
+               MessageDelta.set_tool_display_text(delta, "abc", "Searching")
+    end
+
+    test "overwrites an existing display_text so callers can refine it as more info arrives" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [%ToolCall{call_id: "abc", display_text: "Reading file"}]
+      }
+
+      assert %MessageDelta{tool_calls: [%ToolCall{display_text: "Reading outline.md (lines 60-100)"}]} =
+               MessageDelta.set_tool_display_text(delta, "abc", "Reading outline.md (lines 60-100)")
+    end
+
+    test "is a no-op when display_text is nil so the UI never loses a value" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [%ToolCall{call_id: "abc", display_text: "Reading file"}]
+      }
+
+      assert ^delta = MessageDelta.set_tool_display_text(delta, "abc", nil)
+    end
+
+    test "returns delta unchanged when no call_id matches" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [%ToolCall{call_id: "abc"}]
+      }
+
+      assert ^delta = MessageDelta.set_tool_display_text(delta, "nope", "Searching")
+    end
+  end
+
+  describe "all_tools_terminal?/1" do
+    test "returns true when every tool call has a terminal execution status" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [
+          %ToolCall{call_id: "a", metadata: %{"execution_status" => "completed"}},
+          %ToolCall{call_id: "b", metadata: %{"execution_status" => "failed"}}
+        ]
+      }
+
+      assert MessageDelta.all_tools_terminal?(delta)
+    end
+
+    test "returns false when any tool call is still in flight" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [
+          %ToolCall{call_id: "a", metadata: %{"execution_status" => "completed"}},
+          %ToolCall{call_id: "b", metadata: %{"execution_status" => "executing"}}
+        ]
+      }
+
+      refute MessageDelta.all_tools_terminal?(delta)
+    end
+
+    test "returns false when a tool call has no execution_status set" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [%ToolCall{call_id: "a"}]
+      }
+
+      refute MessageDelta.all_tools_terminal?(delta)
+    end
+
+    test "returns false for nil and empty tool_calls" do
+      refute MessageDelta.all_tools_terminal?(%MessageDelta{role: :assistant, tool_calls: nil})
+      refute MessageDelta.all_tools_terminal?(%MessageDelta{role: :assistant, tool_calls: []})
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Streaming consumers (Phoenix LiveView, Sagents) need to track the lifecycle of a tool call as it arrives in pieces across multiple `MessageDelta` events: first the call is identified, then `display_text` is filled in, then execution status moves through `executing` → `completed`/`failed`. Today every consumer reimplements the same merge-and-update logic against `delta.tool_calls`, including subtle rules like "never overwrite an existing `display_text` with `nil`" and "don't clear the in-flight UI until *every* sibling tool call has terminated." Those rules belong on the library side.

## Solution

Add four small, well-documented helpers to `LangChain.MessageDelta` that codify the merge rules:

- `upsert_tool_call/2` — append a new `ToolCall` or merge non-nil fields onto an existing one with the same `call_id`. `status` is promoted one-way (`:incomplete` → `:complete`, never back), and `metadata` is shallow-merged with incoming keys winning per-key.
- `set_tool_execution_status/3` — drive the `metadata["execution_status"]` lifecycle for a specific `call_id`, delegating to `ToolCall.set_execution_status/2`.
- `set_tool_display_text/3` — refine `display_text` as more is learned (`"Reading file"` → `"Reading \"outline.md\" (lines 60–100)"`). A `nil` incoming value is an explicit no-op so the UI never regresses from showing something to showing nothing.
- `all_tools_terminal?/1` — gate UI cleanup on every tool call reaching a terminal status. Returns `false` for `nil` or empty `tool_calls` so empty deltas don't trigger premature clears.

All helpers are additive — no existing `MessageDelta` behavior changes — and they tolerate `nil`/empty `tool_calls` so callers don't need to guard.

## Changes

- `lib/message_delta.ex` — Added `upsert_tool_call/2`, `set_tool_execution_status/3`, `set_tool_display_text/3`, `all_tools_terminal?/1`, plus private `merge_tool_call_fields/2`, `promote_status/2`, `merge_metadata/2`, and `update_matching_tool_call/3` helpers. Each public function carries a `@spec` and a doctest covering the typical case.
- `test/message_delta_test.exs` — Added four `describe` blocks (one per helper) covering: append vs. merge on `upsert_tool_call`, `nil` tool_calls handling, per-field merge precedence, one-way `:complete` status promotion, shallow metadata merge, `set_*` no-ops when no matching `call_id` is present, the `nil`-display-text no-op rule, and terminal/non-terminal cases for `all_tools_terminal?`.

## Testing

- New unit tests in [test/message_delta_test.exs](https://github.com/brainlid/langchain/blob/feat/message-delta-tool-status-helpers/test/message_delta_test.exs) cover both happy paths and the edge cases that motivated each rule (nil tool_calls, missing call_id, status downgrades, nil display_text).
- Doctests on each public function exercise the typical streaming usage shape.
- No live API tests required — these helpers are pure data transforms on `MessageDelta`.

Run locally with:

```
cd my_langchain && mix test test/message_delta_test.exs
```