### PR TITLE
Fix ChatReqLLM streaming tool-call merge for OpenAI-style chunks

### DIFF
--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -476,6 +476,54 @@ if Code.ensure_loaded?(ReqLLM) do
       {[delta], state}
     end
 
+    # OpenAI-style streaming initial tool_call chunk: metadata carries :index
+    # (and usually :id), and the name is present. When :arguments is an empty
+    # map (placeholder for "args will arrive as tool_call_args fragments"),
+    # emit an :incomplete ToolCall with :arguments left nil so subsequent
+    # string fragments can be concatenated by ToolCall.append_arguments/2 and
+    # later JSON-decoded by ToolCall.complete/1. When :arguments is already a
+    # non-empty map (single-shot delivery — no fragments will follow), emit
+    # the ToolCall as :complete. In both cases the :index is preserved so the
+    # ToolCall lands in the same MessageDelta slot the fragment chunks target.
+    defp process_stream_chunk(
+           %ReqLLM.StreamChunk{
+             type: :tool_call,
+             name: name,
+             arguments: args,
+             metadata: %{index: block_index} = meta
+           },
+           state
+         )
+         when is_binary(name) and is_integer(block_index) do
+      id = meta[:id] || "tool_#{:erlang.unique_integer([:positive])}"
+
+      base_attrs = %{
+        type: :function,
+        call_id: id,
+        name: name,
+        index: block_index
+      }
+
+      attrs =
+        if is_map(args) and map_size(args) > 0 do
+          Map.merge(base_attrs, %{status: :complete, arguments: args})
+        else
+          Map.put(base_attrs, :status, :incomplete)
+        end
+
+      tool_call = ToolCall.new!(attrs)
+
+      delta =
+        MessageDelta.new!(%{
+          role: :assistant,
+          tool_calls: [tool_call],
+          status: :incomplete,
+          index: 0
+        })
+
+      {[delta], state}
+    end
+
     # Tool call arg fragment: emit incomplete ToolCall delta with the partial JSON string.
     # ToolCall.merge/2 will concatenate binary arguments strings across deltas.
     defp process_stream_chunk(

--- a/test/chat_models/chat_req_llm_test.exs
+++ b/test/chat_models/chat_req_llm_test.exs
@@ -1067,6 +1067,95 @@ if Code.ensure_loaded?(ReqLLM) do
         assert Enum.all?(deltas, &match?(%MessageDelta{}, &1))
       end
 
+      test "openai-style streaming tool call assembles a valid Message (regression)" do
+        # Reproduces the pattern emitted by ReqLLM's default OpenAI decoder
+        # (used by direct OpenAI, LiteLLM proxy, etc.):
+        #   - one :tool_call chunk with metadata: %{id, index}, name, arguments: %{}
+        #   - one or more :meta chunks with tool_call_args: %{index, fragment}
+        #   - a terminal :meta with finish_reason: :tool_calls
+        #
+        # Before the fix, the initial chunk landed at index: nil while the
+        # fragment chunks landed at index: 0, producing an orphan ToolCall
+        # without call_id/name and a "delta_conversion_failed" error from
+        # Message.new — exactly the LiteLLM-proxied OpenAI failure mode.
+        model = ChatReqLLM.new!(%{model: "openai:gpt-4o", stream: true})
+
+        chunks = [
+          %ReqLLM.StreamChunk{
+            type: :tool_call,
+            name: "ask_user",
+            arguments: %{},
+            metadata: %{id: "call_abc123", index: 0}
+          },
+          %ReqLLM.StreamChunk{
+            type: :meta,
+            metadata: %{tool_call_args: %{index: 0, fragment: "{\"question\":"}}
+          },
+          %ReqLLM.StreamChunk{
+            type: :meta,
+            metadata: %{tool_call_args: %{index: 0, fragment: "\"hi?\"}"}}
+          },
+          %ReqLLM.StreamChunk{
+            type: :meta,
+            metadata: %{finish_reason: :tool_calls, terminal?: true}
+          }
+        ]
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response(chunks)}
+        end)
+
+        assert {:ok, chain} =
+                 %{llm: model}
+                 |> LLMChain.new!()
+                 |> LLMChain.add_message(Message.new_user!("ask"))
+                 |> LLMChain.run()
+
+        last_msg = List.last(chain.messages)
+        assert %Message{role: :assistant, status: :complete} = last_msg
+        assert [%ToolCall{} = tc] = last_msg.tool_calls
+        assert tc.call_id == "call_abc123"
+        assert tc.name == "ask_user"
+        assert tc.status == :complete
+        assert tc.arguments == %{"question" => "hi?"}
+      end
+
+      test "openai-style streaming tool call with no follow-up fragments still completes" do
+        # If args fit in the initial chunk (non-empty map), no fragment :meta
+        # chunks will follow. The ToolCall should be emitted as :complete with
+        # the arguments already populated.
+        model = ChatReqLLM.new!(%{model: "openai:gpt-4o", stream: true})
+
+        chunks = [
+          %ReqLLM.StreamChunk{
+            type: :tool_call,
+            name: "get_time",
+            arguments: %{"zone" => "UTC"},
+            metadata: %{id: "call_xyz", index: 0}
+          },
+          %ReqLLM.StreamChunk{
+            type: :meta,
+            metadata: %{finish_reason: :tool_calls, terminal?: true}
+          }
+        ]
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response(chunks)}
+        end)
+
+        assert {:ok, chain} =
+                 %{llm: model}
+                 |> LLMChain.new!()
+                 |> LLMChain.add_message(Message.new_user!("time?"))
+                 |> LLMChain.run()
+
+        last_msg = List.last(chain.messages)
+        assert [%ToolCall{} = tc] = last_msg.tool_calls
+        assert tc.call_id == "call_xyz"
+        assert tc.name == "get_time"
+        assert tc.arguments == %{"zone" => "UTC"}
+      end
+
       test "LLMChain runs successfully with stream:true" do
         model = ChatReqLLM.new!(%{model: @live_model, stream: true})
 


### PR DESCRIPTION
## Problem

Streaming tool calls through `ChatReqLLM` against OpenAI-compatible backends (direct OpenAI, LiteLLM proxy, and similar) fail at finalize with:

```
delta_conversion_failed: "Error applying delta message: \"tool_calls: call_id: can't be blank; name: can't be blank\""
```

The error surfaces only when the model invokes a tool while streaming. Non-streaming calls and Anthropic streaming were unaffected.

The root cause is an index mismatch during `MessageDelta` merging. ReqLLM's default OpenAI decoder emits two kinds of chunks for a single tool call:

1. An initial `%StreamChunk{type: :tool_call, name: ..., arguments: %{}, metadata: %{id: ..., index: ...}}` chunk.
2. A stream of `%StreamChunk{type: :meta, metadata: %{tool_call_args: %{index: ..., fragment: "..."}}}` argument-fragment chunks.

`ChatReqLLM.translate_stream_chunk/1` was reading `id` from the initial chunk's metadata but dropping `index`, and was emitting the call as `:complete` with `arguments: %{}`. Fragment chunks then arrived with `index: 0` and no `call_id`/`name`. Because `MessageDelta.merge_tool_calls/2` keys lookups by `index`, the fragments did not merge into the initial tool call — they landed in a separate slot. At finalize, `Message.new` ran `ToolCall.complete/1` on every entry, and the orphan fragment ToolCall failed `validate_required([:call_id, :name])`.

## Solution

Added a new `process_stream_chunk/2` clause that handles OpenAI-shaped initial `:tool_call` chunks (those whose metadata carries `:index`). The clause:

- Carries `:index` through onto the `ToolCall`, so subsequent fragment chunks merge into the same slot.
- When `arguments` is an empty map (placeholder; fragments will follow), emits the `ToolCall` as `:incomplete` with `arguments: nil`. `ToolCall.append_arguments/2` then string-concatenates the incoming JSON fragments, and `ToolCall.complete/1` JSON-decodes the accumulated string at finalize.
- When `arguments` is already a non-empty map (single-shot delivery — no fragments will follow), emits the `ToolCall` as `:complete` with the args inline.

The existing Anthropic `%{start: true}` clause still matches first, so Anthropic streaming is unchanged. Chunks without `:index` in metadata still fall through to the original `translate_stream_chunk/1`, preserving the previous single-shot behaviour for providers that deliver the whole call in one chunk.

## Changes

- [lib/chat_models/chat_req_llm.ex](lib/chat_models/chat_req_llm.ex) — Added OpenAI-style `:tool_call` chunk clause to `process_stream_chunk/2`; preserves `:index` from metadata and chooses `:incomplete`/`:complete` based on whether args fragments are expected to follow.
- [test/chat_models/chat_req_llm_test.exs](test/chat_models/chat_req_llm_test.exs) — Two regression tests:
  - Fragmented case: initial chunk with empty args + `index` + `id`, followed by two `tool_call_args` fragments, then a terminal `:meta`. Asserts the assembled `Message` has a single `ToolCall` with the correct `call_id`, `name`, and JSON-decoded `arguments`.
  - Single-shot case: initial chunk already carrying non-empty args. Asserts the assembled `ToolCall` is `:complete` with the inline args.

## Testing

- `mix test test/chat_models/chat_req_llm_test.exs` — 85 tests, 0 failures (7 live-tagged tests excluded).
- `mix test` — full suite passes: 31 doctests, 1767 tests, 0 failures.
- No live API tests were added for this path because the failure mode requires an OpenAI-compatible streaming backend (and was originally observed through a LiteLLM proxy that the test harness is not wired up to talk to). The regression tests exercise the exact `StreamChunk` sequence ReqLLM emits, which is what `ChatReqLLM` actually consumes.