### PR TITLE
Fix max_runs check discarding successful tool call in run_until_tool_used

### DIFF
--- a/lib/chains/llm_chain/modes/until_tool_used.ex
+++ b/lib/chains/llm_chain/modes/until_tool_used.ex
@@ -53,11 +53,18 @@ defmodule LangChain.Chains.LLMChain.Modes.UntilToolUsed do
   end
 
   defp do_run(chain, opts) do
+    # Order matters: `check_max_runs` must come AFTER `check_until_tool`,
+    # otherwise the very LLM call that successfully invokes the target
+    # tool can have its result discarded — `call_llm` increments the run
+    # counter, the check fires and short-circuits the pipeline before
+    # `execute_tools`/`check_until_tool` get to see the result. With this
+    # order, a successful run terminates first; `check_max_runs` is a
+    # no-op on terminal pipeline states.
     {:continue, chain}
     |> call_llm()
-    |> check_max_runs(opts)
     |> execute_tools()
     |> check_until_tool(opts)
+    |> check_max_runs(opts)
     |> continue_or_done(&do_run/2, opts)
   end
 end

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -3201,6 +3201,33 @@ defmodule LangChain.Chains.LLMChainTest do
       assert error.message == "Exceeded maximum number of runs (3/3)"
     end
 
+    # Regression: a successful tool call on the LLM call that hits the
+    # max_runs ceiling must terminate with success, not be discarded.
+    # Previously `check_max_runs` ran before `check_until_tool` and a
+    # max_runs=1 + first-call success path errored out instead of
+    # returning the tool result.
+    test "succeeds when the target tool is called on the same LLM call that hits max_runs",
+         %{greet: greet, sync: do_thing} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok,
+         new_function_calls!([
+           ToolCall.new!(%{call_id: "call_doThing", name: "do_thing", arguments: nil})
+         ])}
+      end)
+
+      {:ok, updated_chain, tool_result} =
+        %{llm: ChatOpenAI.new!(%{stream: false}), verbose: false}
+        |> LLMChain.new!()
+        |> LLMChain.add_tools([greet, do_thing])
+        |> LLMChain.add_message(Message.new_system!())
+        |> LLMChain.add_message(Message.new_user!("Call do_thing right away."))
+        |> LLMChain.run_until_tool_used("do_thing", max_runs: 1)
+
+      assert updated_chain.last_message.role == :tool
+      assert %ToolResult{is_error: false} = tool_result
+      assert tool_result.name == "do_thing"
+    end
+
     test "returns error when tool_name does not exist in available tools", %{greet: greet} do
       {:error, _updated_chain, error} =
         %{llm: ChatOpenAI.new!(%{stream: false}), verbose: false}


### PR DESCRIPTION
## Problem

`LLMChain.run_until_tool_used/3` with `max_runs: 1` incorrectly errored with `Exceeded maximum number of runs (1/1)` even when the very first LLM call successfully invoked the target tool. The successful tool result was discarded in favor of the max-runs error.

The bug also affects any `max_runs: N` configuration where the target tool happens to be called on the Nth attempt — the success is masked by the ceiling check.

## Solution

The pipeline in `LangChain.Chains.LLMChain.Modes.UntilToolUsed.do_run/2` runs a series of guarded steps where each step either continues with `{:continue, chain}` or short-circuits with a terminal state. The original order placed `check_max_runs` immediately after `call_llm`, so the run counter was incremented and the ceiling check fired *before* `execute_tools` and `check_until_tool` could observe that the target tool had been called.

Reordering moves `check_max_runs` to run after `check_until_tool`. Successful termination is detected first; `check_max_runs` becomes a no-op on already-terminal pipeline states. A comment was added at the call site explaining the ordering constraint so it isn't innocently shuffled in the future.

## Changes

- `lib/chains/llm_chain/modes/until_tool_used.ex` — Move `check_max_runs` to run after `execute_tools` and `check_until_tool` in `do_run/2`; add explanatory comment for the ordering constraint.
- `test/chains/llm_chain_test.exs` — Add regression test covering `max_runs: 1` with a first-call successful tool invocation; asserts the chain returns the `ToolResult` rather than a max-runs error.

## Testing

- Added a focused regression test in `LangChain.Chains.LLMChainTest` that mocks `ChatOpenAI.call/3` to return the target tool call on the first attempt with `max_runs: 1`, and asserts both that `updated_chain.last_message.role == :tool` and that the returned `ToolResult` is non-error.
- Existing `run_until_tool_used` tests (including the pre-existing max-runs exceeded path) continue to cover the failure case where the target tool is never called.