### PR TITLE
Add :origin option to FileGoogle.request_upload_url

### DIFF
--- a/lib/file_uploaders/file_google.ex
+++ b/lib/file_uploaders/file_google.ex
@@ -25,6 +25,20 @@ defmodule LangChain.FileUploader.FileGoogle do
   available for use with `ContentPart.file_url!/2`.
 
   Note: Files uploaded to Gemini expire after 48 hours.
+
+  ## Client-side direct upload
+
+  Step 2 can be performed by a browser or mobile client instead of your server.
+  Call `request_upload_url/5` with the client's origin and forward the returned
+  URL to the client — the client then PUTs the file bytes to that URL directly.
+
+      {:ok, upload_url} =
+        FileGoogle.request_upload_url(uploader, "doc.pdf", "application/pdf", 12_345,
+          origin: "https://app.example.com"
+        )
+
+  The `:origin` option is required for browser uploads because Google uses it
+  to set `Access-Control-Allow-Origin` on the step 2 response.
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -190,22 +204,44 @@ defmodule LangChain.FileUploader.FileGoogle do
   The returned URL can be passed to `upload_file_bytes/4` to complete the upload, or
   forwarded directly to a client (e.g. a browser or mobile app) so it can upload
   the file bytes itself without routing them through your server.
+
+  ## Options
+
+    * `:origin` — When step 2 will be performed by a browser or mobile client,
+      pass the client's origin (scheme + host, e.g. `"https://app.example.com"`).
+      Google uses this origin to set `Access-Control-Allow-Origin` on the step 2
+      response, allowing the cross-origin upload to succeed. Omit when step 2 is
+      performed server-side.
   """
-  @spec request_upload_url(t(), String.t(), String.t(), non_neg_integer()) ::
+  @spec request_upload_url(t(), String.t(), String.t(), non_neg_integer(), keyword()) ::
           {:ok, String.t()} | {:error, LangChain.LangChainError.t()}
-  def request_upload_url(%FileGoogle{} = uploader, display_name, mime_type, byte_count) do
+  def request_upload_url(
+        %FileGoogle{} = uploader,
+        display_name,
+        mime_type,
+        byte_count,
+        opts \\ []
+      ) do
     api_key = get_api_key(uploader)
     url = "#{uploader.endpoint}#{@upload_path}?key=#{api_key}"
+
+    headers = %{
+      "x-goog-upload-protocol" => "resumable",
+      "x-goog-upload-command" => "start",
+      "x-goog-upload-header-content-length" => to_string(byte_count),
+      "x-goog-upload-header-content-type" => mime_type
+    }
+
+    headers =
+      case Keyword.get(opts, :origin) do
+        nil -> headers
+        origin when is_binary(origin) -> Map.put(headers, "origin", origin)
+      end
 
     Req.new(
       url: url,
       json: %{"file" => %{"display_name" => display_name}},
-      headers: %{
-        "x-goog-upload-protocol" => "resumable",
-        "x-goog-upload-command" => "start",
-        "x-goog-upload-header-content-length" => to_string(byte_count),
-        "x-goog-upload-header-content-type" => mime_type
-      },
+      headers: headers,
       receive_timeout: uploader.receive_timeout
     )
     |> Req.merge(uploader.req_opts)

--- a/test/file_uploaders/file_google_test.exs
+++ b/test/file_uploaders/file_google_test.exs
@@ -188,6 +188,46 @@ defmodule LangChain.FileUploader.FileGoogleTest do
     end
   end
 
+  describe "request_upload_url/5" do
+    test "injects origin header when :origin option is given" do
+      expect(Req, :post, fn req ->
+        assert req.headers["origin"] == ["https://app.example.com"]
+
+        {:ok,
+         %Req.Response{
+           status: 200,
+           headers: %{"x-goog-upload-url" => ["https://upload.example.com/upload?id=cors"]},
+           body: %{}
+         }}
+      end)
+
+      uploader = FileGoogle.new!(%{api_key: "AIza-test"})
+
+      assert {:ok, "https://upload.example.com/upload?id=cors"} =
+               FileGoogle.request_upload_url(uploader, "doc.pdf", "application/pdf", 123,
+                 origin: "https://app.example.com"
+               )
+    end
+
+    test "omits origin header when :origin option is absent" do
+      expect(Req, :post, fn req ->
+        refute Map.has_key?(req.headers, "origin")
+
+        {:ok,
+         %Req.Response{
+           status: 200,
+           headers: %{"x-goog-upload-url" => ["https://upload.example.com/upload?id=no-cors"]},
+           body: %{}
+         }}
+      end)
+
+      uploader = FileGoogle.new!(%{api_key: "AIza-test"})
+
+      assert {:ok, "https://upload.example.com/upload?id=no-cors"} =
+               FileGoogle.request_upload_url(uploader, "doc.pdf", "application/pdf", 123)
+    end
+  end
+
   describe "get/2" do
     test "returns FileResult on success with resource name" do
       expect(Req, :get, fn req ->


### PR DESCRIPTION
## Problem

`FileGoogle.request_upload_url/4` initiates Google's two-step resumable upload and returns a presigned URL. It's exposed as a module function so callers can forward the URL to a browser/mobile client and let it perform step 2 directly.

When step 2 runs in a browser, CORS applies. Google sets `Access-Control-Allow-Origin` on the step 2 response based on the `Origin` header sent on step 1 — but there's no first-class way to set that from `request_upload_url/4`. Callers have to inject it through the `req_opts` escape hatch, which relies on hidden knowledge about Google's upload protocol that domain-meaningful options like `:display_name` already shield them from.

(This is Google-specific. OpenAI ([docs](https://developers.openai.com/api/reference/resources/files/methods/create)) and Anthropic ([docs](https://platform.claude.com/docs/en/build-with-claude/files)) Files APIs use a single multipart POST with no presigned-URL flow, so there's no shared shape to lift into the `FileUploader` behaviour.)

## Solution

Extend `request_upload_url/4` to `request_upload_url/5` with a trailing `opts \\ []`. When `opts[:origin]` is set, inject it as the `"origin"` header on the step 1 request.

The default `[]` keeps the existing `upload/3` call site source-compatible. Keyword opts (rather than a positional `origin`) leave room for future options. `upload_file_bytes/4` is deliberately not extended — step 2 either runs server-side (no CORS) or in a browser (which sets `Origin` automatically).
