### PR TITLE
fix(docs): correct {:cont} docstring — processing continues, not halts

### DIFF
--- a/lib/message_processors/json_processor.ex
+++ b/lib/message_processors/json_processor.ex
@@ -112,7 +112,7 @@ defmodule LangChain.MessageProcessors.JsonProcessor do
   Response values:
 
   - `{:cont, %Message{}}` - The returned message replaces the one being
-    processed and no additional processors are run.
+    processed and processing continues with subsequent processors.
   - `{:halt, %Message{}}` - Future processors are skipped. The Message is
     returned as a response to the LLM for reporting errors.
   """


### PR DESCRIPTION
## Summary

The `JsonProcessor.run/2` docstring incorrectly described the `{:cont, %Message{}}` return value as stopping further processing:

```
- `{:cont, %Message{}}` - The returned message replaces the one being
  processed and **no additional processors are run**.
```

This is the opposite of what `:cont` does. Looking at the implementation (line 131), `{:cont, ...}` continues processing through subsequent processors — it's `{:halt, ...}` that stops further processors, as the very next bullet in the docstring correctly states.

## Change

One line: corrected "no additional processors are run" → "processing continues with subsequent processors"

No code changes. Documentation only.

Fixes #215