### PR TITLE
Add Trajectory.from_messages/2 for building trajectories without a live chain

### DIFF
--- a/lib/trajectory.ex
+++ b/lib/trajectory.ex
@@ -28,6 +28,11 @@ defmodule LangChain.Trajectory do
 
       trajectory = Trajectory.from_chain(chain)
 
+      # Or build from a bare message list when no live chain is available
+      # (e.g. a persisted agent state). The llm is optional and only feeds
+      # metadata.
+      trajectory = Trajectory.from_messages(messages, llm)
+
       # Serialize for logging or golden-file comparison
       map = Trajectory.to_map(trajectory)
 
@@ -170,16 +175,45 @@ defmodule LangChain.Trajectory do
       trajectory = Trajectory.from_chain(chain)
   """
   @spec from_chain(LLMChain.t()) :: t()
-  def from_chain(%LLMChain{exchanged_messages: messages, llm: llm}) do
-    tool_calls = extract_tool_calls(messages)
-    token_usage = aggregate_token_usage(messages)
-    metadata = extract_metadata(llm)
+  def from_chain(%LLMChain{exchanged_messages: exchanged_messages, llm: llm}) do
+    from_messages(exchanged_messages, llm)
+  end
 
+  @doc """
+  Build a `Trajectory` from a list of exchanged messages.
+
+  Use this when you have the messages from an assistant operation, workflow,
+  or set of tool-call iterations but do **not** have a live `LLMChain` — for
+  example, a persisted agent state or a sliced "last turn" of a conversation.
+
+  The `messages` argument should be the **exchanged messages for the operation
+  you want to analyze**, not necessarily an entire conversation. Including the
+  leading system/user preamble is harmless for tool-call extraction and
+  matching (those messages carry no tool calls), but for token aggregation and
+  `calls_by_turn/1` semantics you generally want just the turns produced during
+  the operation under analysis.
+
+  `llm` is optional and is only used to populate `metadata` (`:model` and
+  `:llm_module`). Pass `nil` (the default) to produce an empty metadata map.
+  Note that metadata does not survive a JSON roundtrip anyway (see the
+  `from_map/1` note), so it is safe to omit when you only have a stored
+  message list.
+
+  ## Example
+
+      # From a persisted agent state, analyzing the whole conversation:
+      trajectory = Trajectory.from_messages(state.messages, agent.model)
+
+      # From a pre-sliced "last turn" with no llm handy:
+      trajectory = Trajectory.from_messages(last_turn_messages)
+  """
+  @spec from_messages([Message.t()], struct() | nil) :: t()
+  def from_messages(messages, llm \\ nil) when is_list(messages) do
     %Trajectory{
       messages: messages,
-      tool_calls: tool_calls,
-      token_usage: token_usage,
-      metadata: metadata
+      tool_calls: extract_tool_calls(messages),
+      token_usage: aggregate_token_usage(messages),
+      metadata: extract_metadata(llm)
     }
   end
 

--- a/test/trajectory_test.exs
+++ b/test/trajectory_test.exs
@@ -173,6 +173,95 @@ defmodule LangChain.TrajectoryTest do
     end
   end
 
+  describe "from_messages/2" do
+    test "builds a trajectory from a bare message list without an llm" do
+      tc = make_tool_call("search", %{"query" => "weather"})
+
+      messages = [
+        user_msg("What's the weather?"),
+        assistant_msg(nil, tool_calls: [tc])
+      ]
+
+      trajectory = Trajectory.from_messages(messages)
+
+      assert trajectory.messages == messages
+      assert [%{name: "search", arguments: %{"query" => "weather"}}] = trajectory.tool_calls
+      # No llm provided, so metadata is empty
+      assert trajectory.metadata == %{}
+    end
+
+    test "populates metadata when an llm is provided" do
+      {:ok, llm} = ChatOpenAI.new(%{temperature: 0})
+
+      messages = [user_msg("Hello"), assistant_msg("Hi")]
+      trajectory = Trajectory.from_messages(messages, llm)
+
+      assert trajectory.metadata.model == "gpt-3.5-turbo"
+      assert trajectory.metadata.llm_module == ChatOpenAI
+    end
+
+    test "aggregates token usage over a hand-built message list" do
+      usage1 = make_usage(10, 20)
+      usage2 = make_usage(5, 15)
+
+      messages = [
+        user_msg("Hello"),
+        assistant_msg("Hi", usage: usage1),
+        user_msg("More"),
+        assistant_msg("Sure", usage: usage2)
+      ]
+
+      trajectory = Trajectory.from_messages(messages)
+
+      assert trajectory.token_usage.input == 15
+      assert trajectory.token_usage.output == 35
+    end
+
+    test "is equivalent to from_chain/1 on the chain's exchanged_messages" do
+      tc1 = make_tool_call("search", %{"query" => "weather"})
+      tc2 = make_tool_call("get_forecast", %{"city" => "Paris"})
+      tr1 = make_tool_result("search", "Sunny")
+
+      messages = [
+        user_msg("What's the weather in Paris?"),
+        assistant_msg(nil, tool_calls: [tc1], usage: make_usage(10, 20)),
+        tool_msg([tr1]),
+        assistant_msg(nil, tool_calls: [tc2], usage: make_usage(5, 15))
+      ]
+
+      chain = chain_with_messages(messages)
+
+      from_chain = Trajectory.from_chain(chain)
+      from_messages = Trajectory.from_messages(chain.exchanged_messages, chain.llm)
+
+      assert from_chain == from_messages
+    end
+
+    test "a bare-list-without-llm trajectory still matches?/3 correctly" do
+      tc1 = make_tool_call("search", %{"query" => "weather"})
+      tc2 = make_tool_call("get_forecast", %{"city" => "Paris"})
+
+      messages = [
+        user_msg("What's the weather in Paris?"),
+        assistant_msg(nil, tool_calls: [tc1]),
+        assistant_msg(nil, tool_calls: [tc2])
+      ]
+
+      trajectory = Trajectory.from_messages(messages)
+
+      assert Trajectory.matches?(trajectory, [
+               %{name: "search", arguments: %{"query" => "weather"}},
+               %{name: "get_forecast", arguments: %{"city" => "Paris"}}
+             ])
+
+      assert Trajectory.matches?(trajectory, [%{name: "search", arguments: nil}], mode: :superset)
+
+      refute Trajectory.matches?(trajectory, [%{name: "delete_all", arguments: nil}],
+               mode: :superset
+             )
+    end
+  end
+
   describe "to_map/1" do
     test "serializes empty trajectory" do
       trajectory = %Trajectory{messages: [], tool_calls: [], token_usage: nil}


### PR DESCRIPTION
## Problem

`LangChain.Trajectory.from_chain/1` is the only constructor that reads live run data, and it requires an `%LLMChain{}`. But the real work it does — tool-call extraction, token aggregation, and metadata — is a pure function of a `[Message.t()]` plus an optional llm.

Callers that only have a bare list of messages had no entry point: a persisted agent state, a workflow, or a sliced "last turn" of a conversation. There was no way to build a trajectory from those without reconstructing a chain.

## Solution

Add `Trajectory.from_messages/2`, exposing the message list as a first-class seam:

```elixir
# From a persisted agent state, analyzing the whole conversation:
trajectory = Trajectory.from_messages(state.messages, agent.model)

# From a pre-sliced "last turn" with no llm handy:
trajectory = Trajectory.from_messages(last_turn_messages)
```

`llm` is optional and defaults to `nil`, which yields empty metadata via the existing `extract_metadata/1` fallback clause — no helper needed to change. Metadata does not survive a JSON roundtrip anyway, so omitting it is safe when you only have a stored message list.

`from_chain/1` is refactored to **delegate** to `from_messages/2`, so there is a single implementation and the two entry points cannot drift apart.

## Changes

- `lib/trajectory.ex` — Add `from_messages/2` (with optional `llm`); refactor `from_chain/1` to delegate to it
- `lib/trajectory.ex` (`@moduledoc` + `@doc`) — Document the new constructor and the "exchanged messages for an operation" framing
- `test/trajectory_test.exs` — Add a `from_messages/2` describe block: bare-list construction with and without an llm (metadata present vs `%{}`), token aggregation over a hand-built list, `matches?/3` on a no-llm trajectory, and a parity test asserting `from_chain(chain) == from_messages(chain.exchanged_messages, chain.llm)`

## Testing

`mix precommit` passes clean: 31 doctests, 1773 tests, 0 failures (143 excluded live-API tests), plus a clean Sobelow scan. The 5 new tests are in `test/trajectory_test.exs` and run async with no external API calls. The parity test guards the delegation refactor by asserting full struct equality between the two entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)