### PR TITLE
Fix Elixir 1.20 type warnings: dead code and latent bugs

### DIFF
--- a/lib/chat_models/chat_aws_mantle.ex
+++ b/lib/chat_models/chat_aws_mantle.ex
@@ -135,7 +135,6 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
   `ChatOpenAI` — see the smoke tests for verified behavior.
   """
   use Ecto.Schema
-  require Logger
   import Ecto.Changeset
   alias __MODULE__
   alias LangChain.ChatModels.ChatModel

--- a/lib/chat_models/chat_bumblebee.ex
+++ b/lib/chat_models/chat_bumblebee.ex
@@ -96,7 +96,6 @@ defmodule LangChain.ChatModels.ChatBumblebee do
         recompile; MyApp.BumblebeeChat.run_chat
   """
   use Ecto.Schema
-  require Logger
   import Ecto.Changeset
   alias __MODULE__
   alias LangChain.ChatModels.ChatModel

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -311,15 +311,6 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     }
   end
 
-  def for_api(%Message{content: content} = message) when is_list(content) do
-    %{
-      "role" => map_role(message.role),
-      "parts" =>
-        Enum.map(content, &for_api/1)
-        |> List.flatten()
-    }
-  end
-
   def for_api(%ContentPart{type: :text} = part) do
     %{"text" => part.content}
   end

--- a/lib/chat_models/chat_grok.ex
+++ b/lib/chat_models/chat_grok.ex
@@ -73,7 +73,6 @@ defmodule LangChain.ChatModels.ChatGrok do
 
   """
   use Ecto.Schema
-  require Logger
   import Ecto.Changeset
   alias __MODULE__
   alias LangChain.Config

--- a/lib/chat_models/chat_model.ex
+++ b/lib/chat_models/chat_model.ex
@@ -1,5 +1,4 @@
 defmodule LangChain.ChatModels.ChatModel do
-  require Logger
   alias LangChain.Message
   alias LangChain.MessageDelta
   alias LangChain.Function

--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -861,7 +861,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
         %{"type" => "input_image", "file_id" => part.content}
       else
         media_prefix =
-          case Keyword.get(part.options || [], :media, nil) do
+          case Keyword.get(part.options, :media, nil) do
             nil ->
               ""
 

--- a/lib/function_param.ex
+++ b/lib/function_param.ex
@@ -71,7 +71,6 @@ defmodule LangChain.FunctionParam do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  require Logger
   alias __MODULE__
   alias LangChain.LangChainError
 
@@ -188,8 +187,10 @@ defmodule LangChain.FunctionParam do
       type == :array and item == "object" and Enum.empty?(props) ->
         add_error(changeset, :object_properties, "required when array type of object is used")
 
-      # has object_properties but not one of the allowed cases
-      !Enum.empty?(props) and (!(type == :array and item == "object") and !(type == :object)) ->
+      # has object_properties but not one of the allowed cases.
+      # `type` is provably not `:object` here (handled by the clauses above),
+      # so only the array-of-object case needs to be excluded.
+      !Enum.empty?(props) and !(type == :array and item == "object") ->
         add_error(changeset, :object_properties, "not allowed for type #{inspect(type)}")
 
       # not an object and didn't give object_properties

--- a/lib/images/generated_image.ex
+++ b/lib/images/generated_image.ex
@@ -16,7 +16,6 @@ defmodule LangChain.Images.GeneratedImage do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  require Logger
   alias __MODULE__
   alias LangChain.LangChainError
 

--- a/lib/message.ex
+++ b/lib/message.ex
@@ -224,9 +224,6 @@ defmodule LangChain.Message do
           add_error(changeset, :content, "is invalid for role #{role}")
         end
 
-      {:ok, []} ->
-        put_change(changeset, :content, nil)
-
       # any other value is not valid
       {:ok, _value} ->
         add_error(changeset, :content, "must be text or a list of ContentParts")

--- a/lib/message/content_part.ex
+++ b/lib/message/content_part.ex
@@ -222,7 +222,7 @@ defmodule LangChain.Message.ContentPart do
          }
        )
        when is_binary(primary_content) and is_binary(new_content) and primary_type == new_type do
-    %ContentPart{primary | content: (primary.content || "") <> new_content}
+    %ContentPart{primary | content: primary_content <> new_content}
   end
 
   defp append_content(%ContentPart{} = primary, %ContentPart{content: nil}), do: primary

--- a/lib/message/tool_call.ex
+++ b/lib/message/tool_call.ex
@@ -14,7 +14,6 @@ defmodule LangChain.Message.ToolCall do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  require Logger
   alias __MODULE__
   alias LangChain.LangChainError
 

--- a/lib/message/tool_result.ex
+++ b/lib/message/tool_result.ex
@@ -22,7 +22,6 @@ defmodule LangChain.Message.ToolResult do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  require Logger
   alias __MODULE__
   alias LangChain.LangChainError
   alias LangChain.Utils

--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -245,6 +245,17 @@ defmodule LangChain.MessageDelta do
     %MessageDelta{delta | content: nil}
   end
 
+  # ContentPart from merged_content (already processed delta). Must precede the
+  # "empty content" clause below: such a delta has `content: nil` but still
+  # carries a part to merge, so the broad `content in [nil, []]` guard would
+  # otherwise shadow this and silently drop the merged_content.
+  defp append_to_merged_content(
+         %MessageDelta{} = primary,
+         %MessageDelta{content: nil, merged_content: %ContentPart{} = part}
+       ) do
+    merge_content_part_into(primary, part)
+  end
+
   # Empty content - nothing to merge
   defp append_to_merged_content(%MessageDelta{} = primary, %MessageDelta{content: content})
        when content in [nil, []],
@@ -254,14 +265,6 @@ defmodule LangChain.MessageDelta do
   defp append_to_merged_content(%MessageDelta{} = primary, %MessageDelta{content: content})
        when is_binary(content) do
     append_to_merged_content(primary, %MessageDelta{content: ContentPart.text!(content)})
-  end
-
-  # ContentPart from merged_content (already processed delta)
-  defp append_to_merged_content(
-         %MessageDelta{} = primary,
-         %MessageDelta{content: nil, merged_content: %ContentPart{} = part}
-       ) do
-    merge_content_part_into(primary, part)
   end
 
   # Single ContentPart content
@@ -455,9 +458,6 @@ defmodule LangChain.MessageDelta do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:error, Utils.changeset_error_to_string(changeset)}
-
-      {:error, _reason} = error ->
-        error
     end
   end
 

--- a/lib/routing/prompt_route.ex
+++ b/lib/routing/prompt_route.ex
@@ -55,7 +55,6 @@ defmodule LangChain.Routing.PromptRoute do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  require Logger
   alias __MODULE__
   alias LangChain.LangChainError
 

--- a/lib/token_usage.ex
+++ b/lib/token_usage.ex
@@ -20,7 +20,6 @@ defmodule LangChain.TokenUsage do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  require Logger
   alias __MODULE__
   alias LangChain.LangChainError
 

--- a/lib/utils/chat_templates.ex
+++ b/lib/utils/chat_templates.ex
@@ -131,6 +131,10 @@ defmodule LangChain.Utils.ChatTemplates do
   """
   @spec prep_and_validate_messages([Message.t()]) ::
           {Message.t() | nil, Message.t(), [Message.t()]} | no_return()
+  def prep_and_validate_messages([]) do
+    raise LangChainError, "Messages are required."
+  end
+
   def prep_and_validate_messages(messages) do
     {system, first_user, rest} =
       case messages do
@@ -142,9 +146,6 @@ defmodule LangChain.Utils.ChatTemplates do
 
         [%Message{role: :system} = _system | _rest] ->
           raise LangChainError, "Messages must include a user prompt after a system message."
-
-        [] ->
-          raise LangChainError, "Messages are required."
 
         _other ->
           raise LangChainError, "Messages must start with either a system or user message."

--- a/test/chat_models/chat_orq_test.exs
+++ b/test/chat_models/chat_orq_test.exs
@@ -446,8 +446,10 @@ defmodule LangChain.ChatModels.ChatOrqTest do
       merged = MessageDelta.merge_delta(delta_1, delta_2)
 
       assert merged.role == :assistant
-      # The merged content should contain text from both deltas
-      merged_text = merged.content || ""
+      # The merged content should contain text from both deltas. After merging,
+      # `content` is cleared to nil and the accumulated text lives in
+      # `merged_content` as ContentParts.
+      merged_text = ContentPart.content_to_string(merged.merged_content) || ""
       assert is_binary(merged_text)
       # Most deltas will be incomplete until the final one
       assert merged.status == :incomplete


### PR DESCRIPTION
## Problem

Elixir 1.20-rc.6 ships an improved set-theoretic type system whose inference can now prove dead code and latent logic bugs at compile time. A `mix compile --force` surfaced 16 warnings across the library, and the test suite surfaced 2 more. Each warning was either provably-unreachable code (safe to remove) or a clause whose intent was silently defeated by an over-broad guard or shadowing — the latter being real bugs. This change resolves all of them so the codebase compiles cleanly under the new compiler.

## Solution

Each warning was triaged into one of two buckets and fixed accordingly, never suppressed:

- **Dead code** — removed or simplified with identical runtime behavior. This covers 10 unused `require Logger` directives, a byte-identical duplicate `for_api/1` clause in `ChatGoogleAI`, an unreachable `{:error, _reason}` catch-all (`Message.new/1` only ever returns changeset errors), an always-true `type == :object` sub-term inside a `cond` whose earlier clauses already eliminated `:object`, and two `|| default` fallbacks whose left side was type-proven non-nil.

- **Latent bugs** — fixed to honor the original intent:
  - `MessageDelta.append_to_merged_content/2`: the `content in [nil, []]` "nothing to merge" guard shadowed a later clause meant to merge an already-processed `merged_content` ContentPart, silently dropping it. Reordered the specific clause ahead of the broad guard.
  - `ChatOrqTest`: the streaming test read `merged.content`, which `merge_delta/2` always clears to `nil` (text lives in `merged_content`). The assertion only ever passed on its `""` fallback. Now reads the real text via `ContentPart.content_to_string/1`.
  - `ChatTemplates.prep_and_validate_messages/1`: every `[]`/malformed branch `raise`d, so the compiler inferred the domain as `non_empty_list` from the returning clauses only, making the intentional "raises on empty" test look type-incompatible. Lifted the empty-list case into its own function head so `[]` is a declared part of the signature.

## Changes

- `lib/message_delta.ex` — Reordered `append_to_merged_content/2` so the merged_content ContentPart clause precedes the empty-content guard; removed unreachable `{:error, _reason}` clause in `to_message/1`
- `lib/utils/chat_templates.ex` — Promoted the empty-list case of `prep_and_validate_messages/1` to its own function head
- `lib/function_param.ex` — Dropped the always-true `!(type == :object)` sub-term in `validate_object_type/1`
- `lib/message.ex` — Removed the shadowed `{:ok, []}` clause in `validate_content_type/1`
- `lib/message/content_part.ex` — Simplified `(primary.content || "")` to the guard-proven binary
- `lib/chat_models/chat_open_ai_responses.ex` — Dropped dead `part.options || []` fallback
- `lib/chat_models/chat_google_ai.ex` — Removed duplicate `for_api/1` clause
- `lib/chat_models/{chat_model,chat_aws_mantle,chat_grok,chat_bumblebee}.ex`, `lib/{token_usage,function_param,images/generated_image,routing/prompt_route}.ex`, `lib/message/{tool_call,tool_result}.ex` — Removed unused `require Logger`
- `test/chat_models/chat_orq_test.exs` — Read merged delta text from `merged_content` instead of the always-nil `content`

## Testing

`mix compile --force` (both `dev` and `test` envs) is now warning-free. Full suite green: 1804 tests pass (31 doctests), 143 excluded live tests. The clause reorder and function-head refactor were verified against the existing `message_delta`, `message`, `function_param`, `content_part`, `chat_google_ai`, and `chat_templates` test files with no regressions.