### PR TITLE
Fix google ai empty stream body

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -619,7 +619,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
         )
     )
     |> case do
-      {:ok, %Req.Response{status: 200, body: data} = response} ->
+      {:ok, %Req.Response{status: 200, body: data} = response} when is_list(data) ->
         Callbacks.fire(google_ai.callbacks, :on_llm_response_headers, [response.headers])
 
         flattened = List.flatten(data)
@@ -639,6 +639,21 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
             |> reindex_deltas()
             |> Enum.reverse()
         end
+
+      {:ok, %Req.Response{status: 200} = response} ->
+        # Stream ended with zero delta chunks — `Utils.handle_stream_fn/3`
+        # converts the default binary body `""` to `[]` only on the first
+        # `{:data, ...}` callback. If Gemini returns 200 with no streamed
+        # chunks (e.g. immediate finish without content, or all chunks
+        # filtered by the SSE decoder), the body stays `""` and crashes
+        # `List.flatten/1`. Surface as a structured error so the chain can
+        # propagate it cleanly instead of taking down the Task.
+        {:error,
+         LangChainError.exception(
+           type: "empty_stream",
+           message: "Empty streaming response from Gemini (no delta chunks received)",
+           original: response
+         )}
 
       {:ok, %Req.Response{body: {:error, %LangChainError{} = error}}} ->
         {:error, error}

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -602,7 +602,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     end
   end
 
-  def do_api_request(%ChatGoogleAI{stream: true} = google_ai, messages, tools) do
+  def do_api_request(%ChatGoogleAI{stream: true, model: model} = google_ai, messages, tools) do
     Req.new(
       url: build_url(google_ai),
       json: for_api(google_ai, messages, tools),
@@ -646,7 +646,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
       {:ok, %Req.Response{status: 200} = response} ->
         # Stream ended with zero delta chunks — `Utils.handle_stream_fn/3`
         # converts the default binary body `""` to `[]` only on the first
-        # `{:data, ...}` callback. If Gemini returns 200 with no streamed
+        # `{:data, ...}` callback. If LLM returns 200 with no streamed
         # chunks (e.g. immediate finish without content, or all chunks
         # filtered by the SSE decoder), the body stays `""` and crashes
         # `List.flatten/1`. Surface as a structured error so the chain can
@@ -654,7 +654,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
         {:error,
          LangChainError.exception(
            type: "empty_stream",
-           message: "Empty streaming response from Gemini (no delta chunks received)",
+           message: "Empty streaming response from #{model} (no delta chunks received)",
            original: response
          )}
 

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -619,6 +619,9 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
         )
     )
     |> case do
+      {:ok, %Req.Response{body: {:error, %LangChainError{} = error}}} ->
+        {:error, error}
+
       {:ok, %Req.Response{status: 200, body: data} = response} when is_list(data) ->
         Callbacks.fire(google_ai.callbacks, :on_llm_response_headers, [response.headers])
 
@@ -654,9 +657,6 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
            message: "Empty streaming response from Gemini (no delta chunks received)",
            original: response
          )}
-
-      {:ok, %Req.Response{body: {:error, %LangChainError{} = error}}} ->
-        {:error, error}
 
       {:ok, %Req.Response{status: status} = response} when status != 200 ->
         # Try to extract error from the buffered error data

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -2063,5 +2063,25 @@ defmodule ChatModels.ChatGoogleAITest do
       assert error.message == "Unexpected response 1"
       assert error.original["finishReason"] == "MALFORMED_FUNCTION_CALL"
     end
+
+    test "streaming 200 with empty body returns empty_stream error instead of crashing" do
+      # `Req.Response.body` starts as the binary `""` and is converted to `[]`
+      # by `Utils.handle_stream_fn/3` only on the first `{:data, ...}` callback.
+      # If Gemini returns 200 with zero streamed chunks (e.g. immediate finish
+      # without content, or all chunks filtered by the SSE decoder), the body
+      # stays as the binary `""` and `List.flatten/1` crashes with a
+      # FunctionClauseError. This test guards that path.
+      expect(Req, :post, fn _req, _opts ->
+        {:ok, %Req.Response{status: 200, headers: %{}, body: ""}}
+      end)
+
+      model = ChatGoogleAI.new!(%{stream: true, model: "gemini-2.5-flash"})
+
+      assert {:error, %LangChainError{} = error} =
+               ChatGoogleAI.call(model, [Message.new_user!("Hello")])
+
+      assert error.type == "empty_stream"
+      assert error.message =~ "Empty streaming response"
+    end
   end
 end

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -2022,14 +2022,14 @@ defmodule ChatModels.ChatGoogleAITest do
         )
 
       delta1 = %LangChain.MessageDelta{
-        content: [%LangChain.Message.ContentPart{type: :text, content: "Part 1"}],
+        content: %LangChain.Message.ContentPart{type: :text, content: "Part 1"},
         index: 0,
         role: :assistant,
         status: :incomplete
       }
 
       delta2 = %LangChain.MessageDelta{
-        content: [%LangChain.Message.ContentPart{type: :text, content: "Part 2"}],
+        content: %LangChain.Message.ContentPart{type: :text, content: "Part 2"},
         index: 0,
         role: :assistant,
         status: :incomplete

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -2072,7 +2072,7 @@ defmodule ChatModels.ChatGoogleAITest do
       # stays as the binary `""` and `List.flatten/1` crashes with a
       # FunctionClauseError. This test guards that path.
       expect(Req, :post, fn _req, _opts ->
-        {:ok, %Req.Response{status: 200, headers: %{}, body: ""}}
+        {:ok, %Req.Response{status: 200, headers: [], body: ""}}
       end)
 
       model = ChatGoogleAI.new!(%{stream: true, model: "gemini-2.5-flash"})

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -2022,14 +2022,14 @@ defmodule ChatModels.ChatGoogleAITest do
         )
 
       delta1 = %LangChain.MessageDelta{
-        content: %LangChain.Message.ContentPart{type: :text, content: "Part 1"},
+        content: [%LangChain.Message.ContentPart{type: :text, content: "Part 1"}],
         index: 0,
         role: :assistant,
         status: :incomplete
       }
 
       delta2 = %LangChain.MessageDelta{
-        content: %LangChain.Message.ContentPart{type: :text, content: "Part 2"},
+        content: [%LangChain.Message.ContentPart{type: :text, content: "Part 2"}],
         index: 0,
         role: :assistant,
         status: :incomplete


### PR DESCRIPTION
When a streaming request to Gemini returns 200 OK with zero delta chunks (e.g. immediate finish without content, or all chunks filtered by the SSE decoder), `Req.Response.body` stays as the binary default `""` instead of the list of `%MessageDelta{}` the downstream code expects. `Utils.handle_stream_fn/3` only converts `""` to `[]` on the first `{:data, ...}` callback — if no callback fires, the conversion is skipped.

The body then reaches `List.flatten(data)` and crashes with `FunctionClauseError` on `:lists.flatten("")`, killing the upstream Task. Symptom in production:

    ** (FunctionClauseError) no function clause matching in :lists.flatten/1
       :lists.flatten("") at lists.erl:1145
       LangChain.ChatModels.ChatGoogleAI.do_api_request/3 at line 634

Add an `is_list(data)` guard to the existing 200 OK clause and a sibling clause that returns
`{:error, %LangChainError{type: "empty_stream"}}` for the zero-chunk case. The upstream chain already knows how to surface `%LangChainError{}` as a clean status change instead of crashing.

Regression test asserts the structured error is returned instead of the FunctionClauseError.