### PR TITLE
Ignore SSE comment lines in ChatOpenAI stream decoder

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -1061,6 +1061,13 @@ defmodule LangChain.ChatModels.ChatOpenAI do
         "[DONE]" ->
           acc
 
+        ":" <> _sse_comment ->
+          # A line starting with a colon is a comment and is ignored per the SSE
+          # spec: https://html.spec.whatwg.org/multipage/server-sent-events.html
+          # OpenRouter sends ": OPENROUTER PROCESSING" comments to keep the
+          # connection alive.
+          acc
+
         json ->
           parse_combined_data(incomplete, json, done)
       end

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -2080,6 +2080,26 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert parsed == [json_1, json_2]
     end
 
+    test "ignores SSE comment lines while still parsing data", %{json_1: json_1} do
+      # Per the SSE spec, lines starting with a colon are comments and must be
+      # ignored. OpenRouter sends ": OPENROUTER PROCESSING" comments to keep the
+      # connection alive.
+      data =
+        ": OPENROUTER PROCESSING\n\n: OPENROUTER PROCESSING\n\ndata: {\"id\":\"chatcmpl-7e8yp1xBhriNXiqqZ0xJkgNrmMuGS\",\"object\":\"chat.completion.chunk\",\"created\":1689801995,\"model\":\"gpt-4-0613\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":null,\"function_call\":{\"name\":\"calculator\",\"arguments\":\"\"}},\"finish_reason\":null}]}\n\n"
+
+      {parsed, incomplete} = ChatOpenAI.decode_stream({data, ""})
+
+      assert incomplete == ""
+      assert parsed == [json_1]
+    end
+
+    test "a comment-only chunk yields no results and an empty buffer" do
+      {parsed, incomplete} = ChatOpenAI.decode_stream({": OPENROUTER PROCESSING\n\n", ""})
+
+      assert parsed == []
+      assert incomplete == ""
+    end
+
     test "correctly parses when data content contains spaces such as python code with indentation" do
       data =
         "data: {\"id\":\"chatcmpl-7e8yp1xBhriNXiqqZ0xJkgNrmMuGS\",\"object\":\"chat.completion.chunk\",\"created\":1689801995,\"model\":\"gpt-4-0613\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"def my_function(x):\\n    return x + 1\"},\"finish_reason\":null}]}\n\n"


### PR DESCRIPTION
This fixes #259.

Some OpenAI-compatible APIs (or at least OpenRouter) send SSE comment lines starting with a colon (e.g. ': OPENROUTER PROCESSING') to keep connections alive.

Per the SSE spec these must be ignored, but decode_stream/2 still buffered them, corrupting all subsequent chunks and producing an empty response.

Note that I just copied the fix from @joecorcoran's fork [here](https://github.com/joecorcoran/langchain/commit/2c765721dad65ac7b546c258dc3d75cba6f4fd3e) and got Claude to add tests.