### PR TITLE
Ignore SSE comment lines in ChatOpenAI.decode_stream (fixes #259)

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -1055,6 +1055,13 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       str
       |> String.trim()
       |> case do
+        ":" <> _sse_comment ->
+          # A line starting with a colon is an SSE comment and can be ignored per
+          # https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+          # OpenRouter sends ": OPENROUTER PROCESSING" keep-alive comments which
+          # otherwise poison the incomplete-JSON buffer and break the whole stream.
+          acc
+
         "" ->
           acc
 

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -2080,6 +2080,29 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert parsed == [json_1, json_2]
     end
 
+    test "ignores SSE comment lines (e.g. OpenRouter keep-alives)" do
+      # OpenRouter sends SSE comments (lines starting with ":") to keep the
+      # connection alive. They are ignorable per the SSE spec and must not be
+      # buffered as incomplete JSON, which would poison all following chunks.
+      data = ": OPENROUTER PROCESSING\n\n"
+
+      {parsed, incomplete} = ChatOpenAI.decode_stream({data, ""})
+
+      assert incomplete == ""
+      assert parsed == []
+    end
+
+    test "parses a data chunk that follows an SSE comment", %{json_1: json_1} do
+      data =
+        ": OPENROUTER PROCESSING\n\n" <>
+          "data: {\"id\":\"chatcmpl-7e8yp1xBhriNXiqqZ0xJkgNrmMuGS\",\"object\":\"chat.completion.chunk\",\"created\":1689801995,\"model\":\"gpt-4-0613\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":null,\"function_call\":{\"name\":\"calculator\",\"arguments\":\"\"}},\"finish_reason\":null}]}\n\n"
+
+      {parsed, incomplete} = ChatOpenAI.decode_stream({data, ""})
+
+      assert incomplete == ""
+      assert parsed == [json_1]
+    end
+
     test "correctly parses when data content contains spaces such as python code with indentation" do
       data =
         "data: {\"id\":\"chatcmpl-7e8yp1xBhriNXiqqZ0xJkgNrmMuGS\",\"object\":\"chat.completion.chunk\",\"created\":1689801995,\"model\":\"gpt-4-0613\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"def my_function(x):\\n    return x + 1\"},\"finish_reason\":null}]}\n\n"


### PR DESCRIPTION
Fixes #259.

## Problem

OpenAI-compatible streaming APIs may send SSE **comment** lines (starting with a colon), which are ignorable per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation). OpenRouter in particular sends `: OPENROUTER PROCESSING` keep-alive comments to prevent connection timeouts.

`ChatOpenAI.decode_stream/2` splits only on `"data: "`, so a comment line is treated as JSON, fails to decode, and is buffered as `incomplete`. That buffer is then prepended to every subsequent valid chunk — poisoning it — so the entire stream parses to `[]`. Downstream this surfaces as an empty response (and, before the `{:ok, []}` handling was added, a `CaseClauseError` in `LLMChain.do_run/1`).

## Fix

Skip lines beginning with `":"` in the `decode_stream` reduce, mirroring how the [Python OpenAI SDK](https://github.com/openai/openai-python/blob/2e56c8da6f163db00a4ca362020148bb391edca9/src/openai/_streaming.py#L343) handles SSE comments.

## Tests

Adds two regression tests to `decode_stream/2`:
- a lone `": OPENROUTER PROCESSING"` comment parses to `[]` with no leftover buffer
- a data chunk that follows a comment still parses correctly (proves the buffer isn't poisoned)

Full `ChatOpenAITest` suite passes (109 tests). Verified live against OpenRouter: streaming now assembles content token-by-token instead of returning empty.