### PR TITLE
fix: do not put the Vertex AI API key in the request URL

### DIFF
--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -622,14 +622,15 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     end
   end
 
+  @doc false
   @spec build_url(t()) :: String.t()
-  defp build_url(%ChatVertexAI{endpoint: endpoint, model: model} = vertex_ai) do
-    "#{endpoint}/models/#{model}:#{get_action(vertex_ai)}?key=#{get_api_key(vertex_ai)}"
+  def build_url(%ChatVertexAI{endpoint: endpoint, model: model} = vertex_ai) do
+    "#{endpoint}/models/#{model}:#{get_action(vertex_ai)}"
     |> use_sse(vertex_ai)
   end
 
   @spec use_sse(String.t(), t()) :: String.t()
-  defp use_sse(url, %ChatVertexAI{stream: true}), do: url <> "&alt=sse"
+  defp use_sse(url, %ChatVertexAI{stream: true}), do: url <> "?alt=sse"
   defp use_sse(url, _model), do: url
 
   @spec get_action(t()) :: String.t()

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -81,6 +81,40 @@ defmodule ChatModels.ChatVertexAITest do
     end
   end
 
+  describe "build_url/1" do
+    test "builds the request URL for the model and action" do
+      model =
+        ChatVertexAI.new!(%{model: @test_model, endpoint: "http://localhost:1234", stream: false})
+
+      assert ChatVertexAI.build_url(model) ==
+               "http://localhost:1234/models/#{@test_model}:generateContent"
+    end
+
+    test "uses the streaming action and a well-formed `?alt=sse` query when streaming" do
+      model =
+        ChatVertexAI.new!(%{model: @test_model, endpoint: "http://localhost:1234", stream: true})
+
+      # The full URL — with the SSE parameter introduced by `?`, not `&`, since
+      # there is no other query string (the API key is a bearer header).
+      assert ChatVertexAI.build_url(model) ==
+               "http://localhost:1234/models/#{@test_model}:streamGenerateContent?alt=sse"
+    end
+
+    test "does not put the API key in the URL (it is sent as a bearer token)" do
+      model =
+        ChatVertexAI.new!(%{
+          model: @test_model,
+          endpoint: "http://localhost:1234",
+          api_key: "secret-key"
+        })
+
+      url = ChatVertexAI.build_url(model)
+
+      refute url =~ "key="
+      refute url =~ "secret-key"
+    end
+  end
+
   describe "for_api/3" do
     setup do
       params = %{


### PR DESCRIPTION
## Problem

`ChatVertexAI.build_url/1` appends the API key as a query parameter:

```elixir
"#{endpoint}/models/#{model}:#{get_action(vertex_ai)}?key=#{get_api_key(vertex_ai)}"
```

The same key is *also* already sent as a bearer token (`auth: {:bearer, get_api_key(vertex_ai)}` in the Req options), so the query-string copy is redundant - it looks like it arrived via copy paste from ChatGoogleAI. It is also a credential-leak vector: full request URLs routinely appear in server/proxy access logs, error trackers, and browser history — exposing the API key.

## Fix

Drop `?key=...` from the URL. Authentication is unchanged — the bearer token in the `Authorization` header still carries the key.

Also matched test approach based on ChatGoogleAI