### PR TITLE
fix: normalize ToolCall arguments to a map when serializing tool calls

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -1732,7 +1732,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
       "type" => "tool_use",
       "id" => call.call_id,
       "name" => call.name,
-      "input" => call.arguments || %{}
+      "input" => ToolCall.arguments_as_map(call)
     }
   end
 

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -394,7 +394,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
       when is_binary(signature) do
     %{
       "functionCall" => %{
-        "args" => call.arguments,
+        "args" => ToolCall.arguments_as_map(call),
         "name" => call.name
       },
       "thoughtSignature" => signature
@@ -404,7 +404,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   def for_api(%ToolCall{} = call) do
     %{
       "functionCall" => %{
-        "args" => call.arguments,
+        "args" => ToolCall.arguments_as_map(call),
         "name" => call.name
       }
     }

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -311,7 +311,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
        when is_binary(signature) do
     %{
       "functionCall" => %{
-        "args" => call.arguments,
+        "args" => ToolCall.arguments_as_map(call),
         "name" => call.name
       },
       "thoughtSignature" => signature
@@ -321,7 +321,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
   defp for_api(%ToolCall{} = call) do
     %{
       "functionCall" => %{
-        "args" => call.arguments,
+        "args" => ToolCall.arguments_as_map(call),
         "name" => call.name
       }
     }

--- a/lib/message/tool_call.ex
+++ b/lib/message/tool_call.ex
@@ -86,6 +86,51 @@ defmodule LangChain.Message.ToolCall do
     |> apply_action(:insert)
   end
 
+  @doc """
+  Return the tool call's `arguments` as a map, suitable for serializing to a
+  provider API that expects a JSON object.
+
+  `arguments` are only parsed from a JSON string into a map by `complete/1` (via
+  `validate_and_parse_arguments/1`), which runs when a tool call reaches
+  `status: :complete`. A tool call that is serialized without going through that
+  path (e.g. a persisted/replayed `:incomplete` call, or one accumulated from a
+  truncated stream) can still hold a raw string. Passing that string to a
+  provider results in an API error like Anthropic's "Input should be an object".
+
+  This normalizes any shape into a map:
+
+    * a map is returned unchanged
+    * a JSON-object string is decoded
+    * `nil`, an empty string, and undecodable/non-object strings become `%{}`
+
+  ## Examples
+
+      iex> LangChain.Message.ToolCall.arguments_as_map(%LangChain.Message.ToolCall{arguments: %{"a" => 1}})
+      %{"a" => 1}
+
+      iex> LangChain.Message.ToolCall.arguments_as_map(%LangChain.Message.ToolCall{arguments: ~s({"a":1})})
+      %{"a" => 1}
+
+      iex> LangChain.Message.ToolCall.arguments_as_map(%LangChain.Message.ToolCall{arguments: ""})
+      %{}
+
+      iex> LangChain.Message.ToolCall.arguments_as_map(%LangChain.Message.ToolCall{arguments: nil})
+      %{}
+  """
+  @spec arguments_as_map(t()) :: map()
+  def arguments_as_map(%ToolCall{arguments: arguments}), do: normalize_arguments(arguments)
+
+  defp normalize_arguments(arguments) when is_map(arguments), do: arguments
+
+  defp normalize_arguments(arguments) when is_binary(arguments) do
+    case Jason.decode(arguments) do
+      {:ok, map} when is_map(map) -> map
+      _ -> %{}
+    end
+  end
+
+  defp normalize_arguments(_arguments), do: %{}
+
   defp common_validations(changeset) do
     case get_field(changeset, :status) do
       nil ->

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -3485,6 +3485,35 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
       assert json == expected
     end
 
+    test "normalizes string arguments to a JSON object for tool_use input" do
+      # A ToolCall whose arguments never went through completion still holds a
+      # raw JSON string. It must be serialized as an object, not a string, or
+      # Anthropic rejects the request with "Input should be an object".
+      call = %ToolCall{
+        status: :incomplete,
+        type: :function,
+        call_id: "toolu_123",
+        name: "create_task",
+        arguments: ~s({"title":"x"})
+      }
+
+      assert %{"input" => %{"title" => "x"}} = ChatAnthropic.for_api(call)
+    end
+
+    test "normalizes empty-string arguments to an empty object for tool_use input" do
+      # `"" || %{}` is `""`, so an empty-string accumulation slips through the
+      # old guard. A zero-argument tool call must send an empty object.
+      call = %ToolCall{
+        status: :incomplete,
+        type: :function,
+        call_id: "toolu_123",
+        name: "ping",
+        arguments: ""
+      }
+
+      assert %{"input" => %{}} = ChatAnthropic.for_api(call)
+    end
+
     test "turns a tool result into expected JSON format" do
       tool_success_result = ToolResult.new!(%{tool_call_id: "toolu_123", content: "tool answer"})
 

--- a/test/message/tool_call_test.exs
+++ b/test/message/tool_call_test.exs
@@ -170,6 +170,25 @@ defmodule LangChain.Message.ToolCallTest do
     end
   end
 
+  describe "arguments_as_map/1" do
+    test "returns a map unchanged" do
+      call = %ToolCall{arguments: %{"a" => 1}}
+      assert ToolCall.arguments_as_map(call) == %{"a" => 1}
+    end
+
+    test "decodes a JSON-object string" do
+      call = %ToolCall{status: :incomplete, arguments: ~s({"title":"x"})}
+      assert ToolCall.arguments_as_map(call) == %{"title" => "x"}
+    end
+
+    test "returns an empty map for nil, empty, invalid, or non-object arguments" do
+      for arguments <- [nil, "", "not json", "[1, 2, 3]", "\"just a string\""] do
+        call = %ToolCall{status: :incomplete, arguments: arguments}
+        assert ToolCall.arguments_as_map(call) == %{}
+      end
+    end
+  end
+
   describe "merge/2" do
     test "takes new part when nothing existing found" do
       received = %ToolCall{


### PR DESCRIPTION
Closes #580

## Problem

When an assistant `Message` reaches a chat model with a `ToolCall` whose `arguments` is still a **string** (rather than a parsed map), the serialized request sends the tool input as a string and the provider rejects the whole request. On Anthropic:

```
messages.N.content.M.tool_use.input: Input should be an object
```

`ToolCall.arguments` is only parsed from string → map by `validate_and_parse_arguments/1`, which runs **only when `status: :complete`** (via `ToolCall.complete/1`). Any flow that puts a `ToolCall` into an outgoing message without going through that completion path still holds a string:

- a persisted/streamed tool call rehydrated as `status: :incomplete` (agent frameworks that serialize state and replay history)
- an interrupted stream where the `tool_use` JSON was truncated before `content_block_stop`
- a zero-argument tool call whose arguments accumulated as `""` rather than `"{}"`

Anthropic's `for_api/1` guarded this with `call.arguments || %{}`, but that only substitutes for `nil`/`false`. `"" || %{}` is `""`, and a non-empty JSON string is truthy, so the string was sent verbatim.

## Root cause is broader than Anthropic

`ChatGoogleAI` and `ChatVertexAI` have the **same passthrough** (`"args" => call.arguments`) and the same latent bug. (The OpenAI-family providers use `Jason.encode!/1`, a different code path, and are left unchanged.)

## Fix

Add a shared, documented `ToolCall.arguments_as_map/1` helper that normalizes any shape into a map:

- a map is returned unchanged
- a JSON-object string is decoded
- `nil`, empty string, and undecodable / non-object strings become `%{}`

and use it in the three providers that pass arguments straight through:

- `ChatAnthropic` — `tool_use.input`
- `ChatGoogleAI` / `ChatVertexAI` — `functionCall.args` (both the plain and `thoughtSignature` clauses)

Google and Vertex previously sent `args: nil` for zero-argument calls; they now send an empty object, which is the correct representation and consistent with the Anthropic behavior.

Backward compatible: maps pass through unchanged, so existing serialization is unaffected.

## Tests

- `ToolCall.arguments_as_map/1` unit tests + doctests covering map / JSON string / nil / empty / invalid / non-object.
- `ChatAnthropic.for_api/1` regression tests for a string-arguments call (→ object) and an empty-string call (→ empty object).
- Full suite green: `35 doctests, 2017 tests, 0 failures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)