### PR TITLE
Map Function strict flag and FunctionParam syntax in ChatReqLLM tools

### DIFF
--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -90,6 +90,7 @@ if Code.ensure_loaded?(ReqLLM) do
     alias LangChain.MessageDelta
     alias LangChain.TokenUsage
     alias LangChain.Function
+    alias LangChain.FunctionParam
     alias LangChain.Callbacks
     alias LangChain.Utils
 
@@ -895,17 +896,38 @@ if Code.ensure_loaded?(ReqLLM) do
 
     The stub callback is never invoked in normal LangChain operation — the tool
     definition is only used for schema generation (telling the LLM what tools exist).
+
+    The `:strict` flag is passed through so providers that support it (e.g. OpenAI
+    structured outputs) can enforce the parameter schema. Both the `:parameters`
+    (list of `LangChain.FunctionParam`) and `:parameters_schema` (raw JSONSchema
+    map) forms are supported, mirroring `LangChain.ChatModels.ChatOpenAI`.
     """
     @spec function_to_req_llm_tool(Function.t()) :: ReqLLM.Tool.t()
     def function_to_req_llm_tool(%Function{} = fun) do
-      schema = fun.parameters_schema || %{}
-
       ReqLLM.Tool.new!(
         name: fun.name,
         description: fun.description || "",
-        parameter_schema: schema,
+        parameter_schema: get_parameter_schema(fun),
+        strict: fun.strict,
         callback: fn _ -> {:ok, "stub"} end
       )
+    end
+
+    # Build the JSONSchema parameter map for a Function, supporting both the
+    # `:parameters` (FunctionParam list) and `:parameters_schema` (raw map) forms.
+    # Mirrors `LangChain.ChatModels.ChatOpenAI.get_parameters/1`.
+    @spec get_parameter_schema(Function.t()) :: map()
+    defp get_parameter_schema(%Function{parameters: [], parameters_schema: nil}) do
+      %{"type" => "object", "properties" => %{}}
+    end
+
+    defp get_parameter_schema(%Function{parameters: [], parameters_schema: schema})
+         when is_map(schema) do
+      schema
+    end
+
+    defp get_parameter_schema(%Function{parameters: params}) do
+      FunctionParam.to_parameters_schema(params)
     end
 
     defp media_to_mime(:png), do: "image/png"

--- a/test/chat_models/chat_req_llm_test.exs
+++ b/test/chat_models/chat_req_llm_test.exs
@@ -12,6 +12,7 @@ if Code.ensure_loaded?(ReqLLM) do
     alias LangChain.MessageDelta
     alias LangChain.TokenUsage
     alias LangChain.Function
+    alias LangChain.FunctionParam
     alias LangChain.LangChainError
 
     # The Anthropic-based req_llm model string for live tests
@@ -502,6 +503,89 @@ if Code.ensure_loaded?(ReqLLM) do
         assert tool.name == "get_weather"
         assert tool.description == "Get current weather"
         assert tool.parameter_schema == fun.parameters_schema
+      end
+
+      test "defaults strict to false when not set on the Function" do
+        fun =
+          Function.new!(%{
+            name: "get_weather",
+            description: "Get current weather",
+            function: fn _, _ -> {:ok, "sunny"} end
+          })
+
+        assert %ReqLLM.Tool{strict: false} = ChatReqLLM.function_to_req_llm_tool(fun)
+      end
+
+      test "passes strict: true through to the ReqLLM.Tool" do
+        fun =
+          Function.new!(%{
+            name: "get_weather",
+            description: "Get current weather",
+            strict: true,
+            parameters_schema: %{
+              "type" => "object",
+              "properties" => %{"city" => %{"type" => "string"}},
+              "required" => ["city"]
+            },
+            function: fn _, _ -> {:ok, "sunny"} end
+          })
+
+        assert %ReqLLM.Tool{strict: true} = ChatReqLLM.function_to_req_llm_tool(fun)
+      end
+
+      test "strict tool serializes with strict: true in OpenAI format" do
+        fun =
+          Function.new!(%{
+            name: "get_weather",
+            description: "Get current weather",
+            strict: true,
+            parameters_schema: %{
+              "type" => "object",
+              "properties" => %{"city" => %{"type" => "string"}},
+              "required" => ["city"]
+            },
+            function: fn _, _ -> {:ok, "sunny"} end
+          })
+
+        assert %{"function" => %{"strict" => true}} =
+                 fun
+                 |> ChatReqLLM.function_to_req_llm_tool()
+                 |> ReqLLM.Tool.to_schema(:openai)
+      end
+
+      test "maps a Function defined with FunctionParam list to a parameter schema" do
+        fun =
+          Function.new!(%{
+            name: "set_user_name",
+            description: "Sets the user name",
+            parameters: [
+              FunctionParam.new!(%{name: "user_name", type: :string, required: true})
+            ],
+            function: fn _, _ -> {:ok, "ok"} end
+          })
+
+        tool = ChatReqLLM.function_to_req_llm_tool(fun)
+
+        assert %ReqLLM.Tool{} = tool
+
+        assert %{
+                 "type" => "object",
+                 "properties" => %{"user_name" => %{"type" => "string"}},
+                 "required" => ["user_name"]
+               } = tool.parameter_schema
+      end
+
+      test "maps a Function with no parameters to an empty object schema" do
+        fun =
+          Function.new!(%{
+            name: "get_current_user_info",
+            description: "Returns current user info",
+            function: fn _, _ -> {:ok, "ok"} end
+          })
+
+        tool = ChatReqLLM.function_to_req_llm_tool(fun)
+
+        assert %{"type" => "object", "properties" => %{}} = tool.parameter_schema
       end
 
       test "stub callback returns {:ok, stub}" do


### PR DESCRIPTION
## Problem

`ChatReqLLM.function_to_req_llm_tool/1` only understood one of the two ways a `LangChain.Function` can declare its parameters. It read `fun.parameters_schema` (the raw JSONSchema map) directly and ignored `fun.parameters` — the validated `LangChain.FunctionParam` list form. Any tool defined with `FunctionParam` structs was handed to the LLM with an empty (or `nil`) schema. It also dropped `fun.strict` on the floor, so strict structured-output tool calling never reached the provider through the ReqLLM backend.

## Solution

Introduce a private `get_parameter_schema/1` in `ChatReqLLM` that pattern-matches the three parameter cases and produces a correct JSONSchema map in each, mirroring `LangChain.ChatModels.ChatOpenAI.get_parameters/1`:

- empty `:parameters` and `nil` `:parameters_schema` → `%{"type" => "object", "properties" => %{}}`
- empty `:parameters` with a raw `:parameters_schema` map → passthrough
- a `:parameters` list of `FunctionParam` structs → `FunctionParam.to_parameters_schema/1`

The tool builder now calls that helper for `parameter_schema` and also passes `strict: fun.strict` through to `ReqLLM.Tool.new!/1`, so providers that support it (e.g. OpenAI structured outputs) can enforce the schema. This brings the ReqLLM chat model to parity with `ChatOpenAI` for tool definitions.

## Changes

- `lib/chat_models/chat_req_llm.ex` — Added `get_parameter_schema/1` supporting both `:parameters` (FunctionParam list) and `:parameters_schema` (raw map) forms; pass `strict: fun.strict` through to the ReqLLM tool; alias `LangChain.FunctionParam`
- `lib/chat_models/chat_req_llm.ex` (@doc) — Documented the strict passthrough and dual parameter-form support on `function_to_req_llm_tool/1`
- `test/chat_models/chat_req_llm_test.exs` — Added coverage: strict defaults to false, strict: true passes through, strict serializes in OpenAI schema format, FunctionParam list maps to a schema, and no-params maps to an empty object schema

## Testing

Five new unit tests in `test/chat_models/chat_req_llm_test.exs` cover the strict passthrough (including `ReqLLM.Tool.to_schema(:openai)` serialization) and both parameter-declaration forms. No live API calls required.