### PR TITLE
Add `api_key: false` to omit x-api-key header on ChatAnthropic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`ChatAnthropic` accepts `api_key: false` to omit the `x-api-key` header.** When the Anthropic Messages endpoint is fronted by its own authentication — a corporate proxy, or an AWS SigV4-signed gateway such as Bedrock "Mantle" — sending `x-api-key` is rejected or ignored. Setting `api_key: false` now suppresses the header entirely so the caller's own auth (e.g. `req_opts` SigV4 signing) can take over. A `nil` or string `api_key` behaves exactly as before.
+
 ## v0.9.2
 
 A patch release that brings the `ChatReqLLM` backend to parity with `ChatOpenAI` for tool definitions. No breaking changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **`ChatAnthropic` accepts `api_key: false` to omit the `x-api-key` header.** When the Anthropic Messages endpoint is fronted by its own authentication — a corporate proxy, or an AWS SigV4-signed gateway such as Bedrock "Mantle" — sending `x-api-key` is rejected or ignored. Setting `api_key: false` now suppresses the header entirely so the caller's own auth (e.g. `req_opts` SigV4 signing) can take over. A `nil` or string `api_key` behaves exactly as before.
+- **`ChatAnthropic` accepts `suppress_api_key: true` to omit the `x-api-key` header.** When the Anthropic Messages endpoint is fronted by its own authentication — a corporate proxy, or an AWS SigV4-signed gateway such as Bedrock "Mantle" — sending `x-api-key` is rejected or ignored. Setting `suppress_api_key: true` suppresses the header entirely so the caller's own auth (e.g. `req_opts` SigV4 signing) can take over. Defaults to `false`, preserving existing behavior.
 
 ## v0.9.2
 

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -522,12 +522,14 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     # API key for Anthropic. If not set, will use global api key. Allows for usage
     # of a different API key per-call if desired. For instance, allowing a
     # customer to provide their own.
-    #
-    # Set to `false` to omit the `x-api-key` header entirely. This is useful when
-    # the endpoint is fronted by its own authentication mechanism (a corporate
-    # proxy, or an AWS SigV4-signed gateway, for example) and sending `x-api-key`
-    # would be rejected or ignored.
     field :api_key, :string, redact: true
+
+    # Omit the `x-api-key` header entirely. This is useful when the endpoint is
+    # fronted by its own authentication mechanism (a corporate proxy, or an AWS
+    # SigV4-signed gateway, for example) and sending `x-api-key` would be
+    # rejected or ignored. When true, no `x-api-key` header is sent regardless of
+    # `api_key` or the globally configured key.
+    field :suppress_api_key, :boolean, default: false
 
     # https://docs.anthropic.com/claude/reference/versions
     field :api_version, :string, default: "2023-06-01"
@@ -623,6 +625,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   @create_fields [
     :endpoint,
     :api_key,
+    :suppress_api_key,
     :api_version,
     :receive_timeout,
     :model,
@@ -650,29 +653,12 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   """
   @spec new(attrs :: map()) :: {:ok, t} | {:error, Ecto.Changeset.t()}
   def new(%{} = attrs \\ %{}) do
-    # `api_key: false` is a valid value meaning "send no x-api-key header", but
-    # Ecto's `:string` cast would reject the boolean. Pull it out before casting
-    # and set it directly with put_change (which bypasses type casting).
-    {api_key_override, attrs} = pop_api_key_false(attrs)
-
     %ChatAnthropic{}
     |> cast(attrs, @create_fields)
-    |> apply_api_key_override(api_key_override)
     |> cast_embed(:bedrock)
     |> common_validation()
     |> apply_action(:insert)
   end
-
-  defp pop_api_key_false(attrs) do
-    cond do
-      Map.get(attrs, :api_key) == false -> {false, Map.delete(attrs, :api_key)}
-      Map.get(attrs, "api_key") == false -> {false, Map.delete(attrs, "api_key")}
-      true -> {:none, attrs}
-    end
-  end
-
-  defp apply_api_key_override(changeset, false), do: put_change(changeset, :api_key, false)
-  defp apply_api_key_override(changeset, :none), do: changeset
 
   @doc """
   Setup a ChatAnthropic client configuration and return it or raise an error if invalid.
@@ -1161,6 +1147,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   defp headers(%ChatAnthropic{
          bedrock: nil,
          api_key: api_key,
+         suppress_api_key: suppress_api_key,
          api_version: api_version,
          beta_headers: beta_headers
        }) do
@@ -1168,7 +1155,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
       "content-type" => "application/json",
       "anthropic-version" => api_version
     }
-    |> maybe_put_api_key(api_key)
+    |> maybe_put_api_key(api_key, suppress_api_key)
     |> Utils.conditionally_add_to_map(
       "anthropic-beta",
       if(!Enum.empty?(beta_headers), do: Enum.join(beta_headers, ","))
@@ -1182,11 +1169,12 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     }
   end
 
-  # When `api_key: false`, omit the `x-api-key` header so the caller's own
-  # authentication (a proxy or SigV4-signed gateway, for example) can take over.
-  defp maybe_put_api_key(headers, false), do: headers
+  # When `suppress_api_key: true`, omit the `x-api-key` header so the caller's
+  # own authentication (a proxy or SigV4-signed gateway, for example) can take
+  # over.
+  defp maybe_put_api_key(headers, _api_key, true), do: headers
 
-  defp maybe_put_api_key(headers, api_key),
+  defp maybe_put_api_key(headers, api_key, false),
     do: Map.put(headers, "x-api-key", get_api_key(api_key))
 
   defp url(%ChatAnthropic{bedrock: nil} = anthropic) do

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -522,6 +522,11 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     # API key for Anthropic. If not set, will use global api key. Allows for usage
     # of a different API key per-call if desired. For instance, allowing a
     # customer to provide their own.
+    #
+    # Set to `false` to omit the `x-api-key` header entirely. This is useful when
+    # the endpoint is fronted by its own authentication mechanism (a corporate
+    # proxy, or an AWS SigV4-signed gateway, for example) and sending `x-api-key`
+    # would be rejected or ignored.
     field :api_key, :string, redact: true
 
     # https://docs.anthropic.com/claude/reference/versions
@@ -645,12 +650,29 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   """
   @spec new(attrs :: map()) :: {:ok, t} | {:error, Ecto.Changeset.t()}
   def new(%{} = attrs \\ %{}) do
+    # `api_key: false` is a valid value meaning "send no x-api-key header", but
+    # Ecto's `:string` cast would reject the boolean. Pull it out before casting
+    # and set it directly with put_change (which bypasses type casting).
+    {api_key_override, attrs} = pop_api_key_false(attrs)
+
     %ChatAnthropic{}
     |> cast(attrs, @create_fields)
+    |> apply_api_key_override(api_key_override)
     |> cast_embed(:bedrock)
     |> common_validation()
     |> apply_action(:insert)
   end
+
+  defp pop_api_key_false(attrs) do
+    cond do
+      Map.get(attrs, :api_key) == false -> {false, Map.delete(attrs, :api_key)}
+      Map.get(attrs, "api_key") == false -> {false, Map.delete(attrs, "api_key")}
+      true -> {:none, attrs}
+    end
+  end
+
+  defp apply_api_key_override(changeset, false), do: put_change(changeset, :api_key, false)
+  defp apply_api_key_override(changeset, :none), do: changeset
 
   @doc """
   Setup a ChatAnthropic client configuration and return it or raise an error if invalid.
@@ -1143,10 +1165,10 @@ defmodule LangChain.ChatModels.ChatAnthropic do
          beta_headers: beta_headers
        }) do
     %{
-      "x-api-key" => get_api_key(api_key),
       "content-type" => "application/json",
       "anthropic-version" => api_version
     }
+    |> maybe_put_api_key(api_key)
     |> Utils.conditionally_add_to_map(
       "anthropic-beta",
       if(!Enum.empty?(beta_headers), do: Enum.join(beta_headers, ","))
@@ -1159,6 +1181,13 @@ defmodule LangChain.ChatModels.ChatAnthropic do
       "accept" => "application/json"
     }
   end
+
+  # When `api_key: false`, omit the `x-api-key` header so the caller's own
+  # authentication (a proxy or SigV4-signed gateway, for example) can take over.
+  defp maybe_put_api_key(headers, false), do: headers
+
+  defp maybe_put_api_key(headers, api_key),
+    do: Map.put(headers, "x-api-key", get_api_key(api_key))
 
   defp url(%ChatAnthropic{bedrock: nil} = anthropic) do
     anthropic.endpoint

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -4169,6 +4169,36 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
     end
   end
 
+  describe "api_key: false" do
+    test "new!/1 accepts api_key: false" do
+      model = ChatAnthropic.new!(%{model: @test_model, api_key: false})
+      assert model.api_key == false
+    end
+
+    test "new/1 accepts a string-keyed \"api_key\" => false" do
+      assert {:ok, model} = ChatAnthropic.new(%{"model" => @test_model, "api_key" => false})
+      assert model.api_key == false
+    end
+
+    test "omits the x-api-key header when api_key is false" do
+      expect(Req, :post, fn req_struct, _opts ->
+        refute Map.has_key?(req_struct.headers, "x-api-key")
+      end)
+
+      model = ChatAnthropic.new!(%{stream: true, model: @test_model, api_key: false})
+      ChatAnthropic.call(model, "prompt", [])
+    end
+
+    test "sends the x-api-key header when an api_key string is provided" do
+      expect(Req, :post, fn req_struct, _opts ->
+        assert req_struct.headers["x-api-key"] == ["secret-key"]
+      end)
+
+      model = ChatAnthropic.new!(%{stream: true, model: @test_model, api_key: "secret-key"})
+      ChatAnthropic.call(model, "prompt", [])
+    end
+  end
+
   describe "cache_messages for multi-turn conversations" do
     test "when cache_messages is enabled, adds cache_control to last user message's last ContentPart" do
       anthropic = ChatAnthropic.new!(%{cache_messages: %{enabled: true}})

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -4169,27 +4169,41 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
     end
   end
 
-  describe "api_key: false" do
-    test "new!/1 accepts api_key: false" do
-      model = ChatAnthropic.new!(%{model: @test_model, api_key: false})
-      assert model.api_key == false
+  describe "suppress_api_key" do
+    test "defaults to false" do
+      model = ChatAnthropic.new!(%{model: @test_model})
+      assert model.suppress_api_key == false
     end
 
-    test "new/1 accepts a string-keyed \"api_key\" => false" do
-      assert {:ok, model} = ChatAnthropic.new(%{"model" => @test_model, "api_key" => false})
-      assert model.api_key == false
+    test "new!/1 accepts suppress_api_key: true" do
+      model = ChatAnthropic.new!(%{model: @test_model, suppress_api_key: true})
+      assert model.suppress_api_key == true
     end
 
-    test "omits the x-api-key header when api_key is false" do
+    test "new/1 accepts a string-keyed \"suppress_api_key\" => true" do
+      assert {:ok, model} =
+               ChatAnthropic.new(%{"model" => @test_model, "suppress_api_key" => true})
+
+      assert model.suppress_api_key == true
+    end
+
+    test "omits the x-api-key header when suppress_api_key is true" do
       expect(Req, :post, fn req_struct, _opts ->
         refute Map.has_key?(req_struct.headers, "x-api-key")
       end)
 
-      model = ChatAnthropic.new!(%{stream: true, model: @test_model, api_key: false})
+      model =
+        ChatAnthropic.new!(%{
+          stream: true,
+          model: @test_model,
+          api_key: "secret-key",
+          suppress_api_key: true
+        })
+
       ChatAnthropic.call(model, "prompt", [])
     end
 
-    test "sends the x-api-key header when an api_key string is provided" do
+    test "sends the x-api-key header when suppress_api_key is false" do
       expect(Req, :post, fn req_struct, _opts ->
         assert req_struct.headers["x-api-key"] == ["secret-key"]
       end)


### PR DESCRIPTION
## Motivation

Some deployments front the Anthropic Messages API with their own authentication rather than an Anthropic key — a corporate egress proxy, or an AWS SigV4-signed gateway such as Bedrock "Mantle". On the direct (non-`BedrockConfig`) `ChatAnthropic` path, `headers/1` unconditionally injects `x-api-key`, which those endpoints reject or ignore. There was no supported way to suppress it, so the only workaround was monkeypatching the dep at build time.

## Change

`api_key: false` now omits the `x-api-key` header entirely, letting the caller's own auth take over (for example, SigV4 signing supplied through `req_opts`). `nil` and string API keys behave exactly as before.

```elixir
# key fronted by SigV4-signed gateway — send no x-api-key
ChatAnthropic.new!(%{
  endpoint: "https://my-gateway.example.com/anthropic/v1/messages",
  model: "claude-sonnet-4-5",
  api_key: false,
  req_opts: [aws_sigv4: [...]]
})
```

Because `:api_key` is an Ecto `:string` field, `cast/3` would reject the boolean, so the `false` is pulled out of the attrs before casting and set via `put_change/3`. The `x-api-key`/`get_api_key` behavior is unchanged for every other value.

## Tests

Added a `describe "api_key: false"` block covering: `new!/1` and string-keyed `new/1` accepting `false`, the header being omitted when `false`, and still sent for a string key. Full `chat_anthropic_test.exs` suite passes (147 tests, 0 failures), formatted, no new compiler warnings.

## Notes

Happy to adjust the shape (naming, docs, or an alternative like an explicit `skip_api_key` field) if you'd prefer a different API — the goal is just a supported escape hatch for self-authenticated endpoints.