### PR TITLE
Fix ChatReqLLM dropping Anthropic thinking signatures on tool-loop replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`ChatReqLLM` now round-trips Anthropic extended-thinking signatures.** With thinking enabled, Anthropic requires assistant thinking blocks to be replayed with their original signature on tool-result continuations. The adapter lost the signature on the way in and on the way out: streaming never picked it up from the terminal `reasoning_details` meta chunk, non-streaming responses carry it on `message.reasoning_details` rather than the content part, and `content_part_to_req_llm/1` dropped `options[:signature]` on serialization. The result was a 400 (`thinking.signature: Field required`) on every thinking + tool-use turn. Signatures now survive both response paths and are passed back as part metadata; unsigned thinking blocks are omitted with a warning, same as `ChatAnthropic`.
+
 ### Added
 
 - **`ChatAnthropic` accepts `suppress_api_key: true` to omit the `x-api-key` header.** When the Anthropic Messages endpoint is fronted by its own authentication — a corporate proxy, or an AWS SigV4-signed gateway such as Bedrock "Mantle" — sending `x-api-key` is rejected or ignored. Setting `suppress_api_key: true` suppresses the header entirely so the caller's own auth (e.g. `req_opts` SigV4 signing) can take over. Defaults to `false`, preserving existing behavior.

--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -526,6 +526,38 @@ if Code.ensure_loaded?(ReqLLM) do
       {[delta], state}
     end
 
+    # The provider only surfaces the accumulated thinking signature in a
+    # terminal meta chunk; there is no signature StreamChunk. Attach it to
+    # the thinking content slot so the merged assistant message can be
+    # replayed with a signed thinking block during tool loops.
+    defp process_stream_chunk(
+           %ReqLLM.StreamChunk{type: :meta, metadata: %{reasoning_details: details}},
+           state
+         )
+         when is_list(details) do
+      signature =
+        Enum.find_value(details, fn
+          %{signature: signature} when is_binary(signature) and signature != "" -> signature
+          _ -> nil
+        end)
+
+      thinking_index = Map.get(state.type_index_map, :thinking)
+
+      if is_nil(signature) or is_nil(thinking_index) do
+        {[], state}
+      else
+        delta =
+          MessageDelta.new!(%{
+            role: :assistant,
+            content: ContentPart.new!(%{type: :thinking, options: [signature: signature]}),
+            status: :incomplete,
+            index: thinking_index
+          })
+
+        {[delta], state}
+      end
+    end
+
     # Tool call arg fragment: emit incomplete ToolCall delta with the partial JSON string.
     # ToolCall.merge/2 will concatenate binary arguments strings across deltas.
     defp process_stream_chunk(
@@ -823,8 +855,22 @@ if Code.ensure_loaded?(ReqLLM) do
       ReqLLM.Message.ContentPart.text(text || "")
     end
 
-    def content_part_to_req_llm(%ContentPart{type: :thinking, content: text}) do
-      ReqLLM.Message.ContentPart.thinking(text || "")
+    # Anthropic refuses replayed thinking blocks that lack their original
+    # signature ("thinking.signature: Field required"), which kills the
+    # tool loop. Do what ChatAnthropic does: pass the signature through,
+    # and drop unsigned blocks rather than send one the API will reject.
+    def content_part_to_req_llm(%ContentPart{type: :thinking, content: text} = part) do
+      case Keyword.fetch(part.options || [], :signature) do
+        {:ok, signature} when is_binary(signature) and signature != "" ->
+          ReqLLM.Message.ContentPart.thinking(text || "", %{signature: signature})
+
+        _ ->
+          Logger.warning(
+            "Thinking ContentPart without signature will be omitted: #{inspect(part)}"
+          )
+
+          nil
+      end
     end
 
     def content_part_to_req_llm(%ContentPart{type: :image_url, content: url}) do
@@ -968,7 +1014,11 @@ if Code.ensure_loaded?(ReqLLM) do
     end
 
     def do_process_response(%ChatReqLLM{} = _model, %ReqLLM.Response{} = response) do
-      content_parts = translate_response_content(response.message.content)
+      content_parts =
+        response.message.content
+        |> translate_response_content()
+        |> attach_reasoning_signature(response.message)
+
       tool_calls = translate_response_tool_calls(response.message.tool_calls)
       status = translate_finish_reason(response.finish_reason)
       usage = translate_usage(response.usage)
@@ -989,6 +1039,36 @@ if Code.ensure_loaded?(ReqLLM) do
     defp unwrap_message({:error, %Ecto.Changeset{} = changeset}) do
       {:error, LangChainError.exception(changeset)}
     end
+
+    # In non-streaming responses the signature lives on the message's
+    # reasoning_details, not on the thinking content part. Copy it over so
+    # tool-loop replays send a signed block.
+    defp attach_reasoning_signature(parts, %ReqLLM.Message{reasoning_details: details})
+         when is_list(details) do
+      signature =
+        Enum.find_value(details, fn
+          %{signature: signature} when is_binary(signature) and signature != "" -> signature
+          _ -> nil
+        end)
+
+      if is_nil(signature) do
+        parts
+      else
+        Enum.map(parts, fn
+          %ContentPart{type: :thinking, options: opts} = part ->
+            if Keyword.has_key?(opts || [], :signature) do
+              part
+            else
+              %ContentPart{part | options: Keyword.put(opts || [], :signature, signature)}
+            end
+
+          part ->
+            part
+        end)
+      end
+    end
+
+    defp attach_reasoning_signature(parts, _message), do: parts
 
     defp translate_response_content(nil), do: []
     defp translate_response_content([]), do: []

--- a/test/chat_models/chat_req_llm_test.exs
+++ b/test/chat_models/chat_req_llm_test.exs
@@ -295,10 +295,31 @@ if Code.ensure_loaded?(ReqLLM) do
         assert %ReqLLM.Message.ContentPart{type: :text, text: "Hello world"} = result
       end
 
-      test "translates :thinking ContentPart" do
-        part = ContentPart.new!(%{type: :thinking, content: "Let me think..."})
+      test "translates :thinking ContentPart with signature into metadata" do
+        part =
+          ContentPart.new!(%{
+            type: :thinking,
+            content: "Let me think...",
+            options: [signature: "SIG_DATA"]
+          })
+
         result = ChatReqLLM.content_part_to_req_llm(part)
-        assert %ReqLLM.Message.ContentPart{type: :thinking, text: "Let me think..."} = result
+
+        assert %ReqLLM.Message.ContentPart{
+                 type: :thinking,
+                 text: "Let me think...",
+                 metadata: %{signature: "SIG_DATA"}
+               } = result
+      end
+
+      test "omits :thinking ContentPart without signature" do
+        part = ContentPart.new!(%{type: :thinking, content: "Let me think..."})
+
+        {result, log} =
+          ExUnit.CaptureLog.with_log(fn -> ChatReqLLM.content_part_to_req_llm(part) end)
+
+        assert result == nil
+        assert log =~ "Thinking ContentPart without signature will be omitted"
       end
 
       test "translates :image_url ContentPart" do
@@ -648,6 +669,42 @@ if Code.ensure_loaded?(ReqLLM) do
         response = req_llm_text_response("Truncated...", :length)
         result = ChatReqLLM.do_process_response(model, response)
         assert result.status == :length
+      end
+
+      test "grafts the reasoning-details signature onto thinking content parts", %{model: model} do
+        response =
+          struct!(
+            ReqLLM.Response,
+            Map.merge(base_response_fields(), %{
+              message: %ReqLLM.Message{
+                role: :assistant,
+                content: [
+                  ReqLLM.Message.ContentPart.thinking("Let me reason..."),
+                  ReqLLM.Message.ContentPart.text("Answer")
+                ],
+                tool_calls: nil,
+                reasoning_details: [
+                  %ReqLLM.Message.ReasoningDetails{
+                    text: "Let me reason...",
+                    signature: "SIG_FROM_DETAILS",
+                    encrypted?: true,
+                    provider: :anthropic,
+                    format: "anthropic-thinking-v1",
+                    index: 0
+                  }
+                ]
+              },
+              finish_reason: :stop,
+              usage: nil
+            })
+          )
+
+        result = ChatReqLLM.do_process_response(model, response)
+
+        assert [%ContentPart{type: :thinking, options: opts}, %ContentPart{type: :text}] =
+                 result.content
+
+        assert opts[:signature] == "SIG_FROM_DETAILS"
       end
 
       test "maps token usage to message metadata", %{model: model} do


### PR DESCRIPTION
We hit this in production: with extended thinking enabled, every chat turn where Claude calls a tool fails. Turn 1 streams back a thinking block plus a tool_use. When the chain sends the follow-up request with the tool result, the assistant message gets replayed with its thinking block and Anthropic rejects it:

```
messages.1.content.0.thinking.signature: Field required
status: 400, type: invalid_request_error
```

Anthropic requires replayed thinking blocks to carry the signature from the original response. ChatReqLLM loses that signature at three points:

1. Streaming: req_llm accumulates `signature_delta` internally and only exposes it in a terminal meta chunk carrying `reasoning_details` (see agentjido/req_llm#343 and agentjido/req_llm#626). `process_stream_chunk/2` ignored that chunk, so the merged assistant message never had the signature.
2. Non-streaming: req_llm puts the signature on `message.reasoning_details`, not on the thinking content part, so `req_llm_content_part_to_lc/1` found no `metadata[:signature]` either.
3. Outbound: `content_part_to_req_llm/1` serialized thinking parts as bare text and dropped `options[:signature]` even when present.

Worth knowing why nobody noticed earlier: req_llm versions before 1.17.1 silently dropped thinking parts from outgoing Anthropic requests, which the API tolerates. 1.17.1 started encoding them properly, so the unsigned blocks began reaching Anthropic and thinking + tools stopped working entirely.

The fix follows what ChatAnthropic already does (#523 established the omit-unsigned behavior, and #431 did the same signature round-trip for Gemini): keep the signature in `options[:signature]` on the thinking ContentPart, pass it back as ReqLLM part metadata on serialization, and omit unsigned thinking blocks with a warning instead of sending one the API will refuse.

Covered by new unit tests, and verified against the live Anthropic API with thinking + tool call + continuation in both stream modes. We have been running this patch in production since 2026-07-21 with thinking re-enabled.