### PR TITLE
DataExtractionChain: option to return the raw LLM message

### DIFF
--- a/lib/chains/data_extraction_chain.ex
+++ b/lib/chains/data_extraction_chain.ex
@@ -68,6 +68,14 @@ defmodule LangChain.Chains.DataExtractionChain do
         }
       ]
 
+  Pass `return_message: true` to get back the last `Message` returned by the
+  LLM instead of the extracted result, e.g. to inspect token usage:
+
+      {:ok, last_message} =
+        LangChain.Chains.DataExtractionChain.run(chat, schema_parameters, data_prompt,
+          return_message: true
+        )
+
   The `schema_parameters` in the previous example can also be expressed using a
   list of `LangChain.FunctionParam` structs. An equivalent version looks like
   this:
@@ -117,11 +125,23 @@ Passage:
 
   @doc """
   Run the data extraction chain.
+
+  ## Options
+
+  - `:verbose` - when `true`, enables verbose logging on the underlying
+    `LLMChain`. Defaults to `false`.
+  - `:return_message` - when `true`, returns the last `Message` returned by
+    the LLM instead of the extracted result, e.g. to inspect token usage.
+    Defaults to `false` to preserve the existing return of the extracted
+    result.
   """
   @spec run(ChatOpenAI.t(), json_schema :: map(), prompt :: [any()], opts :: Keyword.t()) ::
-          {:ok, result :: [any()]} | {:error, LangChainError.t()}
+          {:ok, result :: [any()]}
+          | {:ok, last_message :: Message.t()}
+          | {:error, LangChainError.t()}
   def run(llm, json_schema, prompt, opts \\ []) do
     verbose = Keyword.get(opts, :verbose, false)
+    return_message = Keyword.get(opts, :return_message, false)
 
     try do
       messages =
@@ -142,17 +162,22 @@ Passage:
       |> case do
         {:ok,
          %LLMChain{
-           last_message: %Message{
-             role: :assistant,
-             tool_calls: [
-               %ToolCall{
-                 name: @function_name,
-                 arguments: %{"info" => info}
-               }
-             ]
-           }
+           last_message:
+             %Message{
+               role: :assistant,
+               tool_calls: [
+                 %ToolCall{
+                   name: @function_name,
+                   arguments: %{"info" => info}
+                 }
+               ]
+             } = last_message
          }} ->
-          normalize_extraction_info(info)
+          if return_message do
+            {:ok, last_message}
+          else
+            normalize_extraction_info(info)
+          end
 
         other ->
           {:error, LangChainError.exception("Unexpected response. #{inspect(other)}")}

--- a/test/chains/data_extraction_chain_test.exs
+++ b/test/chains/data_extraction_chain_test.exs
@@ -1,5 +1,6 @@
 defmodule LangChain.Chains.DataExtractionChainTest do
   use LangChain.BaseCase
+  use Mimic
 
   doctest LangChain.Chains.DataExtractionChain
 
@@ -7,6 +8,9 @@ defmodule LangChain.Chains.DataExtractionChainTest do
   alias LangChain.FunctionParam
   alias LangChain.Chains.DataExtractionChain
   alias LangChain.ChatModels.ChatOpenAI
+  alias LangChain.Message
+  alias LangChain.Message.ToolCall
+  alias LangChain.TokenUsage
 
   describe "build_extract_function/1" do
     test "parameters_schema is set correctly" do
@@ -72,6 +76,65 @@ defmodule LangChain.Chains.DataExtractionChainTest do
     test "returns error for non-list non-map info" do
       assert {:error, %LangChain.LangChainError{}} =
                DataExtractionChain.normalize_extraction_info("not a row")
+    end
+  end
+
+  describe "run/4 :return_message option" do
+    setup do
+      schema_parameters =
+        [FunctionParam.new!(%{name: "person_name", type: :string})]
+        |> FunctionParam.to_parameters_schema()
+
+      {:ok, chat} = ChatOpenAI.new(%{model: "gpt-4o-mini-2024-07-18", stream: false})
+
+      %{schema_parameters: schema_parameters, chat: chat}
+    end
+
+    test "returns the extracted result by default (non-breaking)", %{
+      schema_parameters: schema_parameters,
+      chat: chat
+    } do
+      fake_message =
+        Message.new_assistant!(%{
+          tool_calls: [
+            ToolCall.new!(%{
+              call_id: "call_123",
+              name: "information_extraction",
+              arguments: %{"info" => [%{"person_name" => "Alex"}]}
+            })
+          ]
+        })
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools -> {:ok, [fake_message]} end)
+
+      assert {:ok, [%{"person_name" => "Alex"}]} =
+               DataExtractionChain.run(chat, schema_parameters, "Alex is here.")
+    end
+
+    test "returns the last Message when true, exposing token usage via metadata", %{
+      schema_parameters: schema_parameters,
+      chat: chat
+    } do
+      fake_message =
+        Message.new_assistant!(%{
+          tool_calls: [
+            ToolCall.new!(%{
+              call_id: "call_123",
+              name: "information_extraction",
+              arguments: %{"info" => [%{"person_name" => "Alex"}]}
+            })
+          ],
+          metadata: %{usage: %TokenUsage{input: 42, output: 7}}
+        })
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools -> {:ok, [fake_message]} end)
+
+      assert {:ok, %Message{role: :assistant} = last_message} =
+               DataExtractionChain.run(chat, schema_parameters, "Alex is here.",
+                 return_message: true
+               )
+
+      assert TokenUsage.get(last_message) == %TokenUsage{input: 42, output: 7}
     end
   end
 


### PR DESCRIPTION
## Summary
Currently, there is need for me to inspect / log / report token usage for NER tasks.
This PR:
- Adds a `return_message: true` option to `DataExtractionChain.run/4` that returns the `Message` from the LLM (e.g. to extract the result myself or inspect token usage or do whatever I like) instead of returning just the extracted result.
- is non-breaking: defaults to `false`, so existing callers get the same `{:ok, result}` / `{:error, reason}` return as before.

