### PR TITLE
Expose the executed LLMChain from DataExtractionChain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- **`DataExtractionChain` exposes the executed `LLMChain` through `run_chain/4` and `extract_result/1`.** `run/4` returns only the extracted data, so there was no way to reach the underlying chain to log or report the token usage of an extraction. `run_chain/4` returns `{:ok, %LLMChain{}}` — matching how `RoutingChain`, `TextToTitleChain`, and `SummarizeConversationChain` already work — and `extract_result/1` pulls the extracted data out of it. Because the chain is returned regardless of whether the model produced the expected tool call, usage is reportable even when the extraction itself fails. `run/4` is unchanged and is now implemented in terms of the two.
 - **`ChatAnthropic` accepts `suppress_api_key: true` to omit the `x-api-key` header.** When the Anthropic Messages endpoint is fronted by its own authentication — a corporate proxy, or an AWS SigV4-signed gateway such as Bedrock "Mantle" — sending `x-api-key` is rejected or ignored. Setting `suppress_api_key: true` suppresses the header entirely so the caller's own auth (e.g. `req_opts` SigV4 signing) can take over. Defaults to `false`, preserving existing behavior.
 
 ## v0.9.2

--- a/lib/chains/data_extraction_chain.ex
+++ b/lib/chains/data_extraction_chain.ex
@@ -68,6 +68,18 @@ defmodule LangChain.Chains.DataExtractionChain do
         }
       ]
 
+  ## Accessing the LLMChain
+
+  `run/4` returns only the extracted data. When more than the data is needed,
+  for instance to log or report the token usage of the extraction, use
+  `run_chain/4` to get the executed `LangChain.Chains.LLMChain` and
+  `extract_result/1` to pull the data out of it:
+
+      {:ok, chain} = LangChain.Chains.DataExtractionChain.run_chain(chat, schema_parameters, data_prompt)
+
+      usage = LangChain.TokenUsage.get(chain.last_message)
+      {:ok, result} = LangChain.Chains.DataExtractionChain.extract_result(chain)
+
   The `schema_parameters` in the previous example can also be expressed using a
   list of `LangChain.FunctionParam` structs. An equivalent version looks like
   this:
@@ -116,43 +128,82 @@ Passage:
   end
 
   @doc """
-  Run the data extraction chain.
+  Run the data extraction chain and return the executed `LangChain.Chains.LLMChain`.
+
+  Use this instead of `run/4` when the chain itself is needed and not just the
+  extracted data. The chain gives access to the returned messages, token usage,
+  and everything else recorded during execution.
+
+      {:ok, chain} = DataExtractionChain.run_chain(chat, schema_parameters, data_prompt)
+
+      # inspect the token usage of the extraction
+      usage = LangChain.TokenUsage.get(chain.last_message)
+
+      # get the extracted data from the chain
+      {:ok, result} = DataExtractionChain.extract_result(chain)
+
+  Follows the same return pattern as `LangChain.Chains.LLMChain.run/2`.
+  """
+  @spec run_chain(ChatOpenAI.t(), json_schema :: map(), prompt :: [any()], opts :: Keyword.t()) ::
+          {:ok, LLMChain.t()} | {:error, LLMChain.t(), LangChainError.t()}
+  def run_chain(llm, json_schema, prompt, opts \\ []) do
+    verbose = Keyword.get(opts, :verbose, false)
+
+    messages =
+      [
+        Message.new_system!(
+          "You are a helpful assistant that extracts structured data from text passages. Only use the functions you have been provided with. Extract the data in a single tool use."
+        ),
+        PromptTemplate.new!(%{role: :user, text: @extraction_template})
+      ]
+      |> PromptTemplate.to_messages!(%{input: prompt})
+
+    %{llm: llm, verbose: verbose}
+    |> LLMChain.new!()
+    |> LLMChain.add_tools(build_extract_function(json_schema))
+    |> LLMChain.add_messages(messages)
+    |> LLMChain.run()
+  end
+
+  @doc """
+  Return the extracted data from an executed `LangChain.Chains.LLMChain` that
+  was run by `run_chain/4`.
+
+  Returns an error when the LLM did not respond with the expected extraction
+  tool call.
+  """
+  @spec extract_result(LLMChain.t()) :: {:ok, result :: [any()]} | {:error, LangChainError.t()}
+  def extract_result(%LLMChain{
+        last_message: %Message{
+          role: :assistant,
+          tool_calls: [
+            %ToolCall{
+              name: @function_name,
+              arguments: %{"info" => info}
+            }
+          ]
+        }
+      }) do
+    normalize_extraction_info(info)
+  end
+
+  def extract_result(%LLMChain{} = chain) do
+    {:error, LangChainError.exception("Unexpected response. #{inspect({:ok, chain})}")}
+  end
+
+  @doc """
+  Run the data extraction chain and return the extracted data.
+
+  When the executed chain is needed as well, for instance to report token usage,
+  use `run_chain/4` with `extract_result/1`.
   """
   @spec run(ChatOpenAI.t(), json_schema :: map(), prompt :: [any()], opts :: Keyword.t()) ::
           {:ok, result :: [any()]} | {:error, LangChainError.t()}
   def run(llm, json_schema, prompt, opts \\ []) do
-    verbose = Keyword.get(opts, :verbose, false)
-
     try do
-      messages =
-        [
-          Message.new_system!(
-            "You are a helpful assistant that extracts structured data from text passages. Only use the functions you have been provided with. Extract the data in a single tool use."
-          ),
-          PromptTemplate.new!(%{role: :user, text: @extraction_template})
-        ]
-        |> PromptTemplate.to_messages!(%{input: prompt})
-
-      {:ok, chain} = LLMChain.new(%{llm: llm, verbose: verbose})
-
-      chain
-      |> LLMChain.add_tools(build_extract_function(json_schema))
-      |> LLMChain.add_messages(messages)
-      |> LLMChain.run()
-      |> case do
-        {:ok,
-         %LLMChain{
-           last_message: %Message{
-             role: :assistant,
-             tool_calls: [
-               %ToolCall{
-                 name: @function_name,
-                 arguments: %{"info" => info}
-               }
-             ]
-           }
-         }} ->
-          normalize_extraction_info(info)
+      case run_chain(llm, json_schema, prompt, opts) do
+        {:ok, %LLMChain{} = chain} ->
+          extract_result(chain)
 
         other ->
           {:error, LangChainError.exception("Unexpected response. #{inspect(other)}")}

--- a/test/chains/data_extraction_chain_test.exs
+++ b/test/chains/data_extraction_chain_test.exs
@@ -1,12 +1,18 @@
 defmodule LangChain.Chains.DataExtractionChainTest do
   use LangChain.BaseCase
+  use Mimic
 
   doctest LangChain.Chains.DataExtractionChain
 
+  alias LangChain.Chains.LLMChain
   alias LangChain.Function
   alias LangChain.FunctionParam
   alias LangChain.Chains.DataExtractionChain
   alias LangChain.ChatModels.ChatOpenAI
+  alias LangChain.LangChainError
+  alias LangChain.Message
+  alias LangChain.Message.ToolCall
+  alias LangChain.TokenUsage
 
   describe "build_extract_function/1" do
     test "parameters_schema is set correctly" do
@@ -73,6 +79,124 @@ defmodule LangChain.Chains.DataExtractionChainTest do
       assert {:error, %LangChain.LangChainError{}} =
                DataExtractionChain.normalize_extraction_info("not a row")
     end
+  end
+
+  describe "extract_result/1" do
+    test "returns the extracted data from the chain's tool call" do
+      chain = chain_with_last_message(extraction_message())
+
+      assert {:ok, [%{"person_name" => "Alex"}]} = DataExtractionChain.extract_result(chain)
+    end
+
+    test "returns an error when the LLM did not make the extraction tool call" do
+      chain = chain_with_last_message(Message.new_assistant!(%{content: "I'm not sure."}))
+
+      assert {:error, %LangChainError{message: message}} =
+               DataExtractionChain.extract_result(chain)
+
+      assert message =~ "Unexpected response."
+    end
+  end
+
+  describe "run_chain/4" do
+    setup do
+      schema_parameters =
+        [FunctionParam.new!(%{name: "person_name", type: :string})]
+        |> FunctionParam.to_parameters_schema()
+
+      {:ok, chat} = ChatOpenAI.new(%{model: "gpt-4o-mini-2024-07-18", stream: false})
+
+      %{schema_parameters: schema_parameters, chat: chat}
+    end
+
+    test "returns the executed chain, exposing token usage", %{
+      schema_parameters: schema_parameters,
+      chat: chat
+    } do
+      message = extraction_message(%{usage: %TokenUsage{input: 42, output: 7}})
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools -> {:ok, [message]} end)
+
+      assert {:ok, %LLMChain{last_message: %Message{role: :assistant} = last_message} = chain} =
+               DataExtractionChain.run_chain(chat, schema_parameters, "Alex is here.")
+
+      assert TokenUsage.get(last_message) == %TokenUsage{input: 42, output: 7}
+      assert {:ok, [%{"person_name" => "Alex"}]} = DataExtractionChain.extract_result(chain)
+    end
+
+    test "returns the chain even when the LLM did not make the extraction tool call", %{
+      schema_parameters: schema_parameters,
+      chat: chat
+    } do
+      message =
+        Message.new_assistant!(%{
+          content: "I'm not sure.",
+          metadata: %{usage: %TokenUsage{input: 12, output: 3}}
+        })
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools -> {:ok, [message]} end)
+
+      assert {:ok, %LLMChain{last_message: last_message} = chain} =
+               DataExtractionChain.run_chain(chat, schema_parameters, "Alex is here.")
+
+      # the usage is still reportable even though the extraction failed
+      assert TokenUsage.get(last_message) == %TokenUsage{input: 12, output: 3}
+      assert {:error, %LangChainError{}} = DataExtractionChain.extract_result(chain)
+    end
+  end
+
+  describe "run/4" do
+    setup do
+      schema_parameters =
+        [FunctionParam.new!(%{name: "person_name", type: :string})]
+        |> FunctionParam.to_parameters_schema()
+
+      {:ok, chat} = ChatOpenAI.new(%{model: "gpt-4o-mini-2024-07-18", stream: false})
+
+      %{schema_parameters: schema_parameters, chat: chat}
+    end
+
+    test "returns the extracted result", %{schema_parameters: schema_parameters, chat: chat} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [extraction_message()]}
+      end)
+
+      assert {:ok, [%{"person_name" => "Alex"}]} =
+               DataExtractionChain.run(chat, schema_parameters, "Alex is here.")
+    end
+
+    test "returns an error when the LLM did not make the extraction tool call", %{
+      schema_parameters: schema_parameters,
+      chat: chat
+    } do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!(%{content: "I'm not sure."})]}
+      end)
+
+      assert {:error, %LangChainError{message: message}} =
+               DataExtractionChain.run(chat, schema_parameters, "Alex is here.")
+
+      assert message =~ "Unexpected response."
+    end
+  end
+
+  defp extraction_message(metadata \\ nil) do
+    Message.new_assistant!(%{
+      tool_calls: [
+        ToolCall.new!(%{
+          call_id: "call_123",
+          name: "information_extraction",
+          arguments: %{"info" => [%{"person_name" => "Alex"}]}
+        })
+      ],
+      metadata: metadata
+    })
+  end
+
+  defp chain_with_last_message(%Message{} = message) do
+    %{llm: ChatOpenAI.new!(%{model: "gpt-4o-mini-2024-07-18", stream: false})}
+    |> LLMChain.new!()
+    |> LLMChain.add_message(message)
   end
 
   # Extraction - https://js.langchain.com/docs/modules/chains/openai_functions/extraction


### PR DESCRIPTION
## Problem

`DataExtractionChain.run/4` returns only the extracted data. There is no way to reach the underlying `LLMChain`, so callers can't log or report the token usage of an extraction.

This was raised in #588 by @Chuukwudi, who needed token usage for NER tasks.

## Why not `return_message: true`

#588 solves it with a `return_message: true` option on `run/4`. That works and is non-breaking, but it makes the shape of the `{:ok, _}` return depend on a boolean flag, which flattens the typespec to effectively `{:ok, term()}` for every call site — including the ones that never pass the flag. It also only returns the message on the happy path where the extraction tool call matched, so usage is unreachable in exactly the failure case you'd most want to inspect.

## Approach

The other helper chains in this repo already have a shape for this: `run/N` returns the executed `LLMChain`, and a second function reduces it to the domain value.

| | returns the chain | returns the value |
|---|---|---|
| `RoutingChain` | `run/2` | `evaluate/2` |
| `TextToTitleChain` | `run/2` | `evaluate/2` |
| `SummarizeConversationChain` | `run/3` | `summarize/3`\* |
| `DataExtractionChain` (before) | — | `run/4` |

\* `summarize/3` folds the summary back into a conversation chain rather than returning a bare value, but `run/3` has the same return shape as the others.

This PR gives `DataExtractionChain` the missing half:

- **`run_chain/4`** returns `{:ok, %LLMChain{}} | {:error, %LLMChain{}, %LangChainError{}}`, matching `LLMChain.run/2`.
- **`extract_result/1`** pulls the extracted data out of an executed chain.
- **`run/4`** is unchanged in signature and return, and is now implemented as `run_chain/4 |> extract_result/1`, so the default path and the escape hatch cannot drift apart.

```elixir
{:ok, chain} = DataExtractionChain.run_chain(chat, schema_parameters, data_prompt)

usage = LangChain.TokenUsage.get(chain.last_message)
{:ok, result} = DataExtractionChain.extract_result(chain)
```

Because `run_chain/4` returns the chain whether or not the model produced the expected extraction tool call, token usage stays reportable even when the extraction itself fails.

The `try/rescue` stays on `run/4` only, wrapping the call to `run_chain/4`, so `run/4`'s existing error behavior is preserved. `run_chain/4` lets `PromptTemplate.to_messages!` and `LLMChain.new!` raise, consistent with `RoutingChain.run/2` and `TextToTitleChain.run/2`.

## Tests

Added unit tests (Mimic-mocked, no live calls) covering `extract_result/1` on both the matching and non-matching chain, `run_chain/4` returning usage in the success and the no-tool-call case, and `run/4`'s unchanged behavior.

Full suite: 35 doctests, 2035 tests, 0 failures. `mix format` clean, compiles with `--warnings-as-errors`.

> Note: `mix precommit` currently fails at `mix deps.audit` on `main` as well, due to advisories against `mint 1.7.1` (`< 1.9.0`). Unrelated to this change — flagging it separately.

## Alternative to #588

If this lands, #588 can be closed. Credit to @Chuukwudi for identifying the gap.
