### PR TITLE
Recover string tool-result content in ChatGoogleAI serialization

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -412,9 +412,11 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   end
 
   def for_api(%ToolResult{} = result) do
+    # `content` may be a string or a list of ContentParts. `content_to_string/1`
+    # accepts both, where `parts_to_string/1` requires a list.
     content_string =
       result.content
-      |> ContentPart.parts_to_string()
+      |> ContentPart.content_to_string()
 
     content =
       content_string

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -412,24 +412,13 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   end
 
   def for_api(%ToolResult{} = result) do
-    # `content` may be a string or a list of ContentParts. `content_to_string/1`
-    # accepts both, where `parts_to_string/1` requires a list.
-    content_string =
+    # `content` may be nil, a string, or a list of ContentParts.
+    # `content_to_string/1` accepts all three, where `parts_to_string/1`
+    # requires a list.
+    content =
       result.content
       |> ContentPart.content_to_string()
-
-    content =
-      content_string
-      |> Jason.decode()
-      |> case do
-        {:ok, data} ->
-          # content was converted through JSON
-          data
-
-        {:error, %Jason.DecodeError{}} ->
-          # assume the result is intended to be a string and return it as-is
-          %{"result" => content_string}
-      end
+      |> tool_result_response_for_api()
 
     # There is no explanation for why they want it nested like this. Odd.
     #
@@ -468,6 +457,24 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
 
   def for_api(%NativeTool{name: name, configuration: nil}) do
     name
+  end
+
+  # A tool result may carry no text at all: `content` can be nil, or a
+  # multi-modal ContentPart list holding only non-text parts. Send an empty
+  # object for those, matching ChatVertexAI, rather than handing nil to
+  # `Jason.decode/1`.
+  defp tool_result_response_for_api(nil), do: %{}
+
+  defp tool_result_response_for_api(content_string) when is_binary(content_string) do
+    case Jason.decode(content_string) do
+      {:ok, data} ->
+        # content was converted through JSON
+        data
+
+      {:error, %Jason.DecodeError{}} ->
+        # assume the result is intended to be a string and return it as-is
+        %{"result" => content_string}
+    end
   end
 
   @doc """

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -358,6 +358,50 @@ defmodule ChatModels.ChatGoogleAITest do
       assert expected == ChatGoogleAI.for_api(tool_result)
     end
 
+    test "tool result with no text content creates expected map" do
+      # A multi-modal tool result may carry no `:text` part at all. Reached
+      # through the normal `new!/1` constructor, so this is not limited to
+      # hand-built structs.
+      expected = %{
+        "functionResponse" => %{
+          "name" => "take_screenshot",
+          "response" => %{
+            "name" => "take_screenshot",
+            "content" => %{}
+          }
+        }
+      }
+
+      tool_result =
+        ToolResult.new!(%{
+          name: "take_screenshot",
+          tool_call_id: "call-take_screenshot",
+          content: [ContentPart.image!("base64data", media: :png)]
+        })
+
+      assert expected == ChatGoogleAI.for_api(tool_result)
+    end
+
+    test "tool result with nil content creates expected map" do
+      expected = %{
+        "functionResponse" => %{
+          "name" => "find_theaters",
+          "response" => %{
+            "name" => "find_theaters",
+            "content" => %{}
+          }
+        }
+      }
+
+      tool_result = %ToolResult{
+        name: "find_theaters",
+        tool_call_id: "call-find_theaters",
+        content: nil
+      }
+
+      assert expected == ChatGoogleAI.for_api(tool_result)
+    end
+
     test "adds safety settings to the request if present" do
       settings = [
         %{"category" => "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold" => "BLOCK_ONLY_HIGH"}

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -335,6 +335,29 @@ defmodule ChatModels.ChatGoogleAITest do
       assert expected == ChatGoogleAI.for_api(tool_result)
     end
 
+    test "tool result with a string content creates expected map" do
+      # `ToolResult.new!/1` migrates a string to ContentParts, but a struct
+      # built or updated directly can hold a plain string. Both are valid
+      # shapes for `content`.
+      expected = %{
+        "functionResponse" => %{
+          "name" => "find_theaters",
+          "response" => %{
+            "name" => "find_theaters",
+            "content" => %{"result" => "I don't know where the theaters are."}
+          }
+        }
+      }
+
+      tool_result = %ToolResult{
+        name: "find_theaters",
+        tool_call_id: "call-find_theaters",
+        content: "I don't know where the theaters are."
+      }
+
+      assert expected == ChatGoogleAI.for_api(tool_result)
+    end
+
     test "adds safety settings to the request if present" do
       settings = [
         %{"category" => "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold" => "BLOCK_ONLY_HIGH"}


### PR DESCRIPTION
Fixes #596.

`ToolResult.content` may be a string or a list of ContentParts. The moduledoc
states both shapes, `ContentPart.content_to_string/2` is typed for both, and
`ChatGoogleAI` itself already handles both for `:system` and `Message` content
through `when is_binary(content)` clauses.

Its `ToolResult` clause did not. It called `ContentPart.parts_to_string/1`,
which is guarded `when is_list(parts)`, so a string raised
`FunctionClauseError` while the request was being serialized.

`ToolResult.new/1` runs `Utils.migrate_to_content_parts/1`, which wraps a
string into a list, so a result built through the constructor never hit this. A
struct built directly, or an existing result updated with
`%ToolResult{r | content: "..."}`, keeps the string, and that is a supported
shape. The failure is persistent rather than transient: the raise happens while
serializing the conversation history, so once such a result is in the history,
every later turn fails the same way and the conversation cannot continue.

The fix uses `content_to_string/1`, which accepts nil, a string, or a list.
That is the same helper `ChatDeepSeek` and `ChatOllamaAI` already use on this
path, and it matches what `ChatAnthropic.content_parts_for_api/1` and
`ChatOrq.content_parts_to_string/1` do through an explicit `is_binary` clause.
I chose it over adding a separate `is_binary` clause because it is the accessor
written for this union, and it keeps the clause a single expression. Happy to
switch to an explicit clause if you prefer the `ChatAnthropic` style.

The regression test builds the `ToolResult` struct directly rather than through
`new!/1`, because the constructor's migration is exactly what hides the bug — a
test written the usual way passes against the unpatched code. It asserts the
string case produces the same map the equivalent ContentPart list produces. I
confirmed it fails with `FunctionClauseError` without the fix.

`ChatMistralAI`, `ChatOllamaAI`, and `ChatPerplexity` have `parts_to_string`
calls on paths that can receive a binary as well. I left them alone to keep
this PR to one provider, and can follow up on them separately if you want them
covered.
