### PR TITLE
Strip JSON-Schema keywords Gemini's function declarations reject

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -46,14 +46,16 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   [select subset](https://ai.google.dev/api/caching#Schema) of an OpenAPI 3.0
   schema object rather than full JSON Schema. Keywords outside that subset are
   rejected by the API with `Unknown name "<keyword>" ... Cannot find field`,
-  which fails the entire request rather than the single tool. This module
-  therefore removes those keywords from a tool's parameters before sending them.
+  which fails the entire request rather than the single tool. Tool parameters
+  and the JSON response schema are therefore passed through
+  `LangChain.Utils.GoogleSchema.sanitize/1` before being sent.
 
   One removal changes what the API enforces: `additionalProperties` is not
   supported, so an object schema that sets `additionalProperties: false` is
   still sent, but without it. Gemini does not reject unexpected properties, and
   a tool call's arguments may contain fields the schema did not declare. Where
-  that matters, validate the arguments inside the tool's own function.
+  that matters, validate the arguments inside the tool's own function. See
+  `LangChain.Utils.GoogleSchema` for the full list of removed keywords.
   """
   use Ecto.Schema
   require Logger
@@ -71,6 +73,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   alias LangChain.TokenUsage
   alias LangChain.LangChainError
   alias LangChain.Utils
+  alias LangChain.Utils.GoogleSchema
   alias LangChain.Callbacks
   alias LangChain.NativeTool
   alias LangChain.Message.Citation
@@ -243,7 +246,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     {response_mime_type, response_schema} =
       case google_ai.json_response do
         true ->
-          {"application/json", google_ai.json_schema}
+          {"application/json", GoogleSchema.sanitize(google_ai.json_schema)}
 
         false ->
           {nil, nil}
@@ -462,13 +465,13 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     encoded =
       %{
         "name" => function.name,
-        "parameters" => function |> ChatOpenAI.get_parameters() |> sanitize_parameters_schema()
+        "parameters" => function |> ChatOpenAI.get_parameters() |> GoogleSchema.sanitize()
       }
       |> Utils.conditionally_add_to_map("description", function.description)
 
     # For functions with no parameters, Google AI needs the parameters field removing, otherwise it will error
     # with "* GenerateContentRequest.tools[0].function_declarations[0].parameters.properties: should be non-empty for OBJECT type\n"
-    if encoded["parameters"] == %{"properties" => %{}, "type" => "object"} do
+    if GoogleSchema.empty_object?(encoded["parameters"]) do
       Map.delete(encoded, "parameters")
     else
       encoded
@@ -482,49 +485,6 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   def for_api(%NativeTool{name: name, configuration: nil}) do
     name
   end
-
-  # Keywords that are valid JSON Schema but are not fields of Google's `Schema`
-  # type. A function declaration carrying any of them is rejected outright with
-  # `Unknown name "<keyword>" at 'tools[0].function_declarations[0].parameters':
-  # Cannot find field.`, which fails the whole request rather than the one tool.
-  #
-  # `additionalProperties` is the one that matters most in practice, because
-  # `FunctionParam.to_parameters_schema/1` adds it to every generated schema.
-  @unsupported_schema_keywords ~w(
-    additionalProperties unevaluatedProperties patternProperties propertyNames
-    $schema $ref $defs $comment $id definitions
-    additionalItems prefixItems uniqueItems
-    dependencies dependentRequired dependentSchemas
-    const examples exclusiveMinimum exclusiveMaximum multipleOf
-    readOnly writeOnly deprecated
-    contentEncoding contentMediaType contentSchema
-  )
-
-  # Google's function declarations accept a select subset of an OpenAPI 3.0
-  # schema object, not full JSON Schema. See
-  # https://ai.google.dev/api/caching#Schema for the supported fields.
-  #
-  # Note the semantic loss: `additionalProperties: false` is dropped, so Gemini
-  # does not enforce closed objects and may return unexpected properties in a
-  # tool call's arguments. Validate in the tool itself where that matters.
-  defp sanitize_parameters_schema(%{} = schema) do
-    schema
-    |> Enum.reject(fn {key, _value} ->
-      to_string(key) in @unsupported_schema_keywords
-    end)
-    |> Map.new(fn {key, value} -> {key, sanitize_schema_value(value)} end)
-  end
-
-  defp sanitize_parameters_schema(schema), do: schema
-
-  # Recurse into the containers that hold nested schemas: `properties` maps a
-  # name to a schema, while `items` and `anyOf` hold schemas directly.
-  defp sanitize_schema_value(%{} = value), do: sanitize_parameters_schema(value)
-
-  defp sanitize_schema_value(value) when is_list(value),
-    do: Enum.map(value, &sanitize_schema_value/1)
-
-  defp sanitize_schema_value(value), do: value
 
   @doc """
   Calls the Google AI API passing the ChatGoogleAI struct with configuration, plus

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -39,6 +39,21 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   The above call will return the current Google stock price.
 
   When `google_search` is used, the model will also return grounding information in the metadata attribute of the assistant message.
+
+  **Tool Schemas**
+
+  Google's function declarations accept a
+  [select subset](https://ai.google.dev/api/caching#Schema) of an OpenAPI 3.0
+  schema object rather than full JSON Schema. Keywords outside that subset are
+  rejected by the API with `Unknown name "<keyword>" ... Cannot find field`,
+  which fails the entire request rather than the single tool. This module
+  therefore removes those keywords from a tool's parameters before sending them.
+
+  One removal changes what the API enforces: `additionalProperties` is not
+  supported, so an object schema that sets `additionalProperties: false` is
+  still sent, but without it. Gemini does not reject unexpected properties, and
+  a tool call's arguments may contain fields the schema did not declare. Where
+  that matters, validate the arguments inside the tool's own function.
   """
   use Ecto.Schema
   require Logger
@@ -447,7 +462,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     encoded =
       %{
         "name" => function.name,
-        "parameters" => ChatOpenAI.get_parameters(function)
+        "parameters" => function |> ChatOpenAI.get_parameters() |> sanitize_parameters_schema()
       }
       |> Utils.conditionally_add_to_map("description", function.description)
 
@@ -467,6 +482,49 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   def for_api(%NativeTool{name: name, configuration: nil}) do
     name
   end
+
+  # Keywords that are valid JSON Schema but are not fields of Google's `Schema`
+  # type. A function declaration carrying any of them is rejected outright with
+  # `Unknown name "<keyword>" at 'tools[0].function_declarations[0].parameters':
+  # Cannot find field.`, which fails the whole request rather than the one tool.
+  #
+  # `additionalProperties` is the one that matters most in practice, because
+  # `FunctionParam.to_parameters_schema/1` adds it to every generated schema.
+  @unsupported_schema_keywords ~w(
+    additionalProperties unevaluatedProperties patternProperties propertyNames
+    $schema $ref $defs $comment $id definitions
+    additionalItems prefixItems uniqueItems
+    dependencies dependentRequired dependentSchemas
+    const examples exclusiveMinimum exclusiveMaximum multipleOf
+    readOnly writeOnly deprecated
+    contentEncoding contentMediaType contentSchema
+  )
+
+  # Google's function declarations accept a select subset of an OpenAPI 3.0
+  # schema object, not full JSON Schema. See
+  # https://ai.google.dev/api/caching#Schema for the supported fields.
+  #
+  # Note the semantic loss: `additionalProperties: false` is dropped, so Gemini
+  # does not enforce closed objects and may return unexpected properties in a
+  # tool call's arguments. Validate in the tool itself where that matters.
+  defp sanitize_parameters_schema(%{} = schema) do
+    schema
+    |> Enum.reject(fn {key, _value} ->
+      to_string(key) in @unsupported_schema_keywords
+    end)
+    |> Map.new(fn {key, value} -> {key, sanitize_schema_value(value)} end)
+  end
+
+  defp sanitize_parameters_schema(schema), do: schema
+
+  # Recurse into the containers that hold nested schemas: `properties` maps a
+  # name to a schema, while `items` and `anyOf` hold schemas directly.
+  defp sanitize_schema_value(%{} = value), do: sanitize_parameters_schema(value)
+
+  defp sanitize_schema_value(value) when is_list(value),
+    do: Enum.map(value, &sanitize_schema_value/1)
+
+  defp sanitize_schema_value(value), do: value
 
   @doc """
   Calls the Google AI API passing the ChatGoogleAI struct with configuration, plus

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -36,6 +36,18 @@ defmodule LangChain.ChatModels.ChatVertexAI do
       |> LLMChain.run()
   The above call will return summary of the media content.
   ```
+
+  **Tool Schemas**
+
+  Vertex AI uses the same Gemini `Schema` type as
+  `LangChain.ChatModels.ChatGoogleAI`, which accepts a select subset of an
+  OpenAPI 3.0 schema object rather than full JSON Schema. Tool parameters and
+  the JSON response schema are passed through
+  `LangChain.Utils.GoogleSchema.sanitize/1` before being sent, which removes
+  the keywords the API has no field for. Note that dropping
+  `additionalProperties` means Vertex does not enforce closed objects, so
+  validate a tool call's arguments inside the tool's own function where that
+  matters.
   """
   use Ecto.Schema
   require Logger
@@ -51,6 +63,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
   alias LangChain.Message.ToolResult
   alias LangChain.LangChainError
   alias LangChain.Utils
+  alias LangChain.Utils.GoogleSchema
   alias LangChain.Callbacks
   alias LangChain.TokenUsage
   alias LangChain.NativeTool
@@ -197,7 +210,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     {response_mime_type, response_schema} =
       case vertex_ai.json_response do
         true ->
-          {"application/json", vertex_ai.json_schema}
+          {"application/json", GoogleSchema.sanitize(vertex_ai.json_schema)}
 
         false ->
           {nil, nil}
@@ -232,12 +245,30 @@ defmodule LangChain.ChatModels.ChatVertexAI do
             functions
             |> Enum.map(&ChatOpenAI.for_api(vertex_ai, &1))
             |> Enum.map(&Map.delete(&1, "strict"))
+            |> Enum.map(&function_declaration_for_api/1)
         }
       ])
     else
       req
     end
   end
+
+  # Vertex AI reaches the same Gemini `Schema` type as `ChatGoogleAI`, so a
+  # declaration carrying a keyword outside Google's subset is rejected the same
+  # way. Sanitize the parameters, then drop them entirely when nothing is left
+  # but an empty object, which Google also errors on with
+  # "parameters.properties: should be non-empty for OBJECT type".
+  defp function_declaration_for_api(%{"parameters" => parameters} = declaration) do
+    sanitized = GoogleSchema.sanitize(parameters)
+
+    if GoogleSchema.empty_object?(sanitized) do
+      Map.delete(declaration, "parameters")
+    else
+      Map.put(declaration, "parameters", sanitized)
+    end
+  end
+
+  defp function_declaration_for_api(declaration), do: declaration
 
   defp for_api(%Message{role: :assistant} = message) do
     content_parts = get_message_contents(message) || []

--- a/lib/utils/google_schema.ex
+++ b/lib/utils/google_schema.ex
@@ -1,0 +1,121 @@
+defmodule LangChain.Utils.GoogleSchema do
+  @moduledoc """
+  Removes JSON Schema keywords that Google's Gemini APIs reject.
+
+  Google's function declarations and response schemas accept a
+  [select subset](https://ai.google.dev/api/caching#Schema) of an OpenAPI 3.0
+  schema object rather than full JSON Schema. The `Schema` type is a protobuf
+  message, so a keyword it has no field for is rejected by the parser before
+  any semantic validation runs:
+
+      Invalid JSON payload received. Unknown name "additionalProperties" at
+      'tools[0].function_declarations[0].parameters': Cannot find field.
+
+  That fails the entire request, not the single tool, and the message names a
+  field path rather than the tool, so the cause is not obvious.
+
+  `additionalProperties` is the keyword that matters most in practice, because
+  `LangChain.FunctionParam.to_parameters_schema/1` adds it to every schema it
+  generates. Without this sanitizing step, any tool declared the ordinary way —
+  with a `parameters:` list of `LangChain.FunctionParam` structs — is rejected
+  by Gemini.
+
+  ## Semantic loss
+
+  One removal changes what the API enforces. Dropping `additionalProperties:
+  false` means Gemini does not reject unexpected properties, so a tool call's
+  arguments may contain fields the schema did not declare. Where that matters,
+  validate the arguments inside the tool's own function.
+
+  Schemas built around `$ref` are also flattened, since neither `$ref` nor
+  `$defs` has a Google equivalent. Inline such schemas before sending them.
+  """
+
+  # Keywords that are valid JSON Schema but are not fields of Google's `Schema`
+  # type. Supported keywords are deliberately not enumerated: a denylist lets a
+  # field Google adds later keep working instead of being silently dropped.
+  @unsupported_keywords ~w(
+    additionalProperties unevaluatedProperties patternProperties propertyNames
+    $schema $ref $defs $comment $id $anchor $dynamicRef $dynamicAnchor $vocabulary
+    definitions
+    additionalItems prefixItems unevaluatedItems uniqueItems
+    contains minContains maxContains
+    dependencies dependentRequired dependentSchemas
+    oneOf allOf not if then else
+    const examples exclusiveMinimum exclusiveMaximum multipleOf
+    readOnly writeOnly deprecated
+    contentEncoding contentMediaType contentSchema
+  )
+
+  # Keys whose values hold nested schemas. Recursion is limited to these
+  # because every other value is instance data — `enum` members, a `default`,
+  # an `example` — and filtering those would corrupt a value that happens to
+  # use a keyword as one of its own field names.
+  @schema_bearing_keys ~w(items anyOf)
+
+  @doc """
+  Remove the schema keywords Google does not support, recursing through nested
+  schemas.
+
+  Non-map input is returned unchanged, so this is safe to apply to a `nil`
+  response schema or a schema fragment that is a bare boolean.
+
+  ## Example
+
+      iex> LangChain.Utils.GoogleSchema.sanitize(%{
+      ...>   "type" => "object",
+      ...>   "additionalProperties" => false,
+      ...>   "properties" => %{"city" => %{"type" => "string"}}
+      ...> })
+      %{"type" => "object", "properties" => %{"city" => %{"type" => "string"}}}
+  """
+  @spec sanitize(map()) :: map()
+  @spec sanitize(any()) :: any()
+  def sanitize(%{} = schema) do
+    schema
+    |> Enum.reject(fn {key, _value} -> to_string(key) in @unsupported_keywords end)
+    |> Map.new(fn {key, value} -> {key, sanitize_value(to_string(key), value)} end)
+  end
+
+  def sanitize(schema), do: schema
+
+  # `properties` maps caller-chosen names to schemas. Its keys are property
+  # names rather than schema keywords, so only the values are sanitized. A
+  # parameter named `const` or `examples` has to survive.
+  defp sanitize_value("properties", %{} = properties) do
+    Map.new(properties, fn {name, sub_schema} -> {name, sanitize(sub_schema)} end)
+  end
+
+  # `items` holds a schema; `anyOf` holds a list of them.
+  defp sanitize_value(key, value) when key in @schema_bearing_keys do
+    sanitize_nested(value)
+  end
+
+  defp sanitize_value(_key, value), do: value
+
+  defp sanitize_nested(value) when is_list(value), do: Enum.map(value, &sanitize_nested/1)
+  defp sanitize_nested(%{} = value), do: sanitize(value)
+  defp sanitize_nested(value), do: value
+
+  @doc """
+  Return true when the schema describes an object with no properties.
+
+  Google rejects such a schema with "should be non-empty for OBJECT type", so a
+  function declaration that produces one has to omit its parameters entirely
+  rather than send an empty object.
+
+  ## Example
+
+      iex> LangChain.Utils.GoogleSchema.empty_object?(%{"type" => "object", "properties" => %{}})
+      true
+
+      iex> LangChain.Utils.GoogleSchema.empty_object?(%{"type" => "object", "properties" => %{"a" => %{}}})
+      false
+  """
+  @spec empty_object?(any()) :: boolean()
+  def empty_object?(%{"type" => "object", "properties" => properties})
+      when map_size(properties) == 0,
+      do: true
+
+  def empty_object?(_schema), do: false
+end

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -1853,6 +1853,93 @@ defmodule ChatModels.ChatGoogleAITest do
     end
   end
 
+  describe "tool schema compatibility with Google AI" do
+    @tag live_call: true, live_google_ai: true
+    @tag timeout: 180_000
+    test "accepts a tool declared with a FunctionParam list" do
+      # Regression test for the reported issue. `FunctionParam` generates
+      # `additionalProperties`, which Google's `Schema` type has no field for,
+      # so before sanitizing this failed the whole request with
+      # `Unknown name "additionalProperties" ... Cannot find field`.
+      #
+      # `const` is a parameter name that collides with a JSON Schema keyword,
+      # covering that property names survive sanitizing.
+      alias LangChain.Chains.LLMChain
+
+      test_pid = self()
+
+      function =
+        Function.new!(%{
+          name: "record_reading",
+          description: "Record a sensor reading.",
+          parameters: [
+            FunctionParam.new!(%{
+              name: "const",
+              type: :string,
+              description: "The sensor name.",
+              required: true
+            }),
+            FunctionParam.new!(%{
+              name: "value",
+              type: :integer,
+              description: "The reading value.",
+              required: true
+            })
+          ],
+          function: fn args, _context ->
+            send(test_pid, {:tool_called, args})
+            {:ok, "recorded"}
+          end
+        })
+
+      model = ChatGoogleAI.new!(%{temperature: 0, stream: false, model: "gemini-flash-latest"})
+
+      {:ok, updated_chain} =
+        %{llm: model, verbose: false, stream: false}
+        |> LLMChain.new!()
+        |> LLMChain.add_message(
+          Message.new_user!("Record a reading of 42 for the sensor named 'boiler'.")
+        )
+        |> LLMChain.add_tools(function)
+        |> LLMChain.run(mode: :while_needs_response)
+
+      assert %Message{role: :assistant} = updated_chain.last_message
+
+      # the parameter named `const` has to have survived the round trip
+      assert_received {:tool_called, %{"const" => "boiler", "value" => 42}}
+    end
+
+    @tag live_call: true, live_google_ai: true
+    @tag timeout: 180_000
+    test "accepts a response schema carrying unsupported keywords" do
+      model =
+        ChatGoogleAI.new!(%{
+          temperature: 0,
+          stream: false,
+          model: "gemini-flash-latest",
+          json_response: true,
+          json_schema: %{
+            "type" => "object",
+            "additionalProperties" => false,
+            "required" => ["color"],
+            "properties" => %{
+              "color" => %{"type" => "string", "description" => "A color name."}
+            }
+          }
+        })
+
+      {:ok, [%Message{} = message]} =
+        ChatGoogleAI.call(model, [
+          Message.new_user!("Respond with the color of a clear midday sky.")
+        ])
+
+      assert {:ok, %{"color" => color}} =
+               message.content |> ContentPart.content_to_string() |> Jason.decode()
+
+      assert is_binary(color)
+    end
+  end
+
   @tag live_call: true, live_google_ai: true
   test "image classification with Google AI model" do
     alias LangChain.Chains.LLMChain
@@ -2205,7 +2292,7 @@ defmodule ChatModels.ChatGoogleAITest do
       model =
         ChatGoogleAI.new!(%{
           stream: true,
-          model: "gemini-2.5-flash"
+          model: "gemini-2.0-flash"
         })
 
       expect(Req, :post, fn _req, _opts ->
@@ -2242,7 +2329,7 @@ defmodule ChatModels.ChatGoogleAITest do
         {:ok, %Req.Response{status: 200, headers: [], body: ""}}
       end)
 
-      model = ChatGoogleAI.new!(%{stream: true, model: "gemini-2.5-flash"})
+      model = ChatGoogleAI.new!(%{stream: true, model: "gemini-2.0-flash"})
 
       assert {:error, %LangChainError{} = error} =
                ChatGoogleAI.call(model, [Message.new_user!("Hello")])

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -511,10 +511,122 @@ defmodule ChatModels.ChatGoogleAITest do
                    }
                  },
                  "required" => ["city", "state"],
-                 "type" => "object",
-                 "additionalProperties" => false
+                 "type" => "object"
                }
              } == ChatGoogleAI.for_api(weather)
+    end
+
+    test "removes schema keywords Google does not support" do
+      # Google rejects the whole request with `Unknown name
+      # "additionalProperties" ... Cannot find field` when a declaration
+      # carries a keyword outside its supported subset.
+      {:ok, function} =
+        Function.new(%{
+          name: "record_answer",
+          description: "Record the answer.",
+          parameters_schema: %{
+            "type" => "object",
+            "additionalProperties" => false,
+            "$schema" => "http://json-schema.org/draft-07/schema#",
+            "required" => ["answer"],
+            "properties" => %{
+              "answer" => %{"type" => "string", "const" => "yes"}
+            }
+          },
+          function: fn _args, _context -> {:ok, "recorded"} end
+        })
+
+      assert %{
+               "description" => "Record the answer.",
+               "name" => "record_answer",
+               "parameters" => %{
+                 "type" => "object",
+                 "required" => ["answer"],
+                 "properties" => %{
+                   "answer" => %{"type" => "string"}
+                 }
+               }
+             } == ChatGoogleAI.for_api(function)
+    end
+
+    test "removes unsupported schema keywords from nested schemas" do
+      {:ok, function} =
+        Function.new(%{
+          name: "record_people",
+          description: "Record the people.",
+          parameters_schema: %{
+            "type" => "object",
+            "additionalProperties" => false,
+            "properties" => %{
+              "people" => %{
+                "type" => "array",
+                "items" => %{
+                  "type" => "object",
+                  "additionalProperties" => false,
+                  "properties" => %{
+                    "name" => %{"type" => "string"}
+                  }
+                }
+              }
+            }
+          },
+          function: fn _args, _context -> {:ok, "recorded"} end
+        })
+
+      assert %{
+               "parameters" => %{
+                 "type" => "object",
+                 "properties" => %{
+                   "people" => %{
+                     "type" => "array",
+                     "items" => %{
+                       "type" => "object",
+                       "properties" => %{"name" => %{"type" => "string"}}
+                     }
+                   }
+                 }
+               }
+             } = ChatGoogleAI.for_api(function)
+    end
+
+    test "keeps schema keywords Google supports" do
+      {:ok, function} =
+        Function.new(%{
+          name: "record_score",
+          description: "Record the score.",
+          parameters_schema: %{
+            "type" => "object",
+            "properties" => %{
+              "score" => %{
+                "type" => "integer",
+                "minimum" => 0,
+                "maximum" => 10,
+                "description" => "The score."
+              },
+              "label" => %{"type" => "string", "enum" => ["low", "high"], "nullable" => true}
+            }
+          },
+          function: fn _args, _context -> {:ok, "recorded"} end
+        })
+
+      assert %{
+               "parameters" => %{
+                 "type" => "object",
+                 "properties" => %{
+                   "score" => %{
+                     "type" => "integer",
+                     "minimum" => 0,
+                     "maximum" => 10,
+                     "description" => "The score."
+                   },
+                   "label" => %{
+                     "type" => "string",
+                     "enum" => ["low", "high"],
+                     "nullable" => true
+                   }
+                 }
+               }
+             } = ChatGoogleAI.for_api(function)
     end
 
     test "handles functions without parameters" do

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -141,6 +141,34 @@ defmodule ChatModels.ChatGoogleAITest do
              } = data
     end
 
+    test "removes unsupported schema keywords from the response_schema", %{params: params} do
+      # The response schema is the same Gemini `Schema` type as a function
+      # declaration's parameters, so it rejects the same keywords.
+      google_ai =
+        params
+        |> Map.merge(%{
+          "json_response" => true,
+          "json_schema" => %{
+            "type" => "object",
+            "additionalProperties" => false,
+            "properties" => %{
+              "answer" => %{"type" => "string", "const" => "yes"}
+            }
+          }
+        })
+        |> ChatGoogleAI.new!()
+
+      assert %{
+               "generationConfig" => %{
+                 "response_mime_type" => "application/json",
+                 "response_schema" => %{
+                   "type" => "object",
+                   "properties" => %{"answer" => %{"type" => "string"}}
+                 }
+               }
+             } = ChatGoogleAI.for_api(google_ai, [], [])
+    end
+
     test "generates a map containing function and function call messages", %{google_ai: google_ai} do
       message = "Can you do an action for me?"
       arguments = %{"args" => "data"}
@@ -624,6 +652,33 @@ defmodule ChatModels.ChatGoogleAITest do
                      "enum" => ["low", "high"],
                      "nullable" => true
                    }
+                 }
+               }
+             } = ChatGoogleAI.for_api(function)
+    end
+
+    test "keeps properties whose name matches an unsupported keyword" do
+      # `properties` maps caller-chosen names to schemas. A parameter named
+      # `const` or `examples` is a property name, not a schema keyword, and
+      # must survive.
+      {:ok, function} =
+        Function.new(%{
+          name: "record_config",
+          description: "Record the config.",
+          parameters: [
+            FunctionParam.new!(%{name: "const", type: :string, required: true}),
+            FunctionParam.new!(%{name: "examples", type: :string})
+          ],
+          function: fn _args, _context -> {:ok, "recorded"} end
+        })
+
+      assert %{
+               "parameters" => %{
+                 "type" => "object",
+                 "required" => ["const"],
+                 "properties" => %{
+                   "const" => %{"type" => "string"},
+                   "examples" => %{"type" => "string"}
                  }
                }
              } = ChatGoogleAI.for_api(function)

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -11,6 +11,7 @@ defmodule ChatModels.ChatVertexAITest do
   alias LangChain.Message.ToolResult
   alias LangChain.MessageDelta
   alias LangChain.Function
+  alias LangChain.FunctionParam
   alias LangChain.LangChainError
   alias LangChain.TokenUsage
 
@@ -769,15 +770,74 @@ defmodule ChatModels.ChatVertexAITest do
       assert %{"contents" => []} = data
       assert %{"tools" => [tool_call]} = data
 
+      # A function with no parameters omits the field entirely. Google rejects
+      # an empty OBJECT with "parameters.properties: should be non-empty for
+      # OBJECT type".
       assert %{
                "functionDeclarations" => [
                  %{
                    "name" => "hello_world",
-                   "description" => "Give a hello world greeting.",
-                   "parameters" => %{"properties" => %{}, "type" => "object"}
-                 }
+                   "description" => "Give a hello world greeting."
+                 } = declaration
                ]
              } = tool_call
+
+      refute Map.has_key?(declaration, "parameters")
+    end
+
+    test "removes schema keywords Google does not support from declarations", %{
+      vertex_ai: vertex_ai
+    } do
+      # Vertex AI reaches the same Gemini `Schema` type, so a declaration
+      # carrying `additionalProperties` fails the whole request with
+      # `Unknown name "additionalProperties" ... Cannot find field`.
+      {:ok, function} =
+        Function.new(%{
+          name: "get_weather",
+          description: "Get the weather.",
+          parameters: [
+            FunctionParam.new!(%{name: "city", type: :string, required: true})
+          ],
+          function: fn _args, _context -> {:ok, "75 degrees"} end
+        })
+
+      data = ChatVertexAI.for_api(vertex_ai, [], [function])
+
+      assert %{"tools" => [%{"functionDeclarations" => [declaration]}]} = data
+
+      assert %{
+               "name" => "get_weather",
+               "description" => "Get the weather.",
+               "parameters" => %{
+                 "type" => "object",
+                 "required" => ["city"],
+                 "properties" => %{"city" => %{"type" => "string"}}
+               }
+             } == declaration
+    end
+
+    test "removes unsupported schema keywords from the json response schema", %{
+      vertex_ai: vertex_ai
+    } do
+      vertex_ai = %{
+        vertex_ai
+        | json_response: true,
+          json_schema: %{
+            "type" => "object",
+            "additionalProperties" => false,
+            "properties" => %{"answer" => %{"type" => "string"}}
+          }
+      }
+
+      assert %{
+               "generationConfig" => %{
+                 "response_mime_type" => "application/json",
+                 "response_schema" => %{
+                   "type" => "object",
+                   "properties" => %{"answer" => %{"type" => "string"}}
+                 }
+               }
+             } = ChatVertexAI.for_api(vertex_ai, [], [])
     end
   end
 

--- a/test/utils/google_schema_test.exs
+++ b/test/utils/google_schema_test.exs
@@ -1,0 +1,201 @@
+defmodule LangChain.Utils.GoogleSchemaTest do
+  use ExUnit.Case
+  doctest LangChain.Utils.GoogleSchema
+
+  alias LangChain.Utils.GoogleSchema
+
+  describe "sanitize/1" do
+    test "removes keywords Google's Schema type has no field for" do
+      schema = %{
+        "type" => "object",
+        "additionalProperties" => false,
+        "$schema" => "http://json-schema.org/draft-07/schema#",
+        "unevaluatedProperties" => false,
+        "patternProperties" => %{"^x-" => %{"type" => "string"}},
+        "propertyNames" => %{"pattern" => "^[a-z]+$"},
+        "required" => ["answer"],
+        "properties" => %{"answer" => %{"type" => "string"}}
+      }
+
+      assert %{
+               "type" => "object",
+               "required" => ["answer"],
+               "properties" => %{"answer" => %{"type" => "string"}}
+             } == GoogleSchema.sanitize(schema)
+    end
+
+    test "removes the composition keywords Google does not support" do
+      schema = %{
+        "type" => "object",
+        "properties" => %{
+          "value" => %{
+            "type" => "string",
+            "oneOf" => [%{"const" => "a"}, %{"const" => "b"}],
+            "allOf" => [%{"minLength" => 1}],
+            "not" => %{"const" => ""},
+            "if" => %{"minLength" => 1},
+            "then" => %{"maxLength" => 5},
+            "else" => %{"maxLength" => 10}
+          }
+        }
+      }
+
+      assert %{"properties" => %{"value" => %{"type" => "string"}}} =
+               GoogleSchema.sanitize(schema)
+    end
+
+    test "keeps the keywords Google's Schema type declares" do
+      schema = %{
+        "type" => "integer",
+        "format" => "int32",
+        "title" => "Score",
+        "description" => "The score.",
+        "nullable" => true,
+        "minimum" => 0,
+        "maximum" => 10,
+        "default" => 5,
+        "example" => 7,
+        "pattern" => "^[0-9]+$",
+        "minLength" => 1,
+        "maxLength" => 2,
+        "propertyOrdering" => ["a", "b"]
+      }
+
+      assert schema == GoogleSchema.sanitize(schema)
+    end
+
+    test "recurses through properties, items, and anyOf" do
+      schema = %{
+        "type" => "object",
+        "additionalProperties" => false,
+        "properties" => %{
+          "people" => %{
+            "type" => "array",
+            "additionalProperties" => false,
+            "items" => %{
+              "type" => "object",
+              "additionalProperties" => false,
+              "properties" => %{"name" => %{"type" => "string", "const" => "x"}}
+            }
+          },
+          "either" => %{
+            "anyOf" => [
+              %{"type" => "string", "$ref" => "#/$defs/thing"},
+              %{"type" => "object", "additionalProperties" => false, "properties" => %{}}
+            ]
+          }
+        }
+      }
+
+      assert %{
+               "type" => "object",
+               "properties" => %{
+                 "people" => %{
+                   "type" => "array",
+                   "items" => %{
+                     "type" => "object",
+                     "properties" => %{"name" => %{"type" => "string"}}
+                   }
+                 },
+                 "either" => %{
+                   "anyOf" => [
+                     %{"type" => "string"},
+                     %{"type" => "object", "properties" => %{}}
+                   ]
+                 }
+               }
+             } == GoogleSchema.sanitize(schema)
+    end
+
+    test "keeps properties whose name matches an unsupported keyword" do
+      # `properties` maps caller-chosen names to schemas. A property named
+      # `const` is a property name, not a schema keyword.
+      schema = %{
+        "type" => "object",
+        "additionalProperties" => false,
+        "required" => ["const"],
+        "properties" => %{
+          "const" => %{"type" => "string"},
+          "examples" => %{"type" => "string"},
+          "not" => %{"type" => "boolean"},
+          "if" => %{"type" => "string", "additionalProperties" => false}
+        }
+      }
+
+      assert %{
+               "type" => "object",
+               "required" => ["const"],
+               "properties" => %{
+                 "const" => %{"type" => "string"},
+                 "examples" => %{"type" => "string"},
+                 "not" => %{"type" => "boolean"},
+                 "if" => %{"type" => "string"}
+               }
+             } == GoogleSchema.sanitize(schema)
+    end
+
+    test "leaves instance data untouched" do
+      # `enum` members, a `default`, and an `example` are values rather than
+      # schemas. Filtering them would corrupt data that happens to use a
+      # keyword as one of its own field names.
+      schema = %{
+        "type" => "object",
+        "properties" => %{
+          "settings" => %{
+            "type" => "object",
+            "default" => %{"additionalProperties" => true, "const" => "keep me"},
+            "example" => %{"$ref" => "not-a-reference"}
+          },
+          "choice" => %{
+            "type" => "string",
+            "enum" => ["const", "examples", "$ref"]
+          }
+        }
+      }
+
+      assert %{
+               "properties" => %{
+                 "settings" => %{
+                   "default" => %{"additionalProperties" => true, "const" => "keep me"},
+                   "example" => %{"$ref" => "not-a-reference"}
+                 },
+                 "choice" => %{"enum" => ["const", "examples", "$ref"]}
+               }
+             } = GoogleSchema.sanitize(schema)
+    end
+
+    test "handles atom keys" do
+      assert %{type: "object", properties: %{"a" => %{"type" => "string"}}} ==
+               GoogleSchema.sanitize(%{
+                 type: "object",
+                 additionalProperties: false,
+                 properties: %{"a" => %{"type" => "string"}}
+               })
+    end
+
+    test "passes through non-map input unchanged" do
+      assert nil == GoogleSchema.sanitize(nil)
+      assert true == GoogleSchema.sanitize(true)
+      assert "text" == GoogleSchema.sanitize("text")
+    end
+  end
+
+  describe "empty_object?/1" do
+    test "detects an object schema with no properties" do
+      assert GoogleSchema.empty_object?(%{"type" => "object", "properties" => %{}})
+
+      # extra keys do not stop Google from rejecting the empty object
+      assert GoogleSchema.empty_object?(%{
+               "type" => "object",
+               "properties" => %{},
+               "description" => "Takes nothing."
+             })
+    end
+
+    test "is false for anything else" do
+      refute GoogleSchema.empty_object?(%{"type" => "object", "properties" => %{"a" => %{}}})
+      refute GoogleSchema.empty_object?(%{"type" => "string"})
+      refute GoogleSchema.empty_object?(nil)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #598.

Google's function declarations accept a select subset of an OpenAPI 3.0 schema
object, not full JSON Schema. A declaration carrying a keyword outside that
subset is rejected by the API:

```
Invalid JSON payload received. Unknown name "additionalProperties" at
'tools[0].function_declarations[0].parameters': Cannot find field.
```

The error comes from the protobuf parser, before semantic validation, so it
fails the whole request rather than the single tool. Both `true` and `false`
are rejected — the parser fails on the unknown field name, so the value does
not matter.

`for_api/1` passed a `Function`'s parameters through unmodified. This affected
far more than schemas that set the keyword deliberately, because
`FunctionParam.to_parameters_schema/1` adds `"additionalProperties" => false`
to every schema it generates and recurses into nested objects and array items.
Any tool declared with the ordinary `parameters:` list form was therefore
rejected by Gemini. That injection came from #490, which fixed #440 for
Anthropic — Anthropic requires the keyword, Google refuses it, and Google was
not evaluated at the time.

This PR removes the unsupported keywords before sending, recursing through
`properties`, `items`, and `anyOf`. The list covers keywords Google's `Schema`
type has no field for. Supported ones — `minimum`, `maximum`, `enum`,
`nullable`, `title`, `pattern`, `default`, `format` — are kept. I used a
denylist rather than an allowlist of the supported fields so that a keyword
Google adds later keeps working instead of being silently dropped; if you would
rather have the stricter allowlist, that is an easy change.

Resolving the difference in the adapter follows what `ChatVertexAI` already
does for the same API family, where it strips `strict` as OpenAI-specific.

This also repairs the empty-parameters guard directly below the change. That
guard deletes `parameters` when the schema is empty, because Google errors on
an empty OBJECT, but it compares against a shape without
`additionalProperties`, so since #490 it had stopped matching what the
generator produces. Sanitizing first makes it fire again for functions declared
with `parameters: []`.

**One removal changes what the API enforces, and I want to be explicit about
it.** Without `additionalProperties`, Gemini does not reject unexpected
properties, so a tool call's arguments may contain fields the schema did not
declare. Callers who relied on that guarantee must validate inside the tool's
own function. The moduledoc states this rather than leaving it silent, since
otherwise the library would quietly claim an enforcement it no longer has. If
you would prefer a warning or an opt-out over a silent strip, say so and I will
add it.

Tests cover three cases: keywords removed from a hand-written
`parameters_schema`, removal from nested schemas, and — to guard against
over-stripping — that supported keywords survive untouched. The existing test
asserting `additionalProperties` reaches Google is updated, since that
assertion pinned the reported behavior.

`ChatVertexAI` reaches the same API through `ChatOpenAI.for_api/2` and has the
same gap. I left it out to keep this to one provider, and can extend the fix if
you want them handled together.

Finally, there may be a better fix than stripping. `v1beta` has a
`parametersJsonSchema` field on `FunctionDeclaration` that accepts full JSON
Schema, including `additionalProperties`, and is mutually exclusive with
`parameters`. That would fix this with no semantic loss. I did not take it
because the field does not exist in `v1` and `ChatGoogleAI` lets callers set
`api_version`, so it needs a version-conditional decision about which field to
emit — a design call that seemed yours rather than something to fold into a bug
fix. Happy to redo this on that shape if preferred.
