### PR TITLE
Accept string tool-result content in ChatOllamaAI serialization

### DIFF
--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -459,9 +459,11 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
   end
 
   def for_api(%ToolResult{content: content}) do
+    # `content` may be a string or a list of ContentParts. `content_to_string/1`
+    # accepts both, where `parts_to_string/1` requires a list.
     %{
       "role" => :tool,
-      "content" => ContentPart.parts_to_string(content)
+      "content" => ContentPart.content_to_string(content)
     }
   end
 

--- a/test/chat_models/chat_ollama_ai_test.exs
+++ b/test/chat_models/chat_ollama_ai_test.exs
@@ -512,6 +512,21 @@ defmodule ChatModels.ChatOllamaAITest do
       assert expected == ChatOllamaAI.for_api(message)
     end
 
+    test "for a tool result holding a string, generate expected structure" do
+      # `ToolResult.new!/1` migrates a string into ContentParts, but a struct
+      # built or updated directly keeps the string. Both are supported shapes
+      # for `content`, so this must match what the equivalent list produces.
+      tool_result = %Message.ToolResult{
+        type: :function,
+        tool_call_id: "call_123",
+        name: "give_greeting",
+        content: "Hello, world!"
+      }
+
+      expected = %{"role" => :tool, "content" => "Hello, world!"}
+      assert expected == ChatOllamaAI.for_api(tool_result)
+    end
+
     test "for user message, generate expected structure" do
       message = Message.new_user!("Hello!")
       expected = %{"role" => :user, "content" => "Hello!"}


### PR DESCRIPTION
Follow-up to #597, which fixed the same defect in `ChatGoogleAI`. `ChatOllamaAI` has it too, in the same place.

`ToolResult.content` may be a string or a list of ContentParts. The [`ToolResult` moduledoc](https://github.com/brainlid/langchain/blob/main/lib/message/tool_result.ex) states both shapes, and `ContentPart.content_to_string/2` is the accessor written for that union.

The `ToolResult` clause called `ContentPart.parts_to_string/1`, which is guarded `when is_list(parts)`, so a string raised while the request was being serialized:

```
** (FunctionClauseError) no function clause matching in LangChain.Message.ContentPart.parts_to_string/2

The following arguments were given to LangChain.Message.ContentPart.parts_to_string/2:

    # 1
    "Hello, world!"
    # 2
    :text

Attempted function clauses (showing 1 out of 1):

    def parts_to_string(parts, type) when is_list(parts)

(langchain) lib/message/content_part.ex:327
(langchain) lib/chat_models/chat_ollama_ai.ex:464
```

`ToolResult.new/1` runs `Utils.migrate_to_content_parts/1`, which wraps a string into a list, so a result built through the constructor never reached this. A struct built directly, or an existing result updated with `%ToolResult{r | content: "..."}`, keeps the string, and that is a supported shape. The failure is persistent rather than transient: the raise happens while serializing the conversation history, so once such a result is in the history, every later turn fails the same way and the conversation cannot continue.

## The fix

One call swapped for `ContentPart.content_to_string/1`, which accepts nil, a string, or a list. Same helper and same reasoning as #597.

Unlike `ChatGoogleAI`, there is no second crash hiding behind this one. Google piped the extracted text into `Jason.decode/1`, which raises on nil, so a text-less `content` needed handling too. Ollama passes the text straight through as the `content` value, so a `content` carrying no text already serialized to `"content" => nil` rather than raising. `content_to_string/1` preserves that exactly, which keeps this a true one-liner with no behavior change for the list path.

## Scope

The remaining `parts_to_string` calls were audited rather than assumed:

- `ChatOllamaAI`'s other calls are in `is_list`-guarded clause heads.
- `ChatMistralAI` and `ChatPerplexity` are safe. Every call is either in a guarded head or inside a `case` with an `is_binary` branch, and `content_for_tool_result/2` has explicit binary, list, and nil clauses.
- `ChatVertexAI` and `ChatOrq` already handle both shapes explicitly.

## Test

The regression test builds the `ToolResult` struct directly rather than through `new!/1`, because the constructor's migration is exactly what hides the bug. Written the usual way, the test passes against the unpatched code. It asserts the string case produces the same map the equivalent ContentPart list produces, which the neighboring test already pins.

Confirmed failing with `FunctionClauseError` without the fix. `mix precommit` is clean: 2121 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
