### PR TITLE
Report actionable errors for missing and misnamed tool arguments

### DIFF
--- a/lib/function.ex
+++ b/lib/function.ex
@@ -189,16 +189,43 @@ defmodule LangChain.Function do
 
   ## Parsing arguments before execution
 
-  LangChain's built-in `parameters: [%FunctionParam{}]` declaration only does a
-  required-key presence check at execute time. `parameters_schema:` is treated
-  as a hint sent to the LLM and is not enforced on the way back in. Provider
-  "strict mode" closes the gap somewhat, but is best-effort and varies by
-  provider.
+  Unless a `:parse_args` parser is supplied, both parameter declarations,
+  `parameters: [%FunctionParam{}]` and `parameters_schema:`, get a **top-level
+  required-key presence check** at execute time. Nothing else is enforced:
+  types, enums, formats, and nested object shapes are all passed through to the
+  tool as the LLM sent them. Provider "strict mode" closes that remaining gap
+  somewhat, but is best-effort and varies by provider.
 
-  The optional `:parse_args` callback fills this gap. It runs **after** the
-  built-in required-key check and **before** the user-supplied `function`. The
-  parser receives the raw, string-keyed arguments map from the LLM and returns
-  one of three shapes:
+  When the check fails, the returned error names the required parameters, the
+  missing ones, any unrecognized argument names that were sent, and the full
+  list of accepted parameters. This matters because a model that renames an
+  argument (sending `file_path` where the tool declared `path`) will otherwise
+  read a raw exception as a transient fault and retry the same call verbatim,
+  with each retry teaching itself the wrong calling convention.
+
+  ### `:parse_args` owns argument validation outright
+
+  The optional `:parse_args` callback replaces the built-in check rather than
+  layering on top of it. **When a parser is supplied, LangChain performs no
+  argument validation of its own**: the required-key check is skipped, and an
+  exception raised by the tool body is reported with its original formatting
+  instead of being reinterpreted as an argument-name problem.
+
+  This keeps one voice and one round trip. A parser such as `Zoi` reports
+  missing keys *and* type violations together in a single message, formatted
+  the way you wrote it, rather than having LangChain answer the missing-key
+  case in a different format and hide the rest until the next turn. It also
+  avoids second-guessing a parser that legitimately coerces keys or injects
+  defaults, since the arguments reaching the tool body no longer have to match
+  the declared schema.
+
+  The trade-off is that tools using a parser do not get LangChain's
+  "unrecognized parameter / did you mean" diagnostic. Parsers that want it can
+  build the same message from `required_param_names/1` and
+  `accepted_param_names/1`.
+
+  The parser runs **before** the user-supplied `function` and receives the raw,
+  string-keyed arguments map from the LLM. It returns one of three shapes:
 
       :ok                                # arguments are fine, hand them to `function` as-is
       {:ok, parsed_arguments :: map()}   # use these parsed/coerced arguments instead
@@ -237,6 +264,7 @@ defmodule LangChain.Function do
   import Ecto.Changeset
   require Logger
   alias __MODULE__
+  alias LangChain.FunctionParam
   alias LangChain.LangChainError
 
   @primary_key false
@@ -408,6 +436,114 @@ defmodule LangChain.Function do
     end
   end
 
+  @doc """
+  Return the names of the function's required top-level parameters.
+
+  Works for both declaration styles. For `parameters:` it reads the `required`
+  flag from each `LangChain.FunctionParam`. For `parameters_schema:` it reads
+  the schema's `required` list.
+
+  Returns `[]` when the function declares no parameters or declares none as
+  required.
+
+      iex> alias LangChain.{Function, FunctionParam}
+      iex> fun = Function.new!(%{
+      ...>   name: "demo",
+      ...>   function: fn _args, _context -> {:ok, "ok"} end,
+      ...>   parameters: [
+      ...>     FunctionParam.new!(%{name: "path", type: :string, required: true}),
+      ...>     FunctionParam.new!(%{name: "limit", type: :integer})
+      ...>   ]
+      ...> })
+      iex> Function.required_param_names(fun)
+      ["path"]
+  """
+  @spec required_param_names(t()) :: [String.t()]
+  def required_param_names(%Function{parameters: params})
+      when is_list(params) and params != [] do
+    FunctionParam.required_properties(params)
+  end
+
+  def required_param_names(%Function{parameters_schema: schema}) when is_map(schema) do
+    schema
+    |> schema_get(:required)
+    |> normalize_names()
+  end
+
+  def required_param_names(%Function{}), do: []
+
+  @doc """
+  Return the names of every top-level parameter the function accepts.
+
+  Works for both declaration styles. Returns `[]` when the function's
+  declaration doesn't enumerate its parameters, which happens for a
+  `parameters_schema:` without a `properties` map and for a function declaring
+  no parameters at all. Callers should treat `[]` as "unknown", not as "accepts
+  nothing", since an empty list carries no information about which argument
+  names are valid.
+
+      iex> alias LangChain.Function
+      iex> fun = Function.new!(%{
+      ...>   name: "demo",
+      ...>   function: fn _args, _context -> {:ok, "ok"} end,
+      ...>   parameters_schema: %{
+      ...>     type: "object",
+      ...>     properties: %{path: %{type: "string"}, limit: %{type: "integer"}},
+      ...>     required: ["path"]
+      ...>   }
+      ...> })
+      iex> fun |> Function.accepted_param_names() |> Enum.sort()
+      ["limit", "path"]
+  """
+  @spec accepted_param_names(t()) :: [String.t()]
+  def accepted_param_names(%Function{parameters: params})
+      when is_list(params) and params != [] do
+    Enum.map(params, & &1.name)
+  end
+
+  def accepted_param_names(%Function{parameters_schema: schema}) when is_map(schema) do
+    case schema_get(schema, :properties) do
+      properties when is_map(properties) ->
+        properties |> Map.keys() |> normalize_names()
+
+      _not_a_map ->
+        []
+    end
+  end
+
+  def accepted_param_names(%Function{}), do: []
+
+  # Schemas in the wild are written with atom keys as often as string keys.
+  # `LangChain.Tools.Calculator` uses atom keys for both the schema keys and the
+  # property names, while other schemas use strings throughout. Look for the
+  # atom first, then fall back to its string form.
+  @spec schema_get(map(), atom()) :: any()
+  defp schema_get(schema, key) when is_map(schema) and is_atom(key) do
+    case Map.fetch(schema, key) do
+      {:ok, value} -> value
+      :error -> Map.get(schema, Atom.to_string(key))
+    end
+  end
+
+  # Coerce a list of parameter names to strings, dropping anything that isn't
+  # name-shaped. Only converts atoms to strings, never the reverse, so nothing
+  # here can create atoms from LLM-supplied data.
+  @spec normalize_names(any()) :: [String.t()]
+  defp normalize_names(names) when is_list(names) do
+    Enum.flat_map(names, fn
+      name when is_binary(name) ->
+        [name]
+
+      name when is_atom(name) and not is_nil(name) and not is_boolean(name) ->
+        [Atom.to_string(name)]
+
+      _other ->
+        []
+    end)
+  end
+
+  defp normalize_names(_other), do: []
+
   # Validates that the function field contains a function with arity 2
   @spec validate_function_arity(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp validate_function_arity(changeset) do
@@ -481,7 +617,117 @@ defmodule LangChain.Function do
         "Function! #{function.name} failed in execution. Exception: #{LangChainError.format_exception(err, __STACKTRACE__)}"
       end)
 
-      {:error, "ERROR: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"}
+      case argument_error_message(err, function, fun, arguments) do
+        nil -> {:error, "ERROR: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"}
+        message -> {:error, message}
+      end
+  end
+
+  # The required-parameter check can't reach a tool that reads an *optional*
+  # argument with `Map.fetch!/2` or pattern-matches one in its head, so those
+  # still blow up here. Left alone, the model sees a stack frame from the tool's
+  # source and reads it as a transient system fault rather than as "you used the
+  # wrong argument name", and retries the identical call. Recognize the two
+  # exception shapes that mean exactly that and say so plainly instead.
+  #
+  # Returns nil for every other exception, leaving the existing formatting in
+  # place.
+  @spec argument_error_message(Exception.t(), t(), function(), arguments()) :: String.t() | nil
+  defp argument_error_message(_err, %Function{parse_args: parser}, _fun, _arguments)
+       when is_function(parser, 1) do
+    # The parser owns the argument contract. Two reasons to stay out of the way
+    # here: `arguments` at this point is the *parsed* map, which may have
+    # coerced keys or injected defaults that no longer match the declared
+    # schema, so calling a key "unrecognized" would be wrong. And if a parser
+    # approved the arguments and the body still can't read them, that is a bug
+    # in the tool rather than a mistake by the model -- a stack frame is the
+    # right signal for it.
+    nil
+  end
+
+  defp argument_error_message(%KeyError{term: term, key: key}, function, _fun, arguments)
+       when is_map(term) do
+    # Only when the KeyError is about the arguments map itself, not about some
+    # unrelated map the tool touched. `arguments` here is post-`:parse_args`,
+    # which is the same map handed to the tool body.
+    if term == arguments do
+      build_argument_error_message(function, arguments, key)
+    else
+      nil
+    end
+  end
+
+  defp argument_error_message(%FunctionClauseError{} = err, function, fun, arguments) do
+    # A tool declared as `def execute(%{"path" => path}, _context)` raises here
+    # when the argument name doesn't match. Confirm the clause error came from
+    # the declared tool function itself rather than from something it called.
+    if raised_by_tool_function?(err, fun) do
+      build_argument_error_message(function, arguments, nil)
+    else
+      nil
+    end
+  end
+
+  defp argument_error_message(_err, _function, _fun, _arguments), do: nil
+
+  @spec raised_by_tool_function?(FunctionClauseError.t(), function()) :: boolean()
+  defp raised_by_tool_function?(%FunctionClauseError{} = err, fun) when is_function(fun) do
+    info = Elixir.Function.info(fun)
+
+    # Match on identity rather than on `info[:type]`. A capture written inside
+    # the module that defines it reports `type: :local` even when the target is
+    # public, so `:external` would reject most real tools. An anonymous
+    # function reports a mangled name like :"-caps/0-fun-0-", which still
+    # matches when that same anonymous function is the one that failed to match
+    # its argument, and that is precisely the case worth reporting. Anything
+    # the tool merely *called* has a different module/name/arity and falls
+    # through.
+    err.module == info[:module] and
+      err.function == info[:name] and
+      err.arity == info[:arity]
+  end
+
+  defp raised_by_tool_function?(_err, _fun), do: false
+
+  @spec build_argument_error_message(t(), arguments(), any()) :: String.t() | nil
+  defp build_argument_error_message(%Function{} = function, arguments, missing_key) do
+    args = if is_map(arguments), do: arguments, else: %{}
+
+    case accepted_param_names(function) do
+      # Without a declared parameter list there is nothing useful to say. Fall
+      # back rather than assert the argument names were wrong when we have no
+      # idea which names are right.
+      [] ->
+        nil
+
+      accepted ->
+        unrecognized = unrecognized_arg_names(args, accepted)
+
+        lead =
+          cond do
+            unrecognized != [] ->
+              "The tool was called with an argument name it does not accept."
+
+            is_binary(missing_key) or is_atom(missing_key) ->
+              "The tool needs the #{inspect(missing_key)} argument, which was not provided."
+
+            true ->
+              "The tool could not read the arguments it was given."
+          end
+
+        details =
+          [
+            {"Accepted parameters", accepted},
+            {"Unrecognized parameters", describe_unrecognized(unrecognized, args, accepted)},
+            {"Received", args |> Map.keys() |> normalize_names() |> Enum.sort()}
+          ]
+          |> Enum.reject(fn {_label, values} -> values == [] end)
+          |> Enum.map_join(" ", fn {label, values} -> "#{label}: #{Enum.join(values, ", ")}." end)
+
+        # No stack frame. The tool's source location is noise to the model and
+        # leaks the calling project's file paths into the conversation.
+        "ERROR: #{lead} #{details}"
+    end
   end
 
   # Normalizes the various return types from function execution into consistent tagged tuples
@@ -527,48 +773,139 @@ defmodule LangChain.Function do
     {:error, "An unexpected response was returned from the tool."}
   end
 
-  # Validates that all required parameters are present in the arguments
+  # Validates that all required top-level parameters are present in the
+  # arguments. Applies to both the `parameters:` and `parameters_schema:`
+  # declaration styles.
+  #
+  # Unrecognized argument names are never grounds for rejection on their own;
+  # extra arguments are passed through to the tool as they always have been.
+  # They are only *named* in the error when a required parameter is already
+  # missing, which is exactly the situation a renamed argument produces.
   @spec validate_required_params(t(), arguments()) :: :ok | {:error, String.t()}
-  defp validate_required_params(%Function{parameters: params}, arguments)
-       when is_list(params) and params != [] do
-    params
-    |> collect_required_param_names()
-    |> find_missing_params(arguments)
-    |> format_missing_params_result()
+  defp validate_required_params(%Function{parse_args: parser}, _arguments)
+       when is_function(parser, 1) do
+    # A supplied parser owns argument validation outright. Answering the
+    # missing-key case here would split one tool's errors across two formats
+    # and would keep the parser from reporting missing keys and type
+    # violations together in a single round trip.
+    :ok
   end
 
-  defp validate_required_params(_function, _arguments), do: :ok
+  defp validate_required_params(%Function{} = function, arguments) do
+    # An LLM can hand back `nil` instead of an empty map for a no-argument
+    # call. Treat that as `%{}` rather than letting `Map.has_key?/2` raise a
+    # BadMapError that surfaces to the model as an internal error.
+    args = if is_map(arguments), do: arguments, else: %{}
 
-  # Extracts names of required parameters from the parameter list
-  @spec collect_required_param_names([struct()]) :: [String.t()]
-  defp collect_required_param_names(params) do
-    Enum.reduce(params, [], fn param, acc ->
-      if param.required, do: [param.name | acc], else: acc
+    case function |> required_param_names() |> Enum.reject(&Map.has_key?(args, &1)) do
+      [] -> :ok
+      missing -> {:error, format_missing_params_error(function, args, missing)}
+    end
+  end
+
+  @missing_params_error_intro "Missing required parameters for this tool."
+  @missing_params_error_outro "Ensure you're passing the correct parameter names as defined in the tool schema."
+
+  # Builds the model-facing message. The model reads this string as the tool's
+  # response, so it has to say what was wrong *and* what to send instead.
+  @spec format_missing_params_error(t(), arguments(), [String.t()]) :: String.t()
+  defp format_missing_params_error(%Function{} = function, arguments, missing) do
+    required = required_param_names(function)
+    accepted = accepted_param_names(function)
+    unrecognized = unrecognized_arg_names(arguments, accepted)
+
+    details =
+      [
+        {"Required parameters", required},
+        {"Missing parameters", missing},
+        {"Unrecognized parameters", describe_unrecognized(unrecognized, arguments, accepted)},
+        {"Accepted parameters", accepted}
+      ]
+      |> Enum.reject(fn {_label, values} -> values == [] end)
+      |> Enum.map_join("\n", fn {label, values} -> "#{label}: #{Enum.join(values, ", ")}" end)
+
+    Enum.join([@missing_params_error_intro, details, @missing_params_error_outro], "\n\n")
+  end
+
+  # Argument names the function doesn't declare. Returns `[]` when the accepted
+  # list is unknown, since we can't call a name unrecognized without knowing
+  # which names are recognized.
+  @spec unrecognized_arg_names(arguments(), [String.t()]) :: [String.t()]
+  defp unrecognized_arg_names(_arguments, []), do: []
+
+  defp unrecognized_arg_names(arguments, accepted) do
+    arguments
+    |> Map.keys()
+    |> normalize_names()
+    |> Enum.reject(&(&1 in accepted))
+    |> Enum.sort()
+  end
+
+  # Annotates each unrecognized name with the accepted name it most likely
+  # meant, when one is close enough.
+  @spec describe_unrecognized([String.t()], arguments(), [String.t()]) :: [String.t()]
+  defp describe_unrecognized(unrecognized, arguments, accepted) do
+    # Only suggest names the caller didn't already supply. A parameter that was
+    # correctly provided is never what a misnamed argument was reaching for.
+    candidates = Enum.reject(accepted, &Map.has_key?(arguments, &1))
+
+    Enum.map(unrecognized, fn name ->
+      case suggest_param_name(name, candidates) do
+        nil -> name
+        suggestion -> "#{name} (did you mean \"#{suggestion}\"?)"
+      end
     end)
   end
 
-  # Finds parameters that are required but missing from the arguments
-  @spec find_missing_params([String.t()], arguments()) :: [String.t()]
-  defp find_missing_params([], _arguments), do: []
+  # Jaro alone is not enough here. `String.jaro_distance("file_path", "path")`
+  # is 0.0: the matching window is `max(9, 4) / 2 - 1 = 3` and every character
+  # of "path" sits 5 positions away inside "file_path", so nothing matches.
+  # Renames of that shape (a qualifier added to or dropped from the front) are
+  # the common case, so containment is checked first and scored by how much of
+  # the longer name the shorter one accounts for.
+  @jaro_threshold 0.7
+  @min_containment_length 3
 
-  defp find_missing_params(required_names, arguments) do
-    Enum.reject(required_names, &Map.has_key?(arguments, &1))
+  @spec suggest_param_name(String.t(), [String.t()]) :: String.t() | nil
+  defp suggest_param_name(unknown, candidates) do
+    candidates
+    |> Enum.map(&{&1, name_similarity(unknown, &1)})
+    |> Enum.reject(fn {_candidate, score} -> score == 0.0 end)
+    |> case do
+      [] -> nil
+      scored -> scored |> Enum.max_by(fn {_candidate, score} -> score end) |> elem(0)
+    end
   end
 
-  # Formats the result based on whether any parameters are missing
-  @spec format_missing_params_result([String.t()]) :: :ok | {:error, String.t()}
-  defp format_missing_params_result([]), do: :ok
+  @spec name_similarity(String.t(), String.t()) :: float()
+  defp name_similarity(unknown, candidate) do
+    left = String.downcase(unknown)
+    right = String.downcase(candidate)
 
-  @missing_params_error_template """
-  Missing required parameters for this tool.
+    cond do
+      left == right ->
+        1.0
 
-  Required parameters: ~s
+      contains_name?(left, right) ->
+        {shorter, longer} =
+          if String.length(left) <= String.length(right), do: {left, right}, else: {right, left}
 
-  Ensure you're passing the correct parameter names as defined in the tool schema.
-  """
+        0.7 + 0.3 * (String.length(shorter) / String.length(longer))
 
-  defp format_missing_params_result(missing_params) do
-    expected = Enum.join(missing_params, ", ")
-    {:error, :io_lib.format(@missing_params_error_template, [expected]) |> IO.iodata_to_binary()}
+      true ->
+        case String.jaro_distance(left, right) do
+          score when score > @jaro_threshold -> score
+          _too_far -> 0.0
+        end
+    end
+  end
+
+  # Containment only counts when the shorter name is substantial. Without the
+  # floor, a single-character parameter would be a substring of nearly every
+  # argument name and would win every suggestion.
+  @spec contains_name?(String.t(), String.t()) :: boolean()
+  defp contains_name?(left, right) do
+    min(String.length(left), String.length(right)) >= @min_containment_length and
+      (String.contains?(left, right) or String.contains?(right, left))
   end
 end

--- a/lib/function.ex
+++ b/lib/function.ex
@@ -371,8 +371,14 @@ defmodule LangChain.Function do
   def execute(%Function{function: fun} = function, arguments, context) do
     Logger.debug("Executing function #{inspect(function.name)}")
 
-    with :ok <- validate_required_params(function, arguments),
-         {:ok, parsed_arguments} <- run_parse_args(function, arguments) do
+    # An LLM can hand back `nil` instead of an empty map for a no-argument
+    # call. Normalize once, here, so everything downstream can rely on being
+    # given a map: the required-key check, any `:parse_args` parser, and the
+    # tool body itself.
+    args = if is_map(arguments), do: arguments, else: %{}
+
+    with :ok <- validate_required_params(function, args),
+         {:ok, parsed_arguments} <- run_parse_args(function, args) do
       execute_with_error_handling(function, fun, parsed_arguments, context)
     end
   end
@@ -670,7 +676,9 @@ defmodule LangChain.Function do
 
   defp argument_error_message(_err, _function, _fun, _arguments), do: nil
 
-  @spec raised_by_tool_function?(FunctionClauseError.t(), function()) :: boolean()
+  # `defexception` doesn't generate a `t/0`, so `FunctionClauseError.t()` is an
+  # unknown type to dialyzer. The struct literal expresses the same constraint.
+  @spec raised_by_tool_function?(%FunctionClauseError{}, function()) :: boolean()
   defp raised_by_tool_function?(%FunctionClauseError{} = err, fun) when is_function(fun) do
     info = Elixir.Function.info(fun)
 
@@ -691,8 +699,6 @@ defmodule LangChain.Function do
 
   @spec build_argument_error_message(t(), arguments(), any()) :: String.t() | nil
   defp build_argument_error_message(%Function{} = function, arguments, missing_key) do
-    args = if is_map(arguments), do: arguments, else: %{}
-
     case accepted_param_names(function) do
       # Without a declared parameter list there is nothing useful to say. Fall
       # back rather than assert the argument names were wrong when we have no
@@ -701,7 +707,7 @@ defmodule LangChain.Function do
         nil
 
       accepted ->
-        unrecognized = unrecognized_arg_names(args, accepted)
+        unrecognized = unrecognized_arg_names(arguments, accepted)
 
         lead =
           cond do
@@ -718,8 +724,8 @@ defmodule LangChain.Function do
         details =
           [
             {"Accepted parameters", accepted},
-            {"Unrecognized parameters", describe_unrecognized(unrecognized, args, accepted)},
-            {"Received", args |> Map.keys() |> normalize_names() |> Enum.sort()}
+            {"Unrecognized parameters", describe_unrecognized(unrecognized, arguments, accepted)},
+            {"Received", arguments |> Map.keys() |> normalize_names() |> Enum.sort()}
           ]
           |> Enum.reject(fn {_label, values} -> values == [] end)
           |> Enum.map_join(" ", fn {label, values} -> "#{label}: #{Enum.join(values, ", ")}." end)
@@ -792,14 +798,9 @@ defmodule LangChain.Function do
   end
 
   defp validate_required_params(%Function{} = function, arguments) do
-    # An LLM can hand back `nil` instead of an empty map for a no-argument
-    # call. Treat that as `%{}` rather than letting `Map.has_key?/2` raise a
-    # BadMapError that surfaces to the model as an internal error.
-    args = if is_map(arguments), do: arguments, else: %{}
-
-    case function |> required_param_names() |> Enum.reject(&Map.has_key?(args, &1)) do
+    case function |> required_param_names() |> Enum.reject(&Map.has_key?(arguments, &1)) do
       [] -> :ok
-      missing -> {:error, format_missing_params_error(function, args, missing)}
+      missing -> {:error, format_missing_params_error(function, arguments, missing)}
     end
   end
 

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -3606,6 +3606,53 @@ defmodule LangChain.Chains.LLMChainTest do
       :telemetry.detach("parse-args-telemetry-test")
     end
 
+    test "a renamed argument produces an error ToolResult naming the parameter it meant" do
+      # The message the model actually reads is the ToolResult content. For
+      # every provider except Anthropic, `is_error` never reaches the wire, so
+      # this string is the only signal distinguishing "you used the wrong
+      # argument name" from "the system broke, retry".
+      parent = self()
+
+      tool =
+        Function.new!(%{
+          name: "read_document",
+          description: "Read a document.",
+          parameters_schema: %{
+            type: "object",
+            properties: %{
+              path: %{type: "string"},
+              offset: %{type: "integer"}
+            },
+            required: ["path"]
+          },
+          function: fn _args, _ctx ->
+            send(parent, :function_body_ran)
+            {:ok, "should not reach this"}
+          end
+        })
+
+      chain =
+        LLMChain.new!(%{llm: ChatOpenAI.new!(%{stream: false})})
+        |> LLMChain.add_tools(tool)
+        |> LLMChain.add_message(Message.new_user!("read the doc"))
+        |> LLMChain.add_message(
+          new_function_call!("call_renamed", "read_document", ~s({"file_path": "/a.md"}))
+        )
+
+      updated_chain = LLMChain.execute_tool_calls(chain)
+
+      refute_received :function_body_ran
+
+      assert %Message{role: :tool} = result_message = updated_chain.last_message
+      assert [%ToolResult{} = result] = result_message.tool_results
+      assert result.is_error == true
+
+      assert [%ContentPart{type: :text, content: content}] = result.content
+      assert content =~ "Missing parameters: path"
+      assert content =~ "Unrecognized parameters: file_path (did you mean \"path\"?)"
+      assert content =~ "Accepted parameters:"
+    end
+
     test "returns error tool result when tool_call is a hallucination" do
       chain =
         LLMChain.new!(%{

--- a/test/function_parse_args_zoi_test.exs
+++ b/test/function_parse_args_zoi_test.exs
@@ -87,4 +87,49 @@ defmodule LangChain.FunctionParseArgsZoiTest do
       assert reason == "device_task_id: too small: must have at least 1 character(s)"
     end
   end
+
+  describe "Zoi alongside a parameters_schema declaration" do
+    # The realistic wiring: the schema is declared so the LLM sees it, and Zoi
+    # validates what comes back. LangChain must not answer any of these itself,
+    # or the tool would speak in two different error formats depending on which
+    # kind of mistake the model made.
+    defp function_with_schema do
+      Function.new!(%{
+        name: "diagnose_device_task",
+        parameters_schema: %{
+          type: "object",
+          properties: %{device_task_id: %{type: "string"}},
+          required: ["device_task_id"]
+        },
+        function: &echo_args/2,
+        parse_args: &parse_args/1
+      })
+    end
+
+    test "Zoi answers a missing required key, not the built-in check" do
+      assert {:error, reason} = Function.execute(function_with_schema(), %{}, nil)
+      assert reason == "device_task_id: is required"
+      refute reason =~ "Missing required parameters"
+    end
+
+    test "Zoi answers a renamed argument, not the built-in check" do
+      assert {:error, reason} =
+               Function.execute(function_with_schema(), %{"task_id" => "dt-42"}, nil)
+
+      assert reason == "device_task_id: is required"
+      refute reason =~ "Unrecognized parameters"
+    end
+
+    test "Zoi answers a constraint violation" do
+      assert {:error, reason} =
+               Function.execute(function_with_schema(), %{"device_task_id" => ""}, nil)
+
+      assert reason == "device_task_id: too small: must have at least 1 character(s)"
+    end
+
+    test "valid arguments still reach the body coerced" do
+      assert {:ok, _llm, %{device_task_id: "dt-42"}} =
+               Function.execute(function_with_schema(), %{"device_task_id" => "dt-42"}, nil)
+    end
+  end
 end

--- a/test/function_test.exs
+++ b/test/function_test.exs
@@ -4,6 +4,7 @@ defmodule LangChain.FunctionTest do
   doctest LangChain.Function
 
   alias LangChain.Function
+  alias LangChain.FunctionParam
   alias LangChain.Message.ContentPart
 
   defp hello_world(_args, _context) do
@@ -140,7 +141,7 @@ defmodule LangChain.FunctionTest do
 
       assert result ==
                {:error,
-                "ERROR: (RuntimeError) fake exception at test/function_test.exs:14: LangChain.FunctionTest.returns_context/2"}
+                "ERROR: (RuntimeError) fake exception at test/function_test.exs:15: LangChain.FunctionTest.returns_context/2"}
 
       # returns an error when anything else is returned
       result = Function.execute(function, %{}, %{result: 123})
@@ -241,7 +242,9 @@ defmodule LangChain.FunctionTest do
       assert result == {:ok, "SUCCESS"}
     end
 
-    test "skips validation when using parameters_schema instead of parameters" do
+    test "validates required parameters declared with atom-keyed parameters_schema" do
+      # This is the shape used by LangChain.Tools.Calculator: atom keys for the
+      # schema itself AND for the property names.
       function =
         Function.new!(%{
           name: "with_schema",
@@ -253,9 +256,164 @@ defmodule LangChain.FunctionTest do
           function: &returns_context/2
         })
 
-      # parameters_schema validation is not implemented yet, so it should execute
-      result = Function.execute(function, %{}, %{result: {:ok, "SUCCESS"}})
-      assert result == {:ok, "SUCCESS"}
+      assert {:error, message} = Function.execute(function, %{}, %{result: {:ok, "SUCCESS"}})
+      assert message =~ "Missing required parameters"
+      assert message =~ "Required parameters: field"
+      assert message =~ "Accepted parameters: field"
+    end
+
+    test "validates required parameters declared with string-keyed parameters_schema" do
+      function =
+        Function.new!(%{
+          name: "with_schema",
+          parameters_schema: %{
+            "type" => "object",
+            "properties" => %{"field" => %{"type" => "string"}},
+            "required" => ["field"]
+          },
+          function: &returns_context/2
+        })
+
+      assert {:error, message} = Function.execute(function, %{}, %{result: {:ok, "SUCCESS"}})
+      assert message =~ "Required parameters: field"
+
+      assert {:ok, "SUCCESS"} =
+               Function.execute(function, %{"field" => "x"}, %{result: {:ok, "SUCCESS"}})
+    end
+
+    test "executes when parameters_schema declares no required parameters" do
+      function =
+        Function.new!(%{
+          name: "with_schema",
+          parameters_schema: %{
+            type: "object",
+            properties: %{field: %{type: "string"}}
+          },
+          function: &returns_context/2
+        })
+
+      assert {:ok, "SUCCESS"} = Function.execute(function, %{}, %{result: {:ok, "SUCCESS"}})
+    end
+
+    test "omits the accepted parameters list when the schema has no properties" do
+      function =
+        Function.new!(%{
+          name: "with_schema",
+          parameters_schema: %{type: "object", required: ["field"]},
+          function: &returns_context/2
+        })
+
+      assert {:error, message} = Function.execute(function, %{"other" => 1}, %{})
+      assert message =~ "Required parameters: field"
+      # We don't know which names are valid, so we can't call anything unrecognized.
+      refute message =~ "Accepted parameters"
+      refute message =~ "Unrecognized parameters"
+    end
+
+    test "names a renamed argument and suggests the parameter it meant" do
+      # The motivating case: jaro_distance("file_path", "path") is 0.0, so a
+      # jaro-only suggestion would silently produce no hint here.
+      function =
+        Function.new!(%{
+          name: "read_document",
+          parameters_schema: %{
+            type: "object",
+            properties: %{
+              path: %{type: "string"},
+              offset: %{type: "integer"},
+              limit: %{type: "integer"}
+            },
+            required: ["path"]
+          },
+          function: &returns_context/2
+        })
+
+      assert {:error, message} = Function.execute(function, %{"file_path" => "/a.md"}, %{})
+      assert message =~ "Missing parameters: path"
+      assert message =~ "Unrecognized parameters: file_path (did you mean \"path\"?)"
+      assert message =~ "Accepted parameters:"
+      assert message =~ "path"
+    end
+
+    test "names an unrecognized argument without a suggestion when nothing is similar" do
+      function =
+        Function.new!(%{
+          name: "read_document",
+          parameters_schema: %{
+            type: "object",
+            properties: %{path: %{type: "string"}},
+            required: ["path"]
+          },
+          function: &returns_context/2
+        })
+
+      assert {:error, message} = Function.execute(function, %{"query" => "abc"}, %{})
+      assert message =~ "Unrecognized parameters: query"
+      refute message =~ "did you mean"
+    end
+
+    test "omits the unrecognized line when every supplied argument is declared" do
+      function =
+        Function.new!(%{
+          name: "read_document",
+          parameters: [
+            FunctionParam.new!(%{name: "path", type: :string, required: true}),
+            FunctionParam.new!(%{name: "limit", type: :integer})
+          ],
+          function: &returns_context/2
+        })
+
+      assert {:error, message} = Function.execute(function, %{"limit" => 5}, %{})
+      assert message =~ "Missing parameters: path"
+      refute message =~ "Unrecognized parameters"
+    end
+
+    test "does not suggest a parameter that was already supplied" do
+      function =
+        Function.new!(%{
+          name: "search",
+          parameters: [
+            FunctionParam.new!(%{name: "pattern", type: :string, required: true}),
+            FunctionParam.new!(%{name: "file_path", type: :string, required: true})
+          ],
+          function: &returns_context/2
+        })
+
+      assert {:error, message} =
+               Function.execute(function, %{"file_path" => "/a.md", "patern" => "TODO"}, %{})
+
+      assert message =~ "Unrecognized parameters: patern (did you mean \"pattern\"?)"
+    end
+
+    test "lists required parameters in declaration order" do
+      function =
+        Function.new!(%{
+          name: "create_record",
+          parameters: [
+            FunctionParam.new!(%{name: "alpha", type: :string, required: true}),
+            FunctionParam.new!(%{name: "beta", type: :string, required: true}),
+            FunctionParam.new!(%{name: "gamma", type: :string, required: true})
+          ],
+          function: &returns_context/2
+        })
+
+      assert {:error, message} = Function.execute(function, %{}, %{})
+      assert message =~ "Required parameters: alpha, beta, gamma"
+    end
+
+    test "treats nil arguments as an empty map instead of raising BadMapError" do
+      function =
+        Function.new!(%{
+          name: "create_record",
+          parameters: [
+            FunctionParam.new!(%{name: "record_id", type: :string, required: true})
+          ],
+          function: &returns_context/2
+        })
+
+      assert {:error, message} = Function.execute(function, nil, %{})
+      assert message =~ "Missing required parameters"
+      assert message =~ "record_id"
     end
 
     test "allows execution when required params are present with extra params" do
@@ -467,16 +625,14 @@ defmodule LangChain.FunctionTest do
       assert message =~ "boom"
     end
 
-    test "the built-in required-params check fires before :parse_args" do
-      alias LangChain.FunctionParam
-
-      # If parse_args ran first we'd see :parser_ran in the mailbox; instead
-      # the required-params check should reject the call first.
+    test ":parse_args replaces the built-in required-params check" do
+      # A supplied parser owns argument validation outright, so the built-in
+      # required-key check is skipped entirely and the parser decides.
       parent = self()
 
       function =
         Function.new!(%{
-          name: "required_first",
+          name: "parser_owns_validation",
           parameters: [FunctionParam.new!(%{name: "id", type: :string, required: true})],
           function: &echo_args/2,
           parse_args: fn args ->
@@ -485,9 +641,214 @@ defmodule LangChain.FunctionTest do
           end
         })
 
-      assert {:error, message} = Function.execute(function, %{}, nil)
-      assert message =~ "Missing required parameters"
-      refute_received :parser_ran
+      # "id" is required and absent, but the parser accepted the call, so it runs.
+      assert {:ok, _llm_result, %{}} = Function.execute(function, %{}, nil)
+      assert_received :parser_ran
+    end
+
+    test ":parse_args owns the message for a missing required parameter" do
+      function =
+        Function.new!(%{
+          name: "parser_owns_validation",
+          parameters_schema: %{
+            type: "object",
+            properties: %{coolio: %{type: "string"}},
+            required: ["coolio"]
+          },
+          function: &echo_args/2,
+          parse_args: fn args ->
+            if Map.has_key?(args, "coolio"),
+              do: {:ok, args},
+              else: {:error, "PARSER: coolio is required"}
+          end
+        })
+
+      assert {:error, "PARSER: coolio is required"} =
+               Function.execute(function, %{"value" => 1}, nil)
+    end
+
+    test "an exception from the body keeps its original formatting when a parser is set" do
+      # The parser approved these arguments, so a body that still can't read
+      # them is a tool bug rather than a model mistake. Report it as such.
+      function =
+        Function.new!(%{
+          name: "parser_owns_validation",
+          parameters_schema: %{
+            type: "object",
+            properties: %{path: %{type: "string"}, limit: %{type: "integer"}},
+            required: ["path"]
+          },
+          function: fn args, _ctx -> Map.fetch!(args, "limit") end,
+          parse_args: fn args -> {:ok, args} end
+        })
+
+      assert {:error, message} = Function.execute(function, %{"path" => "/a.md"}, nil)
+      assert message =~ "KeyError"
+      refute message =~ "does not accept"
+    end
+  end
+
+  describe "required_param_names/1 and accepted_param_names/1" do
+    test "read from a list of FunctionParams" do
+      function =
+        Function.new!(%{
+          name: "demo",
+          parameters: [
+            FunctionParam.new!(%{name: "path", type: :string, required: true}),
+            FunctionParam.new!(%{name: "limit", type: :integer}),
+            FunctionParam.new!(%{name: "offset", type: :integer, required: true})
+          ],
+          function: &hello_world/2
+        })
+
+      assert Function.required_param_names(function) == ["path", "offset"]
+      assert Function.accepted_param_names(function) == ["path", "limit", "offset"]
+    end
+
+    test "read from an atom-keyed parameters_schema" do
+      function =
+        Function.new!(%{
+          name: "demo",
+          parameters_schema: %{
+            type: "object",
+            properties: %{path: %{type: "string"}, limit: %{type: "integer"}},
+            required: ["path"]
+          },
+          function: &hello_world/2
+        })
+
+      assert Function.required_param_names(function) == ["path"]
+      assert function |> Function.accepted_param_names() |> Enum.sort() == ["limit", "path"]
+    end
+
+    test "read from a string-keyed parameters_schema" do
+      function =
+        Function.new!(%{
+          name: "demo",
+          parameters_schema: %{
+            "type" => "object",
+            "properties" => %{"path" => %{"type" => "string"}},
+            "required" => ["path"]
+          },
+          function: &hello_world/2
+        })
+
+      assert Function.required_param_names(function) == ["path"]
+      assert Function.accepted_param_names(function) == ["path"]
+    end
+
+    test "return empty lists when nothing is declared" do
+      function = Function.new!(%{name: "demo", function: &hello_world/2})
+
+      assert Function.required_param_names(function) == []
+      assert Function.accepted_param_names(function) == []
+    end
+
+    test "tolerate a schema missing required or properties" do
+      function =
+        Function.new!(%{
+          name: "demo",
+          parameters_schema: %{type: "object"},
+          function: &hello_world/2
+        })
+
+      assert Function.required_param_names(function) == []
+      assert Function.accepted_param_names(function) == []
+    end
+  end
+
+  describe "execute/3 with an argument error raised by the tool" do
+    defp fetches_optional(args, _context) do
+      Map.fetch!(args, "limit")
+    end
+
+    defp fetches_unrelated_map(_args, _context) do
+      Map.fetch!(%{"a" => 1}, "totally_unrelated")
+    end
+
+    defp head_matches_path(%{"path" => path}, _context), do: {:ok, path}
+
+    test "reports a renamed optional argument instead of a stack frame" do
+      function =
+        Function.new!(%{
+          name: "read_document",
+          parameters_schema: %{
+            type: "object",
+            properties: %{path: %{type: "string"}, limit: %{type: "integer"}},
+            required: ["path"]
+          },
+          function: &fetches_optional/2
+        })
+
+      assert {:error, message} =
+               Function.execute(function, %{"path" => "/a.md", "lim" => 5}, %{})
+
+      assert message =~ "does not accept"
+      assert message =~ "Unrecognized parameters: lim (did you mean \"limit\"?)"
+      assert message =~ "Accepted parameters:"
+      # The tool's source location must not leak to the model.
+      refute message =~ "KeyError"
+      refute message =~ ".ex:"
+    end
+
+    test "reports a missing optional argument by name" do
+      function =
+        Function.new!(%{
+          name: "read_document",
+          parameters_schema: %{
+            type: "object",
+            properties: %{path: %{type: "string"}, limit: %{type: "integer"}},
+            required: ["path"]
+          },
+          function: &fetches_optional/2
+        })
+
+      assert {:error, message} = Function.execute(function, %{"path" => "/a.md"}, %{})
+      assert message =~ "needs the \"limit\" argument"
+      assert message =~ "Accepted parameters:"
+      refute message =~ "KeyError"
+    end
+
+    test "reports a FunctionClauseError raised by the declared tool function" do
+      function =
+        Function.new!(%{
+          name: "read_document",
+          parameters_schema: %{
+            type: "object",
+            properties: %{path: %{type: "string"}},
+            required: []
+          },
+          function: &head_matches_path/2
+        })
+
+      assert {:error, message} = Function.execute(function, %{"file_path" => "/a.md"}, %{})
+      assert message =~ "does not accept"
+      assert message =~ "did you mean \"path\"?"
+      refute message =~ "FunctionClauseError"
+    end
+
+    test "leaves a KeyError on an unrelated map with its original formatting" do
+      function =
+        Function.new!(%{
+          name: "read_document",
+          parameters_schema: %{
+            type: "object",
+            properties: %{path: %{type: "string"}},
+            required: ["path"]
+          },
+          function: &fetches_unrelated_map/2
+        })
+
+      assert {:error, message} = Function.execute(function, %{"path" => "/a.md"}, %{})
+      assert message =~ "KeyError"
+      assert message =~ "totally_unrelated"
+    end
+
+    test "falls back to the original formatting when no parameters are declared" do
+      function = Function.new!(%{name: "read_document", function: &fetches_optional/2})
+
+      assert {:error, message} = Function.execute(function, %{"path" => "/a.md"}, %{})
+      assert message =~ "KeyError"
     end
   end
 end


### PR DESCRIPTION
## Problem

Tools declared with `parameters_schema:` received no argument validation at all. `validate_required_params/2` only matched the `parameters: [%FunctionParam{}]` form, so every schema-declared tool fell through its catch-all clause to `:ok`. That is the majority of real tools: this library alone has 24 uses of `parameters_schema:` against 8 of `parameters:`, and both built-in tools (`Calculator`, `DeepResearch`) use the schema form.

The consequence was worse than a skipped check. With nothing validating the call, the tool body ran and raised, and the rescue in `execute_with_error_handling/4` turned that into:

```
ERROR: (KeyError) key "path" not found in: %{"file_path" => "/doc.md"} at lib/my_app/documents.ex:42: MyApp.Documents.read/2
```

An LLM reads exception text plus a stack frame as a transient system fault, not as "you passed the wrong argument name", so it retries the identical call. Each retry appends the wrong call to the conversation history, where it then acts as an in-context example of how the tool is invoked. A downstream project hit exactly this and logged nine identical failed attempts before giving up. The message also leaked the calling project's source paths into the conversation.

## Solution

Validation now reads required parameter names from either declaration style, and the resulting error tells the model what to send instead of describing a crash.

Two new public functions, `required_param_names/1` and `accepted_param_names/1`, extract names from both `parameters:` and `parameters_schema:`. They handle atom and string schema keys interchangeably, which matters because schemas in this codebase use both. `Calculator` writes `%{type: "object", properties: %{expression: ...}, required: ["expression"]}` with atom keys for the schema and the property name, while other schemas use strings throughout. A string-only lookup would have compiled, passed a hand-written test, and silently skipped the library's own built-in tools.

`validate_required_params/2` collapses to a single clause driven by those functions. The error it produces names the required parameters, the missing ones, any unrecognized argument names that were sent, and the full accepted list:

```
Missing required parameters for this tool.

Required parameters: path
Missing parameters: path
Unrecognized parameters: file_path (did you mean "path"?)
Accepted parameters: path, offset, limit

Ensure you're passing the correct parameter names as defined in the tool schema.
```

Unrecognized argument names never cause a rejection on their own. Extra arguments are still passed through to the tool exactly as before. They are only named in an error that was already going to fire, which costs nothing in coverage because a renamed parameter always leaves the real required parameter missing.

The "did you mean" suggestion combines substring containment with Jaro distance, not Jaro alone. `String.jaro_distance("file_path", "path")` is `0.0`: the matching window is `max(9, 4) / 2 - 1 = 3` and every character of `path` sits 5 positions away inside `file_path`, so nothing matches. The conventional Jaro-only approach would silently produce no hint for the most common rename shape, where a qualifier is added to or dropped from the front of a name.

### `:parse_args` now owns argument validation outright

When a `:parse_args` parser is supplied, LangChain performs no argument validation of its own. The required-key check is skipped and an exception from the tool body keeps its original formatting.

Without this, a tool declaring both a schema and a parser would answer the missing-key case in LangChain's format and everything else in the parser's, and a library such as Zoi could no longer report missing keys and type violations together in one round trip. Staying out of the way also avoids second-guessing a parser that legitimately coerces keys or injects defaults, since `Zoi.parse(coerce: true)` returns atom keys and the parsed arguments no longer have to match the declared schema. If a parser approved the arguments and the body still cannot read them, that is a bug in the tool rather than a mistake by the model, and a stack frame is the right signal for it.

This reverses the previously documented ordering, where the built-in check ran before the parser. In practice that ordering only ever affected `parameters:` users, since schema-declared tools had no check to run first.

### Rescued exceptions

`execute_with_error_handling/4` gained a classifier for the two exception shapes that mean "wrong argument name": a `KeyError` whose term is the arguments map, and a `FunctionClauseError` raised by the declared tool function itself. Both produce an argument-focused message naming the accepted parameters, with no stack frame. Everything else keeps its previous formatting byte for byte.

The `FunctionClauseError` check matches on module, name and arity rather than on `Function.info/1`'s `:type`. A capture written inside the module that defines it reports `type: :local` even when the target is public, so gating on `:external` would have rejected nearly every real tool.

## Changes

- [`lib/function.ex`](https://github.com/brainlid/langchain/blob/me-improved-function-argument-missing-error/lib/function.ex) - Added public `required_param_names/1` and `accepted_param_names/1` reading both declaration styles, with atom/string schema key handling. Rewrote `validate_required_params/2` as a single clause covering `parameters_schema:`, and replaced the old error template with one naming required, missing, unrecognized and accepted parameters. Added a containment-plus-Jaro suggestion heuristic. Added an argument-focused classifier to the `execute_with_error_handling/4` rescue. Short-circuited both validation paths when `:parse_args` is set. Non-map arguments are normalized to `%{}` so `nil` arguments produce a proper message rather than a `BadMapError`.
- [`lib/function.ex` (@moduledoc)](https://github.com/brainlid/langchain/blob/me-improved-function-argument-missing-error/lib/function.ex#L190) - Rewrote the "Parsing arguments before execution" section. It previously stated that `parameters_schema:` "is treated as a hint sent to the LLM and is not enforced on the way back in" and that the parser runs after the built-in check. Both are now false. Added a section documenting that `:parse_args` owns validation outright, including the trade-off that parser-backed tools get no "did you mean" diagnostic and can rebuild it from the two new public functions.
- [`test/function_test.exs`](https://github.com/brainlid/langchain/blob/me-improved-function-argument-missing-error/test/function_test.exs) - Rewrote `"skips validation when using parameters_schema instead of parameters"`, which asserted the gap this PR closes. Added coverage for atom-keyed and string-keyed schemas, schemas missing `required` or `properties`, the renamed-argument case end to end, unrecognized names with and without a suggestion, declaration ordering, `nil` arguments, the two new public functions, and a new `describe` block for the rescued-argument-error path. Inverted the test that pinned the old `:parse_args` ordering.
- [`test/function_parse_args_zoi_test.exs`](https://github.com/brainlid/langchain/blob/me-improved-function-argument-missing-error/test/function_parse_args_zoi_test.exs) - Added a `describe` block for a Zoi parser alongside a `parameters_schema` declaration. The existing tests declared no schema at all, which is why they kept passing while that combination was broken.
- [`test/chains/llm_chain_test.exs`](https://github.com/brainlid/langchain/blob/me-improved-function-argument-missing-error/test/chains/llm_chain_test.exs) - Added a test asserting the improved message reaches the `ToolResult` the model actually reads, not just `Function.execute/3`.

Existing tests asserting that extra arguments are accepted and execution proceeds were deliberately left untouched. They are the regression guard that this change stays diagnostic-only.

## Testing

`mix precommit` passes: 2181 tests including 40 doctests, 0 failures, formatted, no new warnings.

The new coverage is unit-level and makes no external API calls, so it runs in the default suite. Both new public functions carry doctests.

Error message wording was checked by hand against the realistic scenarios (renamed required argument, unrelated argument name, no arguments at all, renamed optional argument raising in the body, optional argument simply absent) before the assertions were written, so the strings a model receives were reviewed as prose rather than only pattern-matched.

Downstream blast radius was verified statically. Hand-rolled required-argument guards in sibling projects become redundant but not broken, because their tests invoke `tool.function.(args, ctx)` and `DeepResearch.execute/2` directly and bypass `Function.execute/3`. No existing test asserts on a message this change replaces.