### PR TITLE
Support Responses API context management

### DIFF
--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -200,12 +200,23 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
 
   ## Context Management
 
-  The `context_management` option configures automatic context compaction. For
-  example, compact the context after it reaches 300,000 tokens:
+  The `context_management` option configures server-side context compaction for
+  long-running conversations. When the rendered token count crosses the
+  threshold, the server compacts the context before continuing inference.
+
+  For example, compact the context after it reaches 200,000 tokens:
 
       ChatOpenAIResponses.new!(%{
-        context_management: [%{type: "compaction", compact_threshold: 300_000}]
+        context_management: [%{type: "compaction", compact_threshold: 200_000}]
       })
+
+  `compact_threshold` is optional. When omitted, the server picks a threshold:
+
+      ChatOpenAIResponses.new!(%{context_management: [%{type: "compaction"}]})
+
+  Only the `"compaction"` type is supported today, but entries are passed
+  through to the API as given, so new types and options work without a library
+  change.
 
   ## WebSocket Transport
 
@@ -545,18 +556,23 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     |> validate_context_management()
   end
 
+  # Accept entries with atom or string keys and normalize to string keys. Keys
+  # other than the documented ones are passed through untouched so that new
+  # options added to the API can be used without a library change.
   defp normalize_context_management(changeset) do
     update_change(changeset, :context_management, fn entries ->
       Enum.map(entries, fn entry ->
-        %{
-          "type" => Map.get(entry, :type) || Map.get(entry, "type"),
-          "compact_threshold" =>
-            Map.get(entry, :compact_threshold) || Map.get(entry, "compact_threshold")
-        }
+        Map.new(entry, fn
+          {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+          {key, value} -> {key, value}
+        end)
       end)
     end)
   end
 
+  # The API documents `type` as a string (only "compaction" is supported today,
+  # but that set is expected to grow) and `compact_threshold` as optional. Only
+  # validate what the API actually constrains.
   defp validate_context_management(changeset) do
     validate_change(changeset, :context_management, fn :context_management, entries ->
       Enum.flat_map(entries, fn entry ->
@@ -564,8 +580,11 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
         threshold = entry["compact_threshold"]
 
         cond do
-          type != "compaction" ->
-            [context_management: "entries must have type \"compaction\""]
+          not is_binary(type) or type == "" ->
+            [context_management: "entries must have a string \"type\""]
+
+          is_nil(threshold) ->
+            []
 
           not is_integer(threshold) or threshold <= 0 ->
             [context_management: "compact_threshold must be a positive integer"]

--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -198,6 +198,15 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
 
       ChatOpenAIResponses.new!(%{model: "gpt-5", verbosity: "low"})
 
+  ## Context Management
+
+  The `context_management` option configures automatic context compaction. For
+  example, compact the context after it reaches 300,000 tokens:
+
+      ChatOpenAIResponses.new!(%{
+        context_management: [%{type: "compaction", compact_threshold: 300_000}]
+      })
+
   ## WebSocket Transport
 
   Instead of HTTP, requests can be sent over a persistent WebSocket connection
@@ -318,6 +327,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     field :model, :string, default: "gpt-3.5-turbo"
 
     field :include, {:array, :string}, default: []
+    field :context_management, {:array, :map}, default: nil
     # omit instructions becasue langchain assumes statelessness
     field :max_output_tokens, :integer, default: nil
     # omit metadata because chat_open_ai also omits it
@@ -367,6 +377,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     :endpoint,
     :model,
     :include,
+    :context_management,
     :max_output_tokens,
     :previous_response_id,
     :store,
@@ -525,11 +536,45 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
 
   defp common_validation(changeset) do
     changeset
+    |> normalize_context_management()
     |> validate_required(@required_fields)
     |> validate_number(:temperature, greater_than_or_equal_to: 0, less_than_or_equal_to: 2)
     |> validate_number(:top_p, greater_than_or_equal_to: 0, less_than_or_equal_to: 1)
     |> validate_number(:receive_timeout, greater_than_or_equal_to: 0)
     |> validate_inclusion(:verbosity, ~w(low medium high))
+    |> validate_context_management()
+  end
+
+  defp normalize_context_management(changeset) do
+    update_change(changeset, :context_management, fn entries ->
+      Enum.map(entries, fn entry ->
+        %{
+          "type" => Map.get(entry, :type) || Map.get(entry, "type"),
+          "compact_threshold" =>
+            Map.get(entry, :compact_threshold) || Map.get(entry, "compact_threshold")
+        }
+      end)
+    end)
+  end
+
+  defp validate_context_management(changeset) do
+    validate_change(changeset, :context_management, fn :context_management, entries ->
+      Enum.flat_map(entries, fn entry ->
+        type = entry["type"]
+        threshold = entry["compact_threshold"]
+
+        cond do
+          type != "compaction" ->
+            [context_management: "entries must have type \"compaction\""]
+
+          not is_integer(threshold) or threshold <= 0 ->
+            [context_management: "compact_threshold must be a positive integer"]
+
+          true ->
+            []
+        end
+      end)
+    end)
   end
 
   @doc """
@@ -556,6 +601,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
         end)
         |> Enum.reverse()
     }
+    |> Utils.conditionally_add_to_map(:context_management, openai.context_management)
     |> Utils.conditionally_add_to_map(:include, openai.include)
     |> Utils.conditionally_add_to_map(:max_output_tokens, openai.max_output_tokens)
     |> Utils.conditionally_add_to_map(:previous_response_id, openai.previous_response_id)
@@ -2043,6 +2089,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
       [
         :endpoint,
         :model,
+        :context_management,
         :temperature,
         :frequency_penalty,
         :reasoning,

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -318,12 +318,33 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
                ChatOpenAIResponses.new(%{"context_management" => context_management})
     end
 
+    test "accepts context management without a compact_threshold" do
+      assert {:ok, %ChatOpenAIResponses{context_management: [%{"type" => "compaction"}]}} =
+               ChatOpenAIResponses.new(%{context_management: [%{type: "compaction"}]})
+    end
+
+    test "accepts context management entry types the library doesn't know about" do
+      assert {:ok, %ChatOpenAIResponses{context_management: [%{"type" => "future_type"}]}} =
+               ChatOpenAIResponses.new(%{context_management: [%{type: "future_type"}]})
+    end
+
+    test "preserves context management keys the library doesn't know about" do
+      assert {:ok, %ChatOpenAIResponses{context_management: [entry]}} =
+               ChatOpenAIResponses.new(%{
+                 context_management: [%{type: "compaction", future_option: "keep me"}]
+               })
+
+      assert entry == %{"type" => "compaction", "future_option" => "keep me"}
+    end
+
     test "rejects malformed context management" do
       invalid_values = [
         %{type: "compaction", compact_threshold: 300_000},
         ["compaction"],
-        [%{type: "unknown", compact_threshold: 300_000}],
-        [%{type: "compaction"}],
+        [%{}],
+        [%{compact_threshold: 300_000}],
+        [%{type: :compaction}],
+        [%{type: ""}],
         [%{type: "compaction", compact_threshold: 0}],
         [%{type: "compaction", compact_threshold: -1}],
         [%{type: "compaction", compact_threshold: 1.5}],
@@ -357,6 +378,14 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       model = ChatOpenAIResponses.new!()
 
       refute Map.has_key?(ChatOpenAIResponses.for_api(model, [], []), :context_management)
+    end
+
+    test "omits compact_threshold when unset rather than sending null" do
+      model = ChatOpenAIResponses.new!(%{context_management: [%{type: "compaction"}]})
+
+      assert ChatOpenAIResponses.for_api(model, [], [])[:context_management] == [
+               %{"type" => "compaction"}
+             ]
     end
 
     test "includes context management in the HTTP request payload" do

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -299,7 +299,83 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       assert openai.verbosity == nil
     end
 
+    test "accepts context management with atom keys" do
+      assert {:ok,
+              %ChatOpenAIResponses{
+                context_management: [
+                  %{"type" => "compaction", "compact_threshold" => 300_000}
+                ]
+              }} =
+               ChatOpenAIResponses.new(%{
+                 context_management: [%{type: "compaction", compact_threshold: 300_000}]
+               })
+    end
+
+    test "accepts context management with string keys" do
+      context_management = [%{"type" => "compaction", "compact_threshold" => 300_000}]
+
+      assert {:ok, %ChatOpenAIResponses{context_management: ^context_management}} =
+               ChatOpenAIResponses.new(%{"context_management" => context_management})
+    end
+
+    test "rejects malformed context management" do
+      invalid_values = [
+        %{type: "compaction", compact_threshold: 300_000},
+        ["compaction"],
+        [%{type: "unknown", compact_threshold: 300_000}],
+        [%{type: "compaction"}],
+        [%{type: "compaction", compact_threshold: 0}],
+        [%{type: "compaction", compact_threshold: -1}],
+        [%{type: "compaction", compact_threshold: 1.5}],
+        [%{type: "compaction", compact_threshold: "300000"}]
+      ]
+
+      for context_management <- invalid_values do
+        assert {:error, changeset} =
+                 ChatOpenAIResponses.new(%{context_management: context_management})
+
+        refute changeset.valid?
+      end
+    end
+
     # Support
+  end
+
+  describe "for_api/3 context management" do
+    test "includes the exact context management configuration when set" do
+      model =
+        ChatOpenAIResponses.new!(%{
+          context_management: [%{type: "compaction", compact_threshold: 300_000}]
+        })
+
+      assert ChatOpenAIResponses.for_api(model, [], [])[:context_management] == [
+               %{"type" => "compaction", "compact_threshold" => 300_000}
+             ]
+    end
+
+    test "omits context management when unset" do
+      model = ChatOpenAIResponses.new!()
+
+      refute Map.has_key?(ChatOpenAIResponses.for_api(model, [], []), :context_management)
+    end
+
+    test "includes context management in the HTTP request payload" do
+      expect(Req, :post, fn request ->
+        assert request.options[:json][:context_management] == [
+                 %{"type" => "compaction", "compact_threshold" => 300_000}
+               ]
+
+        {:error, RuntimeError.exception("stop after inspecting request")}
+      end)
+
+      model =
+        ChatOpenAIResponses.new!(%{
+          context_management: [%{type: "compaction", compact_threshold: 300_000}]
+        })
+
+      assert {:error, _error} = ChatOpenAIResponses.do_api_request(model, [], [])
+      verify!()
+    end
   end
 
   describe "for_api/3 reasoning options" do
@@ -1666,6 +1742,26 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       assert restored.endpoint == original.endpoint
       assert restored.reasoning.effort == original.reasoning.effort
     end
+
+    test "serializes and restores context management" do
+      original =
+        ChatOpenAIResponses.new!(%{
+          context_management: [%{type: "compaction", compact_threshold: 300_000}]
+        })
+
+      config = ChatOpenAIResponses.serialize_config(original)
+
+      assert config["context_management"] == [
+               %{"type" => "compaction", "compact_threshold" => 300_000}
+             ]
+
+      assert {:ok,
+              %ChatOpenAIResponses{
+                context_management: [
+                  %{"type" => "compaction", "compact_threshold" => 300_000}
+                ]
+              }} = ChatOpenAIResponses.restore_from_map(config)
+    end
   end
 
   describe "previous_response_id" do
@@ -1899,7 +1995,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
                ChatOpenAIResponses.new(%{model: @test_model})
     end
 
-    test "do_api_request with websocket wraps payload in response.create envelope (non-streaming)" do
+    test "do_api_request with websocket wraps shared payload in response.create envelope (non-streaming)" do
       fake_pid = spawn(fn -> Process.sleep(:infinity) end)
       on_exit(fn -> Process.exit(fake_pid, :kill) end)
 
@@ -1928,6 +2024,11 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
         assert decoded["type"] == "response.create"
         assert decoded["model"] == @test_model
         assert is_list(decoded["input"])
+
+        assert decoded["context_management"] == [
+                 %{"type" => "compaction", "compact_threshold" => 300_000}
+               ]
+
         # These should be stripped for WebSocket
         refute Map.has_key?(decoded, "stream")
         refute Map.has_key?(decoded, "temperature")
@@ -1944,6 +2045,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
         ChatOpenAIResponses.new!(%{
           model: @test_model,
           stream: false,
+          context_management: [%{type: "compaction", compact_threshold: 300_000}],
           websocket: fake_pid
         })
 


### PR DESCRIPTION
Adds support for the OpenAI Responses API `context_management` option, allowing callers to configure automatic compaction when a conversation reaches a token threshold. This helps long-running conversations stay within the model context window without manually truncating history.