### PR TITLE
Preserve assistant roles in Responses history

### DIFF
--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -751,14 +751,26 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
         %Message{role: :assistant, content: content} = msg
       )
       when is_list(content) do
+    # Assistant messages are sent back as "output" messages. They only support
+    # `output_text` and `refusal` content parts, so anything else is omitted. If
+    # nothing remains, the message item itself is omitted.
+    assistant_message =
+      case content_parts_for_api(model, content, :assistant) do
+        [] ->
+          []
+
+        parts ->
+          [
+            %{
+              "role" => "assistant",
+              "type" => "message",
+              "content" => parts
+            }
+          ]
+      end
+
     native_tool_calls_for_api(model, content) ++
-      [
-        %{
-          "role" => "assistant",
-          "type" => "message",
-          "content" => content_parts_for_api(model, content)
-        }
-      ] ++
+      assistant_message ++
       Enum.map(msg.tool_calls || [], &for_api(model, &1))
   end
 
@@ -815,23 +827,49 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
 
   @doc """
   Convert a list of ContentParts to the expected map of data for the OpenAI API.
+
+  The `role` of the message being converted determines which content part types
+  the API accepts. Input messages (`:system`, `:developer`, and `:user`) use the
+  `input_*` part types. Assistant messages are "output" messages and only
+  support `output_text`; unsupported parts are omitted.
   """
-  def content_parts_for_api(%ChatOpenAIResponses{} = model, content_parts)
+  def content_parts_for_api(%ChatOpenAIResponses{} = model, content_parts, role \\ :user)
       when is_list(content_parts) do
-    Enum.map(content_parts, &content_part_for_api(model, &1))
+    Enum.map(content_parts, &content_part_for_api(model, &1, role))
     |> Enum.reject(&is_nil/1)
   end
 
   @doc """
   Convert a ContentPart to the expected map of data for the OpenAI API.
+
+  See `content_parts_for_api/3` for how `role` affects the conversion.
   """
-  def content_part_for_api(%ChatOpenAIResponses{} = _model, %ContentPart{type: :text} = part) do
+  def content_part_for_api(model, content_part, role \\ :user)
+
+  def content_part_for_api(
+        %ChatOpenAIResponses{} = _model,
+        %ContentPart{type: :text} = part,
+        :assistant
+      ) do
+    %{"type" => "output_text", "text" => part.content, "annotations" => []}
+  end
+
+  # Assistant messages only support `output_text` and `refusal` parts. Anything
+  # else has no valid representation and is omitted.
+  def content_part_for_api(%ChatOpenAIResponses{} = _model, %ContentPart{}, :assistant), do: nil
+
+  def content_part_for_api(
+        %ChatOpenAIResponses{} = _model,
+        %ContentPart{type: :text} = part,
+        _role
+      ) do
     %{"type" => "input_text", "text" => part.content}
   end
 
   def content_part_for_api(
         %ChatOpenAIResponses{} = _model,
-        %ContentPart{type: :file_url} = part
+        %ContentPart{type: :file_url} = part,
+        _role
       ) do
     %{
       "type" => "input_file",
@@ -841,7 +879,8 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
 
   def content_part_for_api(
         %ChatOpenAIResponses{} = _model,
-        %ContentPart{type: :file, options: opts} = part
+        %ContentPart{type: :file, options: opts} = part,
+        _role
       ) do
     case Keyword.get(opts, :type, :base64) do
       :file_id ->
@@ -859,7 +898,11 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     end
   end
 
-  def content_part_for_api(%ChatOpenAIResponses{} = _model, %ContentPart{type: image} = part)
+  def content_part_for_api(
+        %ChatOpenAIResponses{} = _model,
+        %ContentPart{type: image} = part,
+        _role
+      )
       when image in [:image, :image_url] do
     output =
       if Keyword.get(part.options, :type) == :file_id do
@@ -902,12 +945,16 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
   end
 
   # Thinking content parts are output-only and should be omitted when sending to the API
-  def content_part_for_api(%ChatOpenAIResponses{} = _model, %ContentPart{type: :thinking}),
+  def content_part_for_api(%ChatOpenAIResponses{} = _model, %ContentPart{type: :thinking}, _role),
     do: nil
 
   # Ignore unknown, unsupported content parts
-  def content_part_for_api(%ChatOpenAIResponses{} = _model, %ContentPart{type: :unsupported}),
-    do: nil
+  def content_part_for_api(
+        %ChatOpenAIResponses{} = _model,
+        %ContentPart{type: :unsupported},
+        _role
+      ),
+      do: nil
 
   @doc false
   def get_parameters(%Function{parameters: [], parameters_schema: nil} = _fun) do

--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -754,7 +754,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     native_tool_calls_for_api(model, content) ++
       [
         %{
-          "role" => "user",
+          "role" => "assistant",
           "type" => "message",
           "content" => content_parts_for_api(model, content)
         }

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -495,21 +495,23 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
   end
 
   describe "assistant history serialization" do
-    test "preserves the role of plain assistant text" do
+    test "preserves the role of plain assistant text and uses output_text" do
       model = ChatOpenAIResponses.new!()
 
       assert [
                %{
                  "type" => "message",
                  "role" => "assistant",
-                 "content" => [%{"type" => "input_text", "text" => "Prior answer"}]
+                 "content" => [%{"type" => "output_text", "text" => "Prior answer"}]
                }
              ] = ChatOpenAIResponses.for_api(model, Message.new_assistant!("Prior answer"))
     end
 
-    test "preserves assistant content parts" do
+    test "omits assistant content parts the API cannot represent" do
       model = ChatOpenAIResponses.new!()
 
+      # Assistant "output" messages only support `output_text` and `refusal`.
+      # An image has no valid representation and is omitted.
       message =
         Message.new_assistant!([
           ContentPart.text!("Look at this image"),
@@ -520,12 +522,35 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
                %{
                  "type" => "message",
                  "role" => "assistant",
-                 "content" => [
-                   %{"type" => "input_text", "text" => "Look at this image"},
-                   %{"type" => "input_image", "image_url" => "https://example.com/image.png"}
-                 ]
+                 "content" => [%{"type" => "output_text", "text" => "Look at this image"}]
                }
              ] = ChatOpenAIResponses.for_api(model, message)
+    end
+
+    test "omits the assistant message entirely when no content survives" do
+      model = ChatOpenAIResponses.new!()
+
+      # A thinking part is output-only and dropped. Emitting a message item with
+      # an empty content list would be rejected by the API.
+      message = Message.new_assistant!([ContentPart.new!(%{type: :thinking, content: "hmm"})])
+
+      assert [] = ChatOpenAIResponses.for_api(model, message)
+    end
+
+    test "keeps native tool calls and tool calls when assistant content is dropped" do
+      model = ChatOpenAIResponses.new!()
+
+      tool_call =
+        ToolCall.new!(%{call_id: "call_abc", name: "calculator", arguments: %{expression: "1+1"}})
+
+      message =
+        Message.new_assistant!(%{
+          content: [ContentPart.new!(%{type: :thinking, content: "hmm"})],
+          tool_calls: [tool_call]
+        })
+
+      assert [%{"type" => "function_call", "call_id" => "call_abc"}] =
+               ChatOpenAIResponses.for_api(model, message)
     end
 
     test "preserves mixed system, user, and assistant history ordering" do
@@ -713,7 +738,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
 
       # Content should only include the text part, not the thinking part
       [content_part] = message_api["content"]
-      assert content_part["type"] == "input_text"
+      assert content_part["type"] == "output_text"
       assert content_part["text"] == "Here's my answer"
     end
   end

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -6,6 +6,9 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
   alias LangChain.ChatModels.ChatOpenAIResponses
   alias LangChain.Function
   alias LangChain.FunctionParam
+  alias LangChain.Message.ContentPart
+  alias LangChain.Message.ToolCall
+  alias LangChain.Message.ToolResult
 
   @test_model "gpt-4o-mini-2024-07-18"
 
@@ -491,6 +494,113 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
     end
   end
 
+  describe "assistant history serialization" do
+    test "preserves the role of plain assistant text" do
+      model = ChatOpenAIResponses.new!()
+
+      assert [
+               %{
+                 "type" => "message",
+                 "role" => "assistant",
+                 "content" => [%{"type" => "input_text", "text" => "Prior answer"}]
+               }
+             ] = ChatOpenAIResponses.for_api(model, Message.new_assistant!("Prior answer"))
+    end
+
+    test "preserves assistant content parts" do
+      model = ChatOpenAIResponses.new!()
+
+      message =
+        Message.new_assistant!([
+          ContentPart.text!("Look at this image"),
+          ContentPart.image_url!("https://example.com/image.png")
+        ])
+
+      assert [
+               %{
+                 "type" => "message",
+                 "role" => "assistant",
+                 "content" => [
+                   %{"type" => "input_text", "text" => "Look at this image"},
+                   %{"type" => "input_image", "image_url" => "https://example.com/image.png"}
+                 ]
+               }
+             ] = ChatOpenAIResponses.for_api(model, message)
+    end
+
+    test "preserves mixed system, user, and assistant history ordering" do
+      model = ChatOpenAIResponses.new!()
+
+      data =
+        ChatOpenAIResponses.for_api(
+          model,
+          [
+            Message.new_system!("Follow the rules"),
+            Message.new_user!("Question"),
+            Message.new_assistant!("Prior answer"),
+            Message.new_user!("Follow-up")
+          ],
+          []
+        )
+
+      assert [system, user, assistant, follow_up] = data.input
+      assert %{"role" => "system"} = system
+      assert %{"role" => "user"} = user
+      assert %{"role" => "assistant"} = assistant
+      assert %{"role" => "user"} = follow_up
+    end
+
+    test "preserves assistant history in a stateful request" do
+      model = ChatOpenAIResponses.new!(%{previous_response_id: "resp_previous"})
+
+      data =
+        ChatOpenAIResponses.for_api(
+          model,
+          [Message.new_assistant!("Prior answer"), Message.new_user!("Follow-up")],
+          []
+        )
+
+      assert data.previous_response_id == "resp_previous"
+      assert [%{"role" => "assistant"}, %{"role" => "user"}] = data.input
+    end
+
+    test "preserves structured stateless history" do
+      model = ChatOpenAIResponses.new!()
+
+      tool_call =
+        ToolCall.new!(%{
+          call_id: "call_123",
+          name: "calculator",
+          arguments: %{expression: "2 + 2"}
+        })
+
+      tool_result =
+        ToolResult.new!(%{
+          tool_call_id: "call_123",
+          content: [ContentPart.text!("4")]
+        })
+
+      messages = [
+        Message.new_user!("Calculate 2 + 2"),
+        Message.new_assistant!(%{content: "I will calculate it", tool_calls: [tool_call]}),
+        Message.new_tool_result!(%{tool_results: [tool_result]}),
+        Message.new_user!("Thanks")
+      ]
+
+      data = ChatOpenAIResponses.for_api(model, messages, [])
+
+      refute Map.has_key?(data, :previous_response_id)
+
+      assert [
+               %{"type" => "message", "role" => "user"},
+               %{"type" => "message", "role" => "assistant"},
+               %{"type" => "function_call", "call_id" => "call_123"},
+               %{"type" => "function_call_output", "call_id" => "call_123"},
+               %{"type" => "message", "role" => "user"}
+             ] = data.input
+    end
+  end
+
   describe "for_api/3 verbosity" do
     test "includes verbosity when set" do
       openai =
@@ -688,8 +798,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
 
       [message, tool_call] = result
       assert message["type"] == "message"
-      # Assistant messages become user in Responses API
-      assert message["role"] == "user"
+      assert message["role"] == "assistant"
       assert tool_call["type"] == "function_call"
     end
 


### PR DESCRIPTION
Preserves assistant roles when serializing conversation history for OpenAI Responses API requests. Previously, assistant messages containing content were rewritten as user messages, changing conversation semantics and potentially causing the model to treat its own prior responses as user instructions.