### PR TITLE
fixed MistralAI json response schema structure

### DIFF
--- a/lib/chat_models/chat_mistral_ai.ex
+++ b/lib/chat_models/chat_mistral_ai.ex
@@ -59,6 +59,11 @@ defmodule LangChain.ChatModels.ChatMistralAI do
     # JSON Schema to validate the output format (for structured JSON output)
     field :json_schema, :map
 
+    # The name given to the schema when json_schema is set. Mistral requires
+    # every JSON schema response format to be given a name; defaults to
+    # "output" when left unset.
+    field :json_schema_name, :string, default: nil
+
     # Whether to force a JSON response format
     field :json_response, :boolean, default: false
 
@@ -92,6 +97,7 @@ defmodule LangChain.ChatModels.ChatMistralAI do
     :stream,
     :tool_choice,
     :json_schema,
+    :json_schema_name,
     :json_response,
     :parallel_tool_calls,
     :verbose_api,
@@ -166,7 +172,7 @@ defmodule LangChain.ChatModels.ChatMistralAI do
   end
 
   # Creates the response_format field for JSON output when json_response is true.
-  # If json_schema is provided, it will be included in the response format.
+  # If json_schema is provided, it will be wrapped in the response format.
   #
   # For Mistral, the format is as follows:
   # https://docs.mistral.ai/capabilities/structured-output/custom_structured_output/
@@ -179,10 +185,37 @@ defmodule LangChain.ChatModels.ChatMistralAI do
   #   }
   # }
   @spec set_response_format(t()) :: map() | nil
-  defp set_response_format(%ChatMistralAI{json_response: true, json_schema: schema})
-       when is_map(schema) and map_size(schema) > 0 do
-    # The schema should already be in the correct format
+  # DEPRECATED: previously `json_schema` was expected to already be the full
+  # `response_format` envelope. Detected here and passed through unchanged
+  # for backwards compatibility, with a warning. Support for this shape will
+  # be removed in a future release — pass a bare JSON Schema instead.
+  defp set_response_format(%ChatMistralAI{
+         json_response: true,
+         json_schema: %{"type" => "json_schema", "json_schema" => %{} = _inner} = schema
+       }) do
+    Logger.warning(
+      "ChatMistralAI: passing a pre-wrapped response_format map as `json_schema` is " <>
+        "deprecated and will be removed in a future release. Set `json_schema` to a bare " <>
+        "JSON Schema instead; it will be wrapped automatically using `json_schema_name`."
+    )
+
     schema
+  end
+
+  defp set_response_format(%ChatMistralAI{
+         json_response: true,
+         json_schema: schema,
+         json_schema_name: name
+       })
+       when is_map(schema) and map_size(schema) > 0 do
+    %{
+      "type" => "json_schema",
+      "json_schema" => %{
+        "schema" => schema,
+        "name" => name || "output",
+        "strict" => true
+      }
+    }
   end
 
   defp set_response_format(%ChatMistralAI{json_response: true}) do
@@ -917,6 +950,7 @@ defmodule LangChain.ChatModels.ChatMistralAI do
         :random_seed,
         :stream,
         :json_schema,
+        :json_schema_name,
         :json_response,
         :verbose_api
       ],

--- a/test/chat_models/chat_mistral_ai_test.exs
+++ b/test/chat_models/chat_mistral_ai_test.exs
@@ -768,6 +768,7 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
                "version" => 1,
                "json_response" => false,
                "json_schema" => nil,
+               "json_schema_name" => nil,
                "verbose_api" => false
              }
     end
@@ -787,25 +788,18 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
   describe "structured output support" do
     test "new/1 accepts json_response and json_schema fields" do
       schema = %{
-        "type" => "json_schema",
-        "json_schema" => %{
-          "schema" => %{
-            "properties" => %{
-              "name" => %{"title" => "Name", "type" => "string"},
-              "authors" => %{
-                "items" => %{"type" => "string"},
-                "title" => "Authors",
-                "type" => "array"
-              }
-            },
-            "required" => ["name", "authors"],
-            "title" => "Book",
-            "type" => "object",
-            "additionalProperties" => false
-          },
-          "name" => "book",
-          "strict" => true
-        }
+        "properties" => %{
+          "name" => %{"title" => "Name", "type" => "string"},
+          "authors" => %{
+            "items" => %{"type" => "string"},
+            "title" => "Authors",
+            "type" => "array"
+          }
+        },
+        "required" => ["name", "authors"],
+        "title" => "Book",
+        "type" => "object",
+        "additionalProperties" => false
       }
 
       assert {:ok, %ChatMistralAI{} = mistral_ai} =
@@ -821,21 +815,77 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
 
     test "for_api/3 includes response_format when json_response is true with schema" do
       schema = %{
+        "properties" => %{
+          "name" => %{"title" => "Name", "type" => "string"},
+          "authors" => %{
+            "items" => %{"type" => "string"},
+            "title" => "Authors",
+            "type" => "array"
+          }
+        },
+        "required" => ["name", "authors"],
+        "title" => "Book",
+        "type" => "object",
+        "additionalProperties" => false
+      }
+
+      mistral_ai =
+        ChatMistralAI.new!(%{
+          "model" => "ministral-8b-latest",
+          "json_response" => true,
+          "json_schema" => schema
+        })
+
+      data = ChatMistralAI.for_api(mistral_ai, [], [])
+
+      assert data.response_format == %{
+               "type" => "json_schema",
+               "json_schema" => %{
+                 "schema" => schema,
+                 "name" => "output",
+                 "strict" => true
+               }
+             }
+    end
+
+    test "for_api/3 uses json_schema_name when set" do
+      schema = %{
+        "type" => "object",
+        "properties" => %{"name" => %{"type" => "string"}},
+        "required" => ["name"]
+      }
+
+      mistral_ai =
+        ChatMistralAI.new!(%{
+          "model" => "ministral-8b-latest",
+          "json_response" => true,
+          "json_schema" => schema,
+          "json_schema_name" => "book"
+        })
+
+      data = ChatMistralAI.for_api(mistral_ai, [], [])
+
+      assert data.response_format == %{
+               "type" => "json_schema",
+               "json_schema" => %{
+                 "schema" => schema,
+                 "name" => "book",
+                 "strict" => true
+               }
+             }
+    end
+
+    test "for_api/3 passes through a pre-wrapped json_schema unchanged with a deprecation warning" do
+      schema = %{
         "type" => "json_schema",
         "json_schema" => %{
           "schema" => %{
             "properties" => %{
-              "name" => %{"title" => "Name", "type" => "string"},
-              "authors" => %{
-                "items" => %{"type" => "string"},
-                "title" => "Authors",
-                "type" => "array"
-              }
+              "name" => %{"title" => "Name", "type" => "string"}
             },
-            "required" => ["name", "authors"],
+            "required" => ["name"],
             "title" => "Book",
-            "type" => "object",
-            "additionalProperties" => false
+            "type" => "object"
           },
           "name" => "book",
           "strict" => true
@@ -849,9 +899,11 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
           "json_schema" => schema
         })
 
-      data = ChatMistralAI.for_api(mistral_ai, [], [])
+      {data, log} =
+        ExUnit.CaptureLog.with_log(fn -> ChatMistralAI.for_api(mistral_ai, [], []) end)
 
       assert data.response_format == schema
+      assert log =~ "deprecated"
     end
 
     test "for_api/3 includes response_format when json_response is true without schema" do
@@ -880,19 +932,12 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
 
     test "serialize_config/1 includes json_response and json_schema fields" do
       schema = %{
-        "type" => "json_schema",
-        "json_schema" => %{
-          "schema" => %{
-            "properties" => %{
-              "name" => %{"title" => "Name", "type" => "string"}
-            },
-            "required" => ["name"],
-            "title" => "Book",
-            "type" => "object"
-          },
-          "name" => "book",
-          "strict" => true
-        }
+        "properties" => %{
+          "name" => %{"title" => "Name", "type" => "string"}
+        },
+        "required" => ["name"],
+        "title" => "Book",
+        "type" => "object"
       }
 
       model =
@@ -910,19 +955,12 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
 
     test "restore_from_map/1 restores json_response and json_schema fields" do
       schema = %{
-        "type" => "json_schema",
-        "json_schema" => %{
-          "schema" => %{
-            "properties" => %{
-              "name" => %{"title" => "Name", "type" => "string"}
-            },
-            "required" => ["name"],
-            "title" => "Book",
-            "type" => "object"
-          },
-          "name" => "book",
-          "strict" => true
-        }
+        "properties" => %{
+          "name" => %{"title" => "Name", "type" => "string"}
+        },
+        "required" => ["name"],
+        "title" => "Book",
+        "type" => "object"
       }
 
       config = %{
@@ -1062,25 +1100,18 @@ defmodule LangChain.ChatModels.ChatMistralAITest do
     @tag live_call: true, live_mistral_ai: true
     test "structured output with JSON schema works" do
       schema = %{
-        "type" => "json_schema",
-        "json_schema" => %{
-          "schema" => %{
-            "properties" => %{
-              "name" => %{"title" => "Name", "type" => "string"},
-              "authors" => %{
-                "items" => %{"type" => "string"},
-                "title" => "Authors",
-                "type" => "array"
-              }
-            },
-            "required" => ["name", "authors"],
-            "title" => "Book",
-            "type" => "object",
-            "additionalProperties" => false
-          },
-          "name" => "book",
-          "strict" => true
-        }
+        "properties" => %{
+          "name" => %{"title" => "Name", "type" => "string"},
+          "authors" => %{
+            "items" => %{"type" => "string"},
+            "title" => "Authors",
+            "type" => "array"
+          }
+        },
+        "required" => ["name", "authors"],
+        "title" => "Book",
+        "type" => "object",
+        "additionalProperties" => false
       }
 
       chat =


### PR DESCRIPTION
Closes https://github.com/brainlid/langchain/issues/613

Every other chat model that supports structured JSON output (`ChatOpenAI`, `ChatDeepSeek`, `ChatAwsMantle`, `ChatOpenAIResponses`, `ChatAnthropic`, `ChatGoogleAI`, `ChatVertexAI`) follows the same convention: you set `json_response: true` and pass a **bare JSON Schema** to `json_schema`. The module wraps that schema into whatever provider-specific envelope the API expects internally (via a `set_response_format`/`set_output_config`/`set_text_format`-style function).

`ChatMistralAI` was the odd one out — it expected `json_schema` to already be the *entire* pre-wrapped `response_format` envelope (`%{"type" => "json_schema", "json_schema" => %{"schema" => ..., "name" => ..., "strict" => true}}`), rather than wrapping it itself. This made it impossible to swap `ChatMistralAI` in for another provider without rewriting how the schema is built, defeating one of the main points of having a shared `ChatModel` behaviour.

### Changes

- `ChatMistralAI` now accepts a bare JSON Schema in `json_schema`, like every other provider, and wraps it into Mistral's required `response_format` shape internally.
- Added a new `json_schema_name` field (default `nil`, falls back to `"output"` when building the request) so callers can optionally name their schema — mirroring `ChatOpenAIResponses`'s `json_schema_name`.
- **Backwards compatible**: if `json_schema` is still passed in the old pre-wrapped shape (`%{"type" => "json_schema", "json_schema" => %{...}}`), it's detected and passed through unchanged, but now logs a `Logger.warning` telling callers to migrate to the bare-schema form. This will be removed in a future release.
- `json_schema_name` is included in `serialize_config/1`/`restore_from_map/1`.

### Before / after

```elixir
# Before: Mistral required callers to build the whole envelope themselves
ChatMistralAI.new!(%{
  json_response: true,
  json_schema: %{
    "type" => "json_schema",
    "json_schema" => %{
      "schema" => %{"type" => "object", "properties" => %{"name" => %{"type" => "string"}}},
      "name" => "output",
      "strict" => true
    }
  }
})

# After: same shape as ChatOpenAI/ChatDeepSeek/etc — a bare schema
ChatMistralAI.new!(%{
  json_response: true,
  json_schema: %{"type" => "object", "properties" => %{"name" => %{"type" => "string"}}}
})
```

The old pre-wrapped form still works today (with a deprecation warning) so this isn't a breaking change.

### Test plan

- [x] `mix test test/chat_models/chat_mistral_ai_test.exs` — 42 passed (5 excluded live-call tests)
- [x] `mix precommit` — full suite green (3 pre-existing, unrelated failures in `prompt_template_security_test.exs` due to `/etc/hostname` not existing in this sandbox)
- [x] Added a test asserting the legacy pre-wrapped format still works and emits a deprecation warning