### PR TITLE
Expose rescued tool exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ One behavior change to note before upgrading:
 
 ### Added
 
+- **Rescued tool exception details.** The new `:on_tool_execution_exception` callback exposes the original exception and stacktrace when LangChain rescues an exception during tool execution, and the resulting `ToolResult` has `is_exception: true`. The existing `:on_tool_execution_failed` callback still fires with the normalized model-facing content, preserving its lifecycle semantics.
 - **`context_management` option on `ChatOpenAIResponses`** for server-side context compaction on long-running conversations. When the rendered token count crosses the threshold, the server compacts the context before continuing inference.
 
   ```elixir

--- a/lib/chains/chain_callbacks.ex
+++ b/lib/chains/chain_callbacks.ex
@@ -215,15 +215,45 @@ defmodule LangChain.Chains.ChainCallbacks do
   @typedoc """
   Executed when a single tool execution fails.
 
-  Fires when tool execution raises an exception or returns an error result.
+  Fires when tool execution raises an exception, returns an error result, names
+  an invalid tool, or is rejected during human review.
 
   - First argument: LLMChain.t()
   - Second argument: ToolCall that failed
-  - Third argument: Error reason or exception
+  - Third argument: Normalized error content returned to the model
 
   The handler's return value is discarded.
   """
   @type chain_tool_execution_failed :: (LLMChain.t(), ToolCall.t(), term() -> any())
+
+  @typedoc """
+  Executed when a tool execution raises an exception that LangChain rescues.
+
+  This is an exception-specific companion to `:on_tool_execution_failed`.
+  Both callbacks fire for rescued exceptions: this callback receives the
+  original exception and stacktrace, while `:on_tool_execution_failed` receives
+  the normalized content returned to the model. The resulting `ToolResult` also
+  has `is_exception: true`.
+
+  Expected `{:error, reason}` results, invalid tool calls, human rejections, and
+  interrupts do not fire this callback.
+
+  - First argument: LLMChain.t()
+  - Second argument: ToolCall that raised
+  - Third argument: Original rescued exception
+  - Fourth argument: Exception stacktrace
+
+  Exceptions and stacktraces can contain sensitive application data. They are
+  not sent to the model by LangChain, but handlers should avoid exposing them to
+  untrusted clients.
+
+  The handler's return value is discarded.
+  """
+  @type chain_tool_execution_exception :: (LLMChain.t(),
+                                           ToolCall.t(),
+                                           Exception.t(),
+                                           Exception.stacktrace() ->
+                                             any())
 
   @typedoc """
   Executed when one or more tools return an interrupt signal.
@@ -342,6 +372,7 @@ defmodule LangChain.Chains.ChainCallbacks do
           optional(:on_tool_pre_execution) => chain_tool_pre_execution(),
           optional(:on_tool_execution_completed) => chain_tool_execution_completed(),
           optional(:on_tool_execution_failed) => chain_tool_execution_failed(),
+          optional(:on_tool_execution_exception) => chain_tool_execution_exception(),
           optional(:on_tool_interrupted) => chain_tool_interrupted(),
           optional(:on_tool_response_created) => chain_tool_response_created(),
           optional(:on_llm_error) => chain_llm_error(),

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1515,56 +1515,36 @@ defmodule LangChain.Chains.LLMChain do
             # Fires inside the spawned Task so handlers (e.g. tenancy/OTel
             # propagation) can re-apply per-process state before the tool runs.
             Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [chain, call, func])
-            result = execute_tool_call(call, func, verbose: verbose, context: use_context)
-            {call, func, result}
+
+            {result, exception} =
+              execute_tool_call_with_exception(call, func,
+                verbose: verbose,
+                context: use_context
+              )
+
+            {call, func, result, exception}
           end)
         end)
         |> Task.await_many(chain.async_tool_timeout || default_async_tool_timeout())
 
       # Fire completed/failed callbacks for async tools and extract results
       async_tool_results =
-        Enum.map(async_results, fn {call, _func, result} ->
-          cond do
-            result.is_interrupt ->
-              :ok
-
-            result.is_error ->
-              Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [
-                chain,
-                call,
-                result.content
-              ])
-
-            true ->
-              Callbacks.fire(chain.callbacks, :on_tool_execution_completed, [chain, call, result])
-          end
-
-          result
+        Enum.map(async_results, fn {call, _func, result, exception} ->
+          fire_tool_execution_callbacks(chain, call, result, exception)
         end)
 
       # Execute sync tools with immediate callbacks
       sync_tool_results =
         Enum.map(grouped[:sync], fn {call, func} ->
           Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [chain, call, func])
-          result = execute_tool_call(call, func, verbose: verbose, context: use_context)
 
-          # Fire completed/failed callback immediately after execution
-          cond do
-            result.is_interrupt ->
-              :ok
+          {result, exception} =
+            execute_tool_call_with_exception(call, func,
+              verbose: verbose,
+              context: use_context
+            )
 
-            result.is_error ->
-              Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [
-                chain,
-                call,
-                result.content
-              ])
-
-            true ->
-              Callbacks.fire(chain.callbacks, :on_tool_execution_completed, [chain, call, result])
-          end
-
-          result
+          fire_tool_execution_callbacks(chain, call, result, exception)
         end)
 
       # log invalid tool calls (can't augment - no func available)
@@ -1681,30 +1661,13 @@ defmodule LangChain.Chains.LLMChain do
                   func
                 ])
 
-                result =
-                  execute_tool_call(tool_call, func, verbose: verbose, context: use_context)
+                {result, exception} =
+                  execute_tool_call_with_exception(tool_call, func,
+                    verbose: verbose,
+                    context: use_context
+                  )
 
-                # Fire completed/failed callback after execution (skip interrupts)
-                cond do
-                  result.is_interrupt ->
-                    :ok
-
-                  result.is_error ->
-                    Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [
-                      chain,
-                      tool_call,
-                      result.content
-                    ])
-
-                  true ->
-                    Callbacks.fire(chain.callbacks, :on_tool_execution_completed, [
-                      chain,
-                      tool_call,
-                      result
-                    ])
-                end
-
-                result
+                fire_tool_execution_callbacks(chain, tool_call, result, exception)
 
               nil ->
                 error_msg = "Tool '#{tool_call.name}' not found"
@@ -1744,30 +1707,13 @@ defmodule LangChain.Chains.LLMChain do
                   func
                 ])
 
-                result =
-                  execute_tool_call(edited_call, func, verbose: verbose, context: use_context)
+                {result, exception} =
+                  execute_tool_call_with_exception(edited_call, func,
+                    verbose: verbose,
+                    context: use_context
+                  )
 
-                # Fire completed/failed callback after execution (skip interrupts)
-                cond do
-                  result.is_interrupt ->
-                    :ok
-
-                  result.is_error ->
-                    Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [
-                      chain,
-                      edited_call,
-                      result.content
-                    ])
-
-                  true ->
-                    Callbacks.fire(chain.callbacks, :on_tool_execution_completed, [
-                      chain,
-                      edited_call,
-                      result
-                    ])
-                end
-
-                result
+                fire_tool_execution_callbacks(chain, edited_call, result, exception)
 
               nil ->
                 error_msg = "Tool '#{tool_call.name}' not found"
@@ -1872,6 +1818,13 @@ defmodule LangChain.Chains.LLMChain do
   """
   @spec execute_tool_call(ToolCall.t(), Function.t(), Keyword.t()) :: ToolResult.t()
   def execute_tool_call(%ToolCall{} = call, %Function{} = function, opts \\ []) do
+    {result, _exception} = execute_tool_call_with_exception(call, function, opts)
+    result
+  end
+
+  @spec execute_tool_call_with_exception(ToolCall.t(), Function.t(), Keyword.t()) ::
+          {ToolResult.t(), Function.execution_exception() | nil}
+  defp execute_tool_call_with_exception(%ToolCall{} = call, %Function{} = function, opts) do
     verbose = Keyword.get(opts, :verbose, false)
     context = Keyword.get(opts, :context, nil)
 
@@ -1884,8 +1837,8 @@ defmodule LangChain.Chains.LLMChain do
       arguments: call.arguments
     }
 
-    enrich_stop = fn result ->
-      %{tool_result: result}
+    enrich_stop = fn {result, _exception} ->
+      %{result: result, tool_result: result}
     end
 
     # Enrich the context with the current call's tool_call_id so tool
@@ -1905,78 +1858,125 @@ defmodule LangChain.Chains.LLMChain do
         try do
           if verbose, do: IO.inspect(function.name, label: "EXECUTING FUNCTION")
 
-          case Function.execute(function, call.arguments, enriched_context) do
-            {:ok, %ToolResult{} = result} ->
-              # allow the tool execution to return a ToolResult. Just set the
-              # tool_call_id and fallback settings for name and display_text. This
-              # allows the tool to explicitly set the options for the ToolResult.
-              %{
-                result
-                | tool_call_id: call.call_id,
-                  name: result.name || function.name,
-                  display_text: result.display_text || function.display_text
-              }
+          {execution_result, exception} =
+            Function.execute_with_exception(function, call.arguments, enriched_context)
 
-            {:ok, llm_result, processed_result} ->
-              if verbose, do: IO.inspect(processed_result, label: "FUNCTION PROCESSED RESULT")
-              # successful execution and storage of processed_content.
-              ToolResult.new!(%{
-                tool_call_id: call.call_id,
-                content: llm_result,
-                processed_content: processed_result,
-                name: function.name,
-                display_text: function.display_text
-              })
+          result =
+            case execution_result do
+              {:ok, %ToolResult{} = result} ->
+                # allow the tool execution to return a ToolResult. Just set the
+                # tool_call_id and fallback settings for name and display_text. This
+                # allows the tool to explicitly set the options for the ToolResult.
+                %{
+                  result
+                  | tool_call_id: call.call_id,
+                    name: result.name || function.name,
+                    display_text: result.display_text || function.display_text
+                }
 
-            {:ok, result} ->
-              if verbose, do: IO.inspect(result, label: "FUNCTION RESULT")
-              # successful execution.
-              ToolResult.new!(%{
-                tool_call_id: call.call_id,
-                content: result,
-                name: function.name,
-                display_text: function.display_text
-              })
+              {:ok, llm_result, processed_result} ->
+                if verbose, do: IO.inspect(processed_result, label: "FUNCTION PROCESSED RESULT")
+                # successful execution and storage of processed_content.
+                ToolResult.new!(%{
+                  tool_call_id: call.call_id,
+                  content: llm_result,
+                  processed_content: processed_result,
+                  name: function.name,
+                  display_text: function.display_text
+                })
 
-            {:interrupt, display_message, interrupt_data} ->
-              if verbose, do: IO.inspect(display_message, label: "FUNCTION INTERRUPTED")
+              {:ok, result} ->
+                if verbose, do: IO.inspect(result, label: "FUNCTION RESULT")
+                # successful execution.
+                ToolResult.new!(%{
+                  tool_call_id: call.call_id,
+                  content: result,
+                  name: function.name,
+                  display_text: function.display_text
+                })
 
-              ToolResult.new!(%{
-                tool_call_id: call.call_id,
-                content: display_message,
-                name: function.name,
-                display_text: function.display_text,
-                is_interrupt: true,
-                interrupt_data: interrupt_data
-              })
+              {:interrupt, display_message, interrupt_data} ->
+                if verbose, do: IO.inspect(display_message, label: "FUNCTION INTERRUPTED")
 
-            {:error, reason} when is_binary(reason) ->
-              if verbose, do: IO.inspect(reason, label: "FUNCTION ERROR")
+                ToolResult.new!(%{
+                  tool_call_id: call.call_id,
+                  content: display_message,
+                  name: function.name,
+                  display_text: function.display_text,
+                  is_interrupt: true,
+                  interrupt_data: interrupt_data
+                })
 
-              ToolResult.new!(%{
-                tool_call_id: call.call_id,
-                content: reason,
-                name: function.name,
-                display_text: function.display_text,
-                is_error: true
-              })
-          end
+              {:error, reason} when is_binary(reason) ->
+                if verbose, do: IO.inspect(reason, label: "FUNCTION ERROR")
+
+                ToolResult.new!(%{
+                  tool_call_id: call.call_id,
+                  content: reason,
+                  name: function.name,
+                  display_text: function.display_text,
+                  is_error: true
+                })
+            end
+
+          result = %{result | is_exception: not is_nil(exception)}
+
+          {result, exception}
         rescue
           err ->
+            stacktrace = __STACKTRACE__
+
             Logger.warning(fn ->
-              "Function #{function.name} failed in execution. Exception: #{LangChainError.format_exception(err, __STACKTRACE__)}"
+              "Function #{function.name} failed in execution. Exception: #{LangChainError.format_exception(err, stacktrace)}"
             end)
 
-            ToolResult.new!(%{
-              tool_call_id: call.call_id,
-              name: function.name,
-              content: "ERROR executing tool: #{inspect(err)}",
-              is_error: true
-            })
+            result =
+              ToolResult.new!(%{
+                tool_call_id: call.call_id,
+                name: function.name,
+                content: "ERROR executing tool: #{inspect(err)}",
+                is_error: true
+              })
+
+            {%{result | is_exception: true}, {err, stacktrace}}
         end
       end,
       enrich_stop: enrich_stop
     )
+  end
+
+  @spec fire_tool_execution_callbacks(
+          t(),
+          ToolCall.t(),
+          ToolResult.t(),
+          Function.execution_exception() | nil
+        ) :: ToolResult.t()
+  defp fire_tool_execution_callbacks(chain, call, result, exception) do
+    cond do
+      result.is_interrupt ->
+        :ok
+
+      result.is_error ->
+        Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [chain, call, result.content])
+
+      true ->
+        Callbacks.fire(chain.callbacks, :on_tool_execution_completed, [chain, call, result])
+    end
+
+    case exception do
+      {error, stacktrace} ->
+        Callbacks.fire(chain.callbacks, :on_tool_execution_exception, [
+          chain,
+          call,
+          error,
+          stacktrace
+        ])
+
+      nil ->
+        :ok
+    end
+
+    result
   end
 
   @doc """

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1837,6 +1837,11 @@ defmodule LangChain.Chains.LLMChain do
       arguments: call.arguments
     }
 
+    # `Telemetry.span/4` seeds stop metadata with `%{result: <block return>}` and
+    # merges this map over it. The block returns `{tool_result, exception}`, so
+    # `:result` must be restated as the ToolResult alone. Dropping it here
+    # publishes the rescued exception and its stacktrace to every consumer of
+    # `[:langchain, :tool, :call, :stop]`.
     enrich_stop = fn {result, _exception} ->
       %{result: result, tool_result: result}
     end

--- a/lib/function.ex
+++ b/lib/function.ex
@@ -298,6 +298,7 @@ defmodule LangChain.Function do
   @type t :: %Function{}
   @type arguments :: %{String.t() => any()}
   @type context :: nil | %{atom() => any()}
+  @type execution_exception :: {Exception.t(), Exception.stacktrace()}
 
   @typedoc """
   Return shape for a `:parse_args` callback. See module doc for full details.
@@ -368,7 +369,15 @@ defmodule LangChain.Function do
   requested by the LLM.
   """
   @spec execute(t(), arguments(), context()) :: any() | no_return()
-  def execute(%Function{function: fun} = function, arguments, context) do
+  def execute(%Function{} = function, arguments, context) do
+    {result, _exception} = execute_with_exception(function, arguments, context)
+    result
+  end
+
+  @doc false
+  @spec execute_with_exception(t(), arguments(), context()) ::
+          {any(), execution_exception() | nil}
+  def execute_with_exception(%Function{function: fun} = function, arguments, context) do
     Logger.debug("Executing function #{inspect(function.name)}")
 
     # An LLM can hand back `nil` instead of an empty map for a no-argument
@@ -377,10 +386,13 @@ defmodule LangChain.Function do
     # tool body itself.
     args = if is_map(arguments), do: arguments, else: %{}
 
-    with :ok <- validate_required_params(function, args),
-         {:ok, parsed_arguments} <- run_parse_args(function, args) do
-      execute_with_error_handling(function, fun, parsed_arguments, context)
-    end
+    result =
+      with :ok <- validate_required_params(function, args),
+           {:ok, parsed_arguments} <- run_parse_args(function, args) do
+        execute_with_error_handling(function, fun, parsed_arguments, context)
+      end
+
+    split_execution_exception(result)
   end
 
   # Invokes the optional `:parse_args` callback. When absent, passes the
@@ -391,7 +403,10 @@ defmodule LangChain.Function do
   # `:on_tool_response_created` callbacks and `[:langchain, :tool, :call]`
   # telemetry firing on parse failures, which downstream consumers rely on for
   # token usage accounting and trajectory analysis.
-  @spec run_parse_args(t(), arguments()) :: {:ok, map()} | {:error, String.t()}
+  @spec run_parse_args(t(), arguments()) ::
+          {:ok, map()}
+          | {:error, String.t()}
+          | {:exception, {:error, String.t()}, Exception.t(), Exception.stacktrace()}
   defp run_parse_args(%Function{parse_args: nil}, arguments), do: {:ok, arguments}
 
   defp run_parse_args(%Function{parse_args: parser, name: name}, arguments)
@@ -406,7 +421,8 @@ defmodule LangChain.Function do
             LangChainError.format_exception(err, __STACKTRACE__)
         end)
 
-        {:error, "ERROR: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"}
+        message = "ERROR: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"
+        {:exception, {:error, message}, err, __STACKTRACE__}
     end
   end
 
@@ -614,6 +630,7 @@ defmodule LangChain.Function do
           | {:ok, any(), any()}
           | {:interrupt, String.t(), any()}
           | {:error, String.t()}
+          | {:exception, {:error, String.t()}, Exception.t(), Exception.stacktrace()}
   defp execute_with_error_handling(function, fun, arguments, context) do
     fun.(arguments, context)
     |> normalize_execution_result(function)
@@ -623,11 +640,24 @@ defmodule LangChain.Function do
         "Function! #{function.name} failed in execution. Exception: #{LangChainError.format_exception(err, __STACKTRACE__)}"
       end)
 
-      case argument_error_message(err, function, fun, arguments) do
-        nil -> {:error, "ERROR: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"}
-        message -> {:error, message}
-      end
+      result =
+        case argument_error_message(err, function, fun, arguments) do
+          nil ->
+            {:error, "ERROR: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"}
+
+          message ->
+            {:error, message}
+        end
+
+      {:exception, result, err, __STACKTRACE__}
   end
+
+  @spec split_execution_exception(any()) :: {any(), execution_exception() | nil}
+  defp split_execution_exception({:exception, result, exception, stacktrace}) do
+    {result, {exception, stacktrace}}
+  end
+
+  defp split_execution_exception(result), do: {result, nil}
 
   # The required-parameter check can't reach a tool that reads an *optional*
   # argument with `Map.fetch!/2` or pattern-matches one in its head, so those

--- a/lib/message/tool_result.ex
+++ b/lib/message/tool_result.ex
@@ -16,6 +16,15 @@ defmodule LangChain.Message.ToolResult do
   Advanced use: You can use the `options` field for LLM-specific features like
   cache control.
 
+  ## Errors
+
+  `is_error` marks any failed tool result. `is_exception` additionally marks
+  results produced when LangChain rescued an exception during tool execution.
+  The original exception and stacktrace are not stored on the result; use the
+  `:on_tool_execution_exception` callback to observe them. The model-facing
+  `content` still contains LangChain's formatted exception message and source
+  location, so applications should not include secrets in exception messages.
+
   To do this, the Elixir function's result should be a `{:ok, "String response
   for LLM", native_elixir_data}`. See `LangChain.Function` for details and
   examples.
@@ -42,6 +51,8 @@ defmodule LangChain.Message.ToolResult do
     field :display_text, :string
     # flag if the result is an error
     field :is_error, :boolean, default: false
+    # flag if the result was produced from a rescued exception
+    field :is_exception, :boolean, default: false
     # flag indicating this tool result represents a paused/interrupted tool
     field :is_interrupt, :boolean, default: false
     # opaque interrupt data (not sent to LLM, virtual only)

--- a/lib/message/tool_result.ex
+++ b/lib/message/tool_result.ex
@@ -71,6 +71,7 @@ defmodule LangChain.Message.ToolResult do
     :processed_content,
     :display_text,
     :is_error,
+    :is_exception,
     :is_interrupt,
     :interrupt_data,
     :options

--- a/lib/open_telemetry/enrich.ex
+++ b/lib/open_telemetry/enrich.ex
@@ -35,7 +35,7 @@ defmodule LangChain.OpenTelemetry.Enrich do
   | Called from | Span it enriches |
   |---|---|
   | A tool's own function body | `execute_tool {tool}` |
-  | `:on_tool_pre_execution`, `:on_tool_execution_completed`, `:on_tool_execution_failed` | `execute_tool {tool}` |
+  | `:on_tool_pre_execution`, `:on_tool_execution_completed`, `:on_tool_execution_failed`, `:on_tool_execution_exception` | `execute_tool {tool}` |
   | `:on_message_processed`, `:on_llm_token_usage` | `invoke_agent {chain_type}` |
   | Outside any LangChain operation | Whatever span your app has open, or nothing |
 

--- a/lib/open_telemetry/enrich.ex
+++ b/lib/open_telemetry/enrich.ex
@@ -35,8 +35,7 @@ defmodule LangChain.OpenTelemetry.Enrich do
   | Called from | Span it enriches |
   |---|---|
   | A tool's own function body | `execute_tool {tool}` |
-  | `:on_tool_pre_execution`, `:on_tool_execution_completed`, `:on_tool_execution_failed`, `:on_tool_execution_exception` | `execute_tool {tool}` |
-  | `:on_message_processed`, `:on_llm_token_usage` | `invoke_agent {chain_type}` |
+  | `:on_message_processed`, `:on_llm_token_usage`, and the tool callbacks (`:on_tool_pre_execution`, `:on_tool_execution_completed`, `:on_tool_execution_failed`, `:on_tool_execution_exception`) | `invoke_agent {chain_type}` |
   | Outside any LangChain operation | Whatever span your app has open, or nothing |
 
   Attributes set this way apply to that one span. They are not inherited by sibling

--- a/lib/trajectory.ex
+++ b/lib/trajectory.ex
@@ -544,7 +544,8 @@ defmodule LangChain.Trajectory do
         %{
           name: tr.name,
           content: ContentPart.content_to_string(tr.content),
-          is_error: tr.is_error
+          is_error: tr.is_error,
+          is_exception: tr.is_exception
         }
       end)
     )

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -3527,12 +3527,13 @@ defmodule LangChain.Chains.LLMChainTest do
              ]
 
       assert result.is_error == true
+      assert result.is_exception == true
       assert result.name == "go_time"
     end
 
     test "outer rescue in execute_tool_call/2 produces a ToolResult tagged with the function name" do
-      # Function.execute/3 has its own inner rescue, so the outer rescue in
-      # execute_tool_call/2 only fires if Function.execute/3 itself raises.
+      # Function.execute_with_exception/3 has its own inner rescue, so the outer
+      # rescue in execute_tool_call/2 only fires if it raises unexpectedly.
       # Stub it to raise so we exercise that defensive branch and verify the
       # produced ToolResult carries the function's name
       tool =
@@ -3542,7 +3543,7 @@ defmodule LangChain.Chains.LLMChainTest do
           function: fn _args, _context -> :unreachable end
         })
 
-      Mimic.expect(Function, :execute, fn _function, _args, _context ->
+      Mimic.expect(Function, :execute_with_exception, fn _function, _args, _context ->
         raise RuntimeError, "boom outside inner rescue"
       end)
 
@@ -3563,6 +3564,7 @@ defmodule LangChain.Chains.LLMChainTest do
       assert result.tool_call_id == "call_fake123"
       assert result.name == "go_time"
       assert result.is_error == true
+      assert result.is_exception == true
 
       assert [%ContentPart{type: :text, content: text}] = result.content
       assert text =~ "ERROR executing tool:"
@@ -3755,6 +3757,7 @@ defmodule LangChain.Chains.LLMChainTest do
             {:ok,
              %ToolResult{
                content: [ContentPart.text!("Hello!", cache_control: true)],
+               is_exception: true,
                options: [custom: 1]
              }}
           end
@@ -3774,6 +3777,7 @@ defmodule LangChain.Chains.LLMChainTest do
       assert result.content == [ContentPart.text!("Hello!", cache_control: true)]
       assert result.processed_content == nil
       assert result.options == [custom: 1]
+      assert result.is_exception == false
     end
 
     test "execute_tool_call handles {:interrupt, msg, data} return", %{chain: chain} do

--- a/test/chains/llm_chain_tool_callbacks_test.exs
+++ b/test/chains/llm_chain_tool_callbacks_test.exs
@@ -94,7 +94,7 @@ defmodule LangChain.Chains.LLMChainToolCallbacksTest do
       assert tool_result.is_error == false
     end
 
-    test "fires on_tool_execution_failed callback when tool raises error" do
+    test "fires on_tool_execution_failed callback when tool returns an error" do
       test_pid = self()
 
       # Create a failing tool
@@ -110,6 +110,9 @@ defmodule LangChain.Chains.LLMChainToolCallbacksTest do
       callbacks = %{
         on_tool_execution_failed: fn _chain, tool_call, error ->
           send(test_pid, {:failed, tool_call.name, error})
+        end,
+        on_tool_execution_exception: fn _chain, tool_call, exception, stacktrace ->
+          send(test_pid, {:exception, tool_call.name, exception, stacktrace})
         end,
         on_tool_execution_completed: fn _chain, tool_call, _tool_result ->
           send(test_pid, {:completed, tool_call.name})
@@ -132,13 +135,188 @@ defmodule LangChain.Chains.LLMChainToolCallbacksTest do
         })
 
       chain = LLMChain.add_message(chain, message)
-      _updated_chain = LLMChain.execute_tool_calls(chain)
+      updated_chain = LLMChain.execute_tool_calls(chain)
 
       # Error can be a string or list of ContentParts
       assert_received {:failed, "fail_tool", _error}
 
       # Ensure on_tool_execution_completed did NOT fire
       refute_received {:completed, "fail_tool"}
+      refute_received {:exception, "fail_tool", _, _}
+      assert [%{is_error: true, is_exception: false}] = updated_chain.last_message.tool_results
+    end
+
+    test "fires on_tool_execution_failed callback when tool raises an exception" do
+      test_pid = self()
+
+      tool =
+        Function.new!(%{
+          name: "raising_tool",
+          description: "Always raises",
+          parameters_schema: %{type: "object", properties: %{}},
+          function: fn _args, _ctx -> raise RuntimeError, "Something went wrong" end
+        })
+
+      callbacks = %{
+        on_tool_execution_exception: fn _chain, tool_call, exception, stacktrace ->
+          send(test_pid, {:exception, tool_call.name, exception, stacktrace})
+        end,
+        on_tool_execution_failed: fn _chain, tool_call, error ->
+          send(test_pid, {:failed, tool_call.name, error})
+        end
+      }
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: [callbacks]
+        })
+
+      message =
+        Message.new_assistant!(%{
+          content: "Test",
+          tool_calls: [
+            ToolCall.new!(%{call_id: "call_exception", name: "raising_tool", arguments: %{}})
+          ]
+        })
+
+      chain = LLMChain.add_message(chain, message)
+      updated_chain = LLMChain.execute_tool_calls(chain)
+
+      assert_received {:exception, "raising_tool", %RuntimeError{message: "Something went wrong"},
+                       stacktrace}
+
+      assert [_ | _] = stacktrace
+      assert_received {:failed, "raising_tool", error}
+      assert [%LangChain.Message.ContentPart{type: :text, content: content}] = error
+      assert content =~ "RuntimeError"
+      assert content =~ "Something went wrong"
+      assert [%{is_error: true, is_exception: true}] = updated_chain.last_message.tool_results
+    end
+
+    test "fires on_tool_execution_exception for async tool exceptions" do
+      test_pid = self()
+
+      tool =
+        Function.new!(%{
+          name: "async_raising_tool",
+          async: true,
+          function: fn _args, _ctx -> raise ArgumentError, "async failure" end
+        })
+
+      callbacks = %{
+        on_tool_execution_exception: fn _chain, tool_call, exception, stacktrace ->
+          send(test_pid, {:exception, tool_call.name, exception, stacktrace, self()})
+        end
+      }
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: [callbacks]
+        })
+        |> LLMChain.add_message(
+          Message.new_assistant!(%{
+            tool_calls: [
+              ToolCall.new!(%{
+                call_id: "call_async_exception",
+                name: "async_raising_tool",
+                arguments: %{}
+              })
+            ]
+          })
+        )
+
+      updated_chain = LLMChain.execute_tool_calls(chain)
+
+      assert_received {:exception, "async_raising_tool", %ArgumentError{message: "async failure"},
+                       [_ | _], callback_pid}
+
+      assert callback_pid == self()
+      assert [%{is_error: true, is_exception: true}] = updated_chain.last_message.tool_results
+    end
+
+    test "fires the failure callback before an exception callback that raises" do
+      test_pid = self()
+
+      tool =
+        Function.new!(%{
+          name: "raising_tool",
+          function: fn _args, _ctx -> raise RuntimeError, "tool failure" end
+        })
+
+      callbacks = %{
+        on_tool_execution_failed: fn _chain, _tool_call, _error ->
+          send(test_pid, :failed_callback_fired)
+        end,
+        on_tool_execution_exception: fn _chain, _tool_call, _exception, _stacktrace ->
+          raise "callback failure"
+        end
+      }
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: [callbacks]
+        })
+        |> LLMChain.add_message(
+          Message.new_assistant!(%{
+            tool_calls: [
+              ToolCall.new!(%{call_id: "call_callback_failure", name: "raising_tool"})
+            ]
+          })
+        )
+
+      assert_raise LangChain.LangChainError, ~r/callback failure/, fn ->
+        LLMChain.execute_tool_calls(chain)
+      end
+
+      assert_received :failed_callback_fired
+    end
+
+    test "fires on_tool_execution_exception when argument parsing raises" do
+      test_pid = self()
+
+      tool =
+        Function.new!(%{
+          name: "parser_raising_tool",
+          parse_args: fn _args -> raise ArgumentError, "invalid arguments" end,
+          function: fn _args, _ctx -> {:ok, "unreachable"} end
+        })
+
+      callbacks = %{
+        on_tool_execution_exception: fn _chain, tool_call, exception, stacktrace ->
+          send(test_pid, {:exception, tool_call.name, exception, stacktrace})
+        end
+      }
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: [callbacks]
+        })
+        |> LLMChain.add_message(
+          Message.new_assistant!(%{
+            tool_calls: [
+              ToolCall.new!(%{
+                call_id: "call_parser_exception",
+                name: "parser_raising_tool",
+                arguments: %{}
+              })
+            ]
+          })
+        )
+
+      updated_chain = LLMChain.execute_tool_calls(chain)
+
+      assert_received {:exception, "parser_raising_tool",
+                       %ArgumentError{message: "invalid arguments"}, [_ | _]}
+
+      assert [%{is_error: true, is_exception: true}] = updated_chain.last_message.tool_results
     end
 
     test "fires on_tool_execution_failed callback for invalid tool" do
@@ -166,9 +344,10 @@ defmodule LangChain.Chains.LLMChainToolCallbacksTest do
         })
 
       chain = LLMChain.add_message(chain, message)
-      _updated_chain = LLMChain.execute_tool_calls(chain)
+      updated_chain = LLMChain.execute_tool_calls(chain)
 
       assert_received {:failed, "nonexistent_tool", _error}
+      assert [%{is_error: true, is_exception: false}] = updated_chain.last_message.tool_results
     end
 
     test "fires callbacks for multiple tools in correct order" do
@@ -267,6 +446,40 @@ defmodule LangChain.Chains.LLMChainToolCallbacksTest do
       assert_received {:completed, "test_tool"}
     end
 
+    test "fires on_tool_execution_exception for approved HITL tool exceptions" do
+      test_pid = self()
+
+      tool =
+        Function.new!(%{
+          name: "raising_tool",
+          function: fn _args, _ctx -> raise RuntimeError, "HITL failure" end
+        })
+
+      callbacks = %{
+        on_tool_execution_exception: fn _chain, tool_call, exception, stacktrace ->
+          send(test_pid, {:exception, tool_call.name, exception, stacktrace})
+        end
+      }
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: [callbacks]
+        })
+
+      tool_call =
+        ToolCall.new!(%{call_id: "call_hitl_exception", name: "raising_tool", arguments: %{}})
+
+      updated_chain =
+        LLMChain.execute_tool_calls_with_decisions(chain, [tool_call], [%{type: :approve}])
+
+      assert_received {:exception, "raising_tool", %RuntimeError{message: "HITL failure"},
+                       [_ | _]}
+
+      assert [%{is_error: true, is_exception: true}] = updated_chain.last_message.tool_results
+    end
+
     test "fires on_tool_execution_failed callback for rejected tools in HITL" do
       test_pid = self()
 
@@ -298,10 +511,11 @@ defmodule LangChain.Chains.LLMChainToolCallbacksTest do
 
       decisions = [%{type: :reject}]
 
-      _updated_chain = LLMChain.execute_tool_calls_with_decisions(chain, tool_calls, decisions)
+      updated_chain = LLMChain.execute_tool_calls_with_decisions(chain, tool_calls, decisions)
 
       assert_received {:failed, "test_tool", error}
       assert error =~ "rejected by a human reviewer"
+      assert [%{is_exception: false}] = updated_chain.last_message.tool_results
     end
 
     test "fires callbacks for edited tool calls in HITL" do

--- a/test/chat_models/telemetry_test.exs
+++ b/test/chat_models/telemetry_test.exs
@@ -763,7 +763,7 @@ defmodule LangChain.ChatModels.TelemetryTest do
 
       call = ToolCall.new!(%{call_id: "call-1", name: "hello", arguments: %{}})
 
-      LLMChain.execute_tool_call(call, fun, context: custom_ctx)
+      result = LLMChain.execute_tool_call(call, fun, context: custom_ctx)
 
       assert_received {:telemetry_event, [:langchain, :tool, :call, :start], start_metadata}
       assert start_metadata.tool_name == "hello"
@@ -771,8 +771,41 @@ defmodule LangChain.ChatModels.TelemetryTest do
 
       assert_received {:telemetry_event, [:langchain, :tool, :call, :stop], stop_metadata}
       assert start_metadata.call_id == stop_metadata.call_id
+      assert stop_metadata.result == result
+      assert stop_metadata.tool_result == result
 
       :telemetry.detach("test-tool-custom-context")
+    end
+
+    test "tool call stop telemetry does not expose rescued exceptions" do
+      test_pid = self()
+
+      :telemetry.attach(
+        "test-tool-exception-metadata",
+        [:langchain, :tool, :call, :stop],
+        fn _name, _measurements, metadata, _config ->
+          send(test_pid, {:tool_stop, metadata})
+        end,
+        nil
+      )
+
+      fun =
+        Function.new!(%{
+          name: "raising_tool",
+          function: fn _args, _ctx -> raise RuntimeError, "private failure" end
+        })
+
+      call = ToolCall.new!(%{call_id: "call-exception", name: "raising_tool", arguments: %{}})
+      result = LLMChain.execute_tool_call(call, fun)
+
+      assert_received {:tool_stop, metadata}
+      assert %LangChain.Message.ToolResult{is_error: true, is_exception: true} = metadata.result
+      assert metadata.result == result
+      assert metadata.tool_result == result
+      refute Map.has_key?(metadata, :exception)
+      refute Map.has_key?(metadata, :stacktrace)
+
+      :telemetry.detach("test-tool-exception-metadata")
     end
   end
 

--- a/test/message/tool_result_test.exs
+++ b/test/message/tool_result_test.exs
@@ -16,6 +16,7 @@ defmodule LangChain.Message.ToolResultTest do
       assert msg.name == nil
       assert msg.display_text == nil
       assert msg.is_error == false
+      assert msg.is_exception == false
     end
 
     test "accepts valid input" do
@@ -78,6 +79,7 @@ defmodule LangChain.Message.ToolResultTest do
       assert msg.tool_call_id == "call_123asdf"
       assert msg.display_text == "Failed to run hello_world"
       assert msg.is_error == true
+      assert msg.is_exception == false
     end
 
     test "returns errors when invalid" do

--- a/test/message/tool_result_test.exs
+++ b/test/message/tool_result_test.exs
@@ -82,6 +82,21 @@ defmodule LangChain.Message.ToolResultTest do
       assert msg.is_exception == false
     end
 
+    test "flags when produced from a rescued exception" do
+      {:ok, %ToolResult{} = msg} =
+        ToolResult.new(%{
+          type: :function,
+          tool_call_id: "call_123asdf",
+          name: "hello_world",
+          content: "ERROR executing tool: %RuntimeError{message: \"boom\"}",
+          is_error: true,
+          is_exception: true
+        })
+
+      assert msg.is_error == true
+      assert msg.is_exception == true
+    end
+
     test "returns errors when invalid" do
       {:error, changeset} =
         ToolResult.new(%{tool_call_id: nil, content: nil})

--- a/test/trajectory_test.exs
+++ b/test/trajectory_test.exs
@@ -300,7 +300,7 @@ defmodule LangChain.TrajectoryTest do
     end
 
     test "serializes tool results in messages" do
-      tr = make_tool_result("search", "Result text")
+      tr = %{make_tool_result("search", "Result text") | is_error: true, is_exception: true}
 
       trajectory = %Trajectory{
         messages: [tool_msg([tr])],
@@ -310,7 +310,18 @@ defmodule LangChain.TrajectoryTest do
 
       result = Trajectory.to_map(trajectory)
 
-      assert [%{tool_results: [%{name: "search", content: "Result text", is_error: false}]}] =
+      assert [
+               %{
+                 tool_results: [
+                   %{
+                     name: "search",
+                     content: "Result text",
+                     is_error: true,
+                     is_exception: true
+                   }
+                 ]
+               }
+             ] =
                result.messages
     end
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -118,6 +118,7 @@ This pattern allows:
 - `:on_message_processed` — Message complete and processed (use for persistence)
 - `:on_tool_call_identified` — Tool name detected during streaming (args may be incomplete)
 - `:on_tool_execution_started/completed/failed` — Tool execution lifecycle
+- `:on_tool_execution_exception` — Original rescued tool exception and stacktrace
 - `:on_tool_response_created` — Tool results compiled into message
 - `:on_message_processing_error` — Message processor failure
 


### PR DESCRIPTION
## Summary

- add an exception-specific tool execution callback with the original exception and stacktrace
- preserve existing failure callback and model-facing error behavior
- keep exception details out of messages and telemetry metadata

## Verification

- No vulnerabilities found.

15:50:57.388 [info] Loading 122 CA(s) from :otp store

15:50:57.393 [info] OTLP exporter successfully initialized
Running ExUnit with seed: 610334, max_cases: 32
Excluding tags: [live_call: true]

.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 14.1 seconds (2.7s async, 11.4s sync)

Result: 2205 passed (40 doctests, 2165 tests), 145 excluded (2,205 tests passed; 145 live tests excluded)
- focused callback, function, LLM chain, and telemetry tests