### PR TITLE
Add :content_filtered and :stream_error message statuses

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1137,15 +1137,15 @@ defmodule LangChain.Chains.LLMChain do
     %LLMChain{chain | delta: merged}
   end
 
-  # Handle when the server is overloaded and cancelled the stream on the server side.
+  # Handle when the server is overloaded and ended the stream on the server side.
   def merge_delta(%LLMChain{} = chain, {:error, %LangChainError{type: "overloaded"} = error}) do
-    cancel_delta(chain, :cancelled, error)
+    cancel_delta(chain, :stream_error, error)
   end
 
   # Handle any other error received during streaming (e.g. content filtering, invalid_request_error).
   def merge_delta(%LLMChain{} = chain, {:error, %LangChainError{} = error}) do
     Logger.warning("Received error during streaming: #{error.message}")
-    cancel_delta(chain, :cancelled, error)
+    cancel_delta(chain, :stream_error, error)
   end
 
   # Unified function to augment tool calls with display_text and optionally
@@ -1264,7 +1264,7 @@ defmodule LangChain.Chains.LLMChain do
   def delta_to_message_when_complete(
         %LLMChain{delta: %MessageDelta{status: status} = delta} = chain
       )
-      when status in [:complete, :length] do
+      when status in [:complete, :length, :content_filtered] do
     # it's complete. Attempt to convert delta to a message
     case MessageDelta.to_message(delta) do
       {:ok, %Message{} = message} ->
@@ -1982,6 +1982,10 @@ defmodule LangChain.Chains.LLMChain do
   @doc """
   Remove an incomplete MessageDelta from `delta` and add a Message with the
   desired status to the chain.
+
+  The partial content produced so far is preserved on the message rather than
+  discarded. Pass `:cancelled` for a caller-initiated stop and `:stream_error`
+  for a stream that died. See `LangChain.Message` for the full set.
   """
   def cancel_delta(%LLMChain{delta: nil} = chain, _message_status), do: chain
 

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -450,6 +450,31 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   - **Haiku considerations**: Haiku has a high minimum (4096 tokens) which can mean low initial utilization. However, enabling `:cache_messages` has minimal cost impact, so it's safe to enable.
   - **TTL tradeoff**: Default TTL is 5m (1.25x write cost). Setting TTL to 1h increases write cost to 3x but may improve utilization for longer sessions.
 
+  ## Refusals
+
+  Anthropic's safety classifiers can decline a request. A declined request is a
+  normal HTTP 200 response carrying `stop_reason: "refusal"`, not an error, and
+  its content is empty when the classifier fired before any output or partial
+  when it fired mid-stream.
+
+  A refusal produces a message with `status: :content_filtered`. The response
+  also carries a `stop_details` object naming the policy category that stopped
+  it, which is placed in the message's `metadata` under `:stop_details`:
+
+      {:ok, message} = ChatAnthropic.call(model, messages, [])
+
+      case message.status do
+        :content_filtered ->
+          message.metadata[:stop_details]
+          # => %{"type" => "refusal", "category" => "cyber", "explanation" => "..."}
+
+        _ ->
+          message.content
+      end
+
+  `stop_details` is null for every stop reason other than `refusal`, so the
+  `:stop_details` key is absent from `metadata` on any other message.
+
   ## Connection Retry Behavior
 
   The `retry_count` option controls how many times a request is retried when
@@ -1194,19 +1219,23 @@ defmodule LangChain.ChatModels.ChatAnthropic do
           | MessageDelta.t()
           | [MessageDelta.t()]
           | {:error, LangChainError.t()}
-  def do_process_response(_model, %{
-        "role" => "assistant",
-        "content" => contents,
-        "stop_reason" => stop_reason,
-        "type" => "message",
-        "usage" => usage
-      }) do
+  def do_process_response(
+        _model,
+        %{
+          "role" => "assistant",
+          "content" => contents,
+          "stop_reason" => stop_reason,
+          "type" => "message",
+          "usage" => usage
+        } = data
+      ) do
     new_message =
       %{
         role: :assistant,
         content: [],
         status: stop_reason_to_status(stop_reason)
       }
+      |> Map.merge(stop_details_metadata(data["stop_details"]))
       |> Message.new()
       |> TokenUsage.set_wrapped(get_token_usage(usage))
       |> to_response()
@@ -1397,15 +1426,16 @@ defmodule LangChain.ChatModels.ChatAnthropic do
         _model,
         %{
           "type" => "message_delta",
-          "delta" => %{"stop_reason" => stop_reason},
+          "delta" => %{"stop_reason" => stop_reason} = delta,
           "usage" => usage
-        } = _data
+        } = data
       ) do
     %{
       role: :assistant,
       content: nil,
       status: stop_reason_to_status(stop_reason)
     }
+    |> Map.merge(stop_details_metadata(delta["stop_details"] || data["stop_details"]))
     |> MessageDelta.new()
     |> TokenUsage.set_wrapped(get_token_usage(usage))
     |> to_response()
@@ -1580,11 +1610,19 @@ defmodule LangChain.ChatModels.ChatAnthropic do
   defp stop_reason_to_status("tool_use"), do: :complete
   defp stop_reason_to_status("max_tokens"), do: :length
   defp stop_reason_to_status("stop_sequence"), do: :complete
+  defp stop_reason_to_status("refusal"), do: :content_filtered
 
   defp stop_reason_to_status(other) do
     Logger.warning("Unsupported stop_reason. Reason: #{inspect(other)}")
     nil
   end
+
+  # `stop_details` names the policy category behind a refusal and is null for
+  # every other stop reason, so only a refusal contributes metadata.
+  defp stop_details_metadata(details) when is_map(details),
+    do: %{metadata: %{stop_details: details}}
+
+  defp stop_details_metadata(_details), do: %{}
 
   @doc false
   def parse_stream_events(%ChatAnthropic{bedrock: nil}, {chunk, buffer}) do

--- a/lib/chat_models/chat_aws_mantle.ex
+++ b/lib/chat_models/chat_aws_mantle.ex
@@ -806,7 +806,7 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
   defp finish_reason_to_status(nil), do: :incomplete
   defp finish_reason_to_status("stop"), do: :complete
   defp finish_reason_to_status("tool_calls"), do: :complete
-  defp finish_reason_to_status("content_filter"), do: :complete
+  defp finish_reason_to_status("content_filter"), do: :content_filtered
   defp finish_reason_to_status("length"), do: :length
   defp finish_reason_to_status("max_tokens"), do: :length
   defp finish_reason_to_status(_other), do: nil

--- a/lib/chat_models/chat_deepseek.ex
+++ b/lib/chat_models/chat_deepseek.ex
@@ -1166,7 +1166,7 @@ defmodule LangChain.ChatModels.ChatDeepSeek do
   defp finish_reason_to_status(nil), do: :incomplete
   defp finish_reason_to_status("stop"), do: :complete
   defp finish_reason_to_status("tool_calls"), do: :complete
-  defp finish_reason_to_status("content_filter"), do: :complete
+  defp finish_reason_to_status("content_filter"), do: :content_filtered
   defp finish_reason_to_status("length"), do: :length
   defp finish_reason_to_status("max_tokens"), do: :length
 

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -1338,7 +1338,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   defp finish_reason_to_status(nil), do: :incomplete
   defp finish_reason_to_status("stop"), do: :complete
   defp finish_reason_to_status("tool_calls"), do: :complete
-  defp finish_reason_to_status("content_filter"), do: :complete
+  defp finish_reason_to_status("content_filter"), do: :content_filtered
   defp finish_reason_to_status("length"), do: :length
   defp finish_reason_to_status("max_tokens"), do: :length
 

--- a/lib/chat_models/chat_orq.ex
+++ b/lib/chat_models/chat_orq.ex
@@ -1031,7 +1031,7 @@ defmodule LangChain.ChatModels.ChatOrq do
           :complete
 
         "content_filter" ->
-          :complete
+          :content_filtered
 
         "length" ->
           :length
@@ -1181,7 +1181,7 @@ defmodule LangChain.ChatModels.ChatOrq do
           :complete
 
         "content_filter" ->
-          :complete
+          :content_filtered
 
         "length" ->
           :length

--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -1159,7 +1159,7 @@ if Code.ensure_loaded?(ReqLLM) do
     def translate_finish_reason(:stop), do: :complete
     def translate_finish_reason(:tool_calls), do: :complete
     def translate_finish_reason(:length), do: :length
-    def translate_finish_reason(:content_filter), do: :complete
+    def translate_finish_reason(:content_filter), do: :content_filtered
     def translate_finish_reason(:cancelled), do: :complete
     def translate_finish_reason(:incomplete), do: :length
     def translate_finish_reason(:error), do: :complete

--- a/lib/message.ex
+++ b/lib/message.ex
@@ -16,6 +16,34 @@ defmodule LangChain.Message do
 
   - `:tool` - A message for returning the result of executing a `tool` request.
 
+  ## Status
+
+  `status` records how the message terminated. Every value other than
+  `:complete` means the model did not finish, and each names a distinct cause so
+  a caller can tell them apart without inspecting metadata:
+
+  - `:complete` - the model finished on its own.
+
+  - `:length` - the output token cap was reached. The message holds whatever was
+    produced up to the cap.
+
+  - `:content_filtered` - the provider's content filter stopped the response.
+    Reported by providers that return a `"content_filter"` finish reason.
+
+  - `:stream_error` - the stream died mid-flight (a provider `overloaded`, an
+    invalid request, a filter applied at the transport level). The partial
+    content is preserved. `LangChain.Chains.LLMChain` sets this and puts the
+    `LangChain.LangChainError` in `metadata[:streaming_error]`, so the reason is
+    available as well as the fact.
+
+  - `:cancelled` - a caller stopped the response. Set by
+    `LangChain.Chains.LLMChain.cancel_delta/2`, which preserves the partial
+    content rather than discarding it.
+
+  Only a `:complete` message has its tool call arguments parsed into maps.
+  Anything else may hold a truncated or unparsed `arguments` string, since the
+  model may have been cut off mid-call.
+
   ## Tools
 
   A `tool_call` comes from the `:assistant` role. The `tool_id` identifies which
@@ -104,7 +132,10 @@ defmodule LangChain.Message do
     field :content, :any, virtual: true
     field :processed_content, :any, virtual: true
     field :index, :integer
-    field :status, Ecto.Enum, values: [:complete, :cancelled, :length], default: :complete
+
+    field :status, Ecto.Enum,
+      values: [:complete, :cancelled, :length, :content_filtered, :stream_error],
+      default: :complete
 
     field :role, Ecto.Enum,
       values: [:system, :user, :assistant, :tool],
@@ -126,7 +157,7 @@ defmodule LangChain.Message do
   end
 
   @type t :: %Message{}
-  @type status :: :complete | :cancelled | :length
+  @type status :: :complete | :cancelled | :length | :content_filtered | :stream_error
 
   @update_fields [
     :role,

--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -65,8 +65,15 @@ defmodule LangChain.MessageDelta do
     field :content, :any, virtual: true
     # The accumulated list of ContentParts after merging deltas
     field :merged_content, :any, virtual: true, default: []
-    # Marks if the delta completes the message.
-    field :status, Ecto.Enum, values: [:incomplete, :complete, :length], default: :incomplete
+    # Marks if the delta completes the message, and how it terminated. Mirrors
+    # `LangChain.Message.status` for the terminal values a provider can report
+    # on a stream. `:cancelled` and `:stream_error` are absent because they are
+    # decided by the chain rather than the provider, and are applied to the
+    # assembled Message.
+    field :status, Ecto.Enum,
+      values: [:incomplete, :complete, :length, :content_filtered],
+      default: :incomplete
+
     # When requesting multiple choices for a response, the `index` represents
     # which choice it is. It is a 0 based list.
     field :index, :integer
@@ -174,6 +181,7 @@ defmodule LangChain.MessageDelta do
     |> merge_tool_calls(new_delta)
     |> update_index(new_delta)
     |> update_status(new_delta)
+    |> merge_delta_metadata(new_delta)
     |> accumulate_token_usage(new_delta)
     |> clear_content()
   end
@@ -398,10 +406,27 @@ defmodule LangChain.MessageDelta do
 
   defp update_index(%MessageDelta{} = primary, %MessageDelta{}), do: primary
 
+  # Carry provider metadata from an incoming delta onto the accumulated one so
+  # it reaches the assembled message. `:usage` is excluded because
+  # `accumulate_token_usage/2` sums it across deltas rather than replacing it.
+  @spec merge_delta_metadata(t(), t()) :: t()
+  defp merge_delta_metadata(%MessageDelta{} = primary, %MessageDelta{metadata: incoming})
+       when is_map(incoming) do
+    case Map.drop(incoming, [:usage]) do
+      empty when map_size(empty) == 0 ->
+        primary
+
+      new_metadata ->
+        %MessageDelta{primary | metadata: Map.merge(primary.metadata || %{}, new_metadata)}
+    end
+  end
+
+  defp merge_delta_metadata(%MessageDelta{} = primary, %MessageDelta{}), do: primary
+
   # Only update status from :incomplete to a terminal state
   @spec update_status(t(), t()) :: t()
   defp update_status(%MessageDelta{status: :incomplete} = primary, %MessageDelta{status: status})
-       when status in [:complete, :length] do
+       when status in [:complete, :length, :content_filtered] do
     %MessageDelta{primary | status: status}
   end
 

--- a/lib/open_telemetry/attributes.ex
+++ b/lib/open_telemetry/attributes.ex
@@ -265,9 +265,9 @@ defmodule LangChain.OpenTelemetry.Attributes do
 
   # Best-effort `gen_ai.response.finish_reasons` reconstructed from the assembled
   # message's normalized `:status`. LangChain collapses a provider's raw finish
-  # reason into `Message.status` (`:complete | :length | :cancelled`), so this is
-  # lossy: a `:complete` message that carries tool calls maps to `"tool_calls"`,
-  # otherwise `:complete` -> `"stop"`. Streaming results (a delta or list of
+  # reason into `Message.status`, so this is lossy: a message that carries tool
+  # calls maps to `"tool_calls"` whatever its status, and `:complete` otherwise
+  # maps to `"stop"`. Streaming results (a delta or list of
   # deltas) are merged to a message first. Returns [] when nothing is derivable.
   @spec finish_reason_attributes(term()) :: [{String.t(), term()}]
   defp finish_reason_attributes(result) do
@@ -305,6 +305,8 @@ defmodule LangChain.OpenTelemetry.Attributes do
   defp message_finish_reason(%LangChain.Message{status: :complete}), do: "stop"
   defp message_finish_reason(%LangChain.Message{status: :length}), do: "length"
   defp message_finish_reason(%LangChain.Message{status: :cancelled}), do: "cancelled"
+  defp message_finish_reason(%LangChain.Message{status: :content_filtered}), do: "content_filter"
+  defp message_finish_reason(%LangChain.Message{status: :stream_error}), do: "error"
   defp message_finish_reason(_), do: nil
 
   # Serializes the LLM output for `gen_ai.output.messages`. Streaming calls return

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -584,7 +584,7 @@ defmodule LangChain.Chains.LLMChainTest do
              } = updated_chain.delta
     end
 
-    test "cancels the current delta when applying an overloaded error", %{chain: chain} do
+    test "ends the current delta as a stream error when overloaded", %{chain: chain} do
       assert chain.messages == []
 
       error = LangChainError.exception(type: "overloaded", message: "Overloaded")
@@ -604,12 +604,12 @@ defmodule LangChain.Chains.LLMChainTest do
       assert [%Message{} = new_message] = updated_chain.messages
       assert new_message.role == :assistant
       assert new_message.content == [ContentPart.text!("Greetings from your favorite ")]
-      assert new_message.status == :cancelled
+      assert new_message.status == :stream_error
       # the error is stored in metadata
       assert new_message.metadata.streaming_error == error
     end
 
-    test "cancels the current delta on a generic streaming error", %{chain: chain} do
+    test "ends the current delta as a stream error on a generic streaming error", %{chain: chain} do
       error =
         LangChainError.exception(
           type: "invalid_request_error",
@@ -626,8 +626,39 @@ defmodule LangChain.Chains.LLMChainTest do
       assert [%Message{} = msg] = updated_chain.messages
       assert msg.role == :assistant
       assert msg.content == [ContentPart.text!("Some partial response")]
-      assert msg.status == :cancelled
+      assert msg.status == :stream_error
       assert msg.metadata.streaming_error == error
+    end
+  end
+
+  describe "delta_to_message_when_complete/1" do
+    setup do
+      %{chain: LLMChain.new!(%{llm: ChatOpenAI.new!(%{stream: true})})}
+    end
+
+    test "converts a content filtered delta and keeps the partial content", %{chain: chain} do
+      # A provider that stops a response with its content filter still ends the
+      # stream. Treating the delta as unfinished would leave it hanging on the
+      # chain and the caller waiting on a message that never arrives.
+      updated_chain =
+        chain
+        |> LLMChain.merge_delta(MessageDelta.new!(%{role: :assistant, content: "Some partial "}))
+        |> LLMChain.merge_delta(MessageDelta.new!(%{content: "resp", status: :content_filtered}))
+
+      assert {:ok, %LLMChain{} = result} = LLMChain.delta_to_message_when_complete(updated_chain)
+      assert result.delta == nil
+      assert [%Message{} = msg] = result.messages
+      assert msg.status == :content_filtered
+      assert msg.content == [ContentPart.text!("Some partial resp")]
+    end
+
+    test "leaves an incomplete delta on the chain", %{chain: chain} do
+      updated_chain =
+        LLMChain.merge_delta(chain, MessageDelta.new!(%{role: :assistant, content: "Still "}))
+
+      assert {:ok, %LLMChain{} = result} = LLMChain.delta_to_message_when_complete(updated_chain)
+      assert %MessageDelta{status: :incomplete} = result.delta
+      assert result.messages == []
     end
   end
 
@@ -2866,9 +2897,9 @@ defmodule LangChain.Chains.LLMChainTest do
       assert chain.needs_response == false
     end
 
-    test "streaming error with empty delta produces cancelled message" do
+    test "streaming error with empty delta produces a stream_error message" do
       # A streaming error occurs while the delta has no content yet.
-      # The cancel_delta path converts it to a cancelled message.
+      # The cancel_delta path converts it to a stream_error message.
       handler = %{
         on_error: fn _chain, error ->
           send(self(), {:error_callback, error})
@@ -2889,9 +2920,9 @@ defmodule LangChain.Chains.LLMChainTest do
         |> LLMChain.add_message(Message.new_user!("Hello"))
         |> LLMChain.run()
 
-      # Empty delta converts successfully to a cancelled message
+      # Empty delta converts successfully to a stream_error message
       assert chain.last_message.role == :assistant
-      assert chain.last_message.status == :cancelled
+      assert chain.last_message.status == :stream_error
       assert chain.needs_response == false
     end
 

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -594,6 +594,70 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
       assert struct.role == :assistant
       assert struct.content == [ContentPart.text!("Greetings!")]
       assert is_nil(struct.index)
+      refute Map.has_key?(struct.metadata, :stop_details)
+    end
+
+    test "a refusal is content filtered and reports the policy category", %{model: model} do
+      response = %{
+        "id" => "id-123",
+        "type" => "message",
+        "role" => "assistant",
+        "content" => [],
+        "model" => "claude-opus-4-5",
+        "stop_reason" => "refusal",
+        "stop_details" => %{
+          "type" => "refusal",
+          "category" => "cyber",
+          "explanation" => "Request matched a restricted policy."
+        },
+        "usage" => %{"input_tokens" => 17, "output_tokens" => 0}
+      }
+
+      assert %Message{} = struct = ChatAnthropic.do_process_response(model, response)
+      assert struct.role == :assistant
+      assert struct.status == :content_filtered
+      assert struct.content == []
+
+      assert struct.metadata[:stop_details] == %{
+               "type" => "refusal",
+               "category" => "cyber",
+               "explanation" => "Request matched a restricted policy."
+             }
+    end
+
+    test "a refusal that stopped mid-output keeps the partial content", %{model: model} do
+      response = %{
+        "id" => "id-123",
+        "type" => "message",
+        "role" => "assistant",
+        "content" => [%{"type" => "text", "text" => "Here is the first step"}],
+        "model" => "claude-opus-4-5",
+        "stop_reason" => "refusal",
+        "stop_details" => %{"type" => "refusal", "category" => nil, "explanation" => nil},
+        "usage" => %{"input_tokens" => 17, "output_tokens" => 6}
+      }
+
+      assert %Message{} = struct = ChatAnthropic.do_process_response(model, response)
+      assert struct.status == :content_filtered
+      assert struct.content == [ContentPart.text!("Here is the first step")]
+      assert struct.metadata[:stop_details]["type"] == "refusal"
+    end
+
+    test "a non-refusal stop reason carries a null stop_details", %{model: model} do
+      response = %{
+        "id" => "id-123",
+        "type" => "message",
+        "role" => "assistant",
+        "content" => [%{"type" => "text", "text" => "Greetings!"}],
+        "model" => "claude-opus-4-5",
+        "stop_reason" => "end_turn",
+        "stop_details" => nil,
+        "usage" => %{"input_tokens" => 17, "output_tokens" => 11}
+      }
+
+      assert %Message{} = struct = ChatAnthropic.do_process_response(model, response)
+      assert struct.status == :complete
+      refute Map.has_key?(struct.metadata, :stop_details)
     end
 
     test "handles receiving a complete message with thinking", %{model: model} do
@@ -791,6 +855,88 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
                  output: 80,
                  raw: %{"output_tokens" => 80}
                })
+    end
+
+    test "a streamed refusal is content filtered and reports the policy category", %{model: model} do
+      response = %{
+        "type" => "message_delta",
+        "delta" => %{
+          "stop_reason" => "refusal",
+          "stop_sequence" => nil,
+          "stop_details" => %{
+            "type" => "refusal",
+            "category" => "bio",
+            "explanation" => "Request matched a restricted policy."
+          }
+        },
+        "usage" => %{"output_tokens" => 12}
+      }
+
+      assert %MessageDelta{} = struct = ChatAnthropic.do_process_response(model, response)
+      assert struct.status == :content_filtered
+
+      assert struct.metadata[:stop_details] == %{
+               "type" => "refusal",
+               "category" => "bio",
+               "explanation" => "Request matched a restricted policy."
+             }
+    end
+
+    test "a streamed refusal reports stop_details sent at the event level", %{model: model} do
+      response = %{
+        "type" => "message_delta",
+        "delta" => %{"stop_reason" => "refusal", "stop_sequence" => nil},
+        "stop_details" => %{"type" => "refusal", "category" => "cyber"},
+        "usage" => %{"output_tokens" => 12}
+      }
+
+      assert %MessageDelta{} = struct = ChatAnthropic.do_process_response(model, response)
+      assert struct.status == :content_filtered
+      assert struct.metadata[:stop_details] == %{"type" => "refusal", "category" => "cyber"}
+    end
+
+    test "a streamed refusal survives merging into the assembled message", %{model: model} do
+      start_event = %{
+        "type" => "message_start",
+        "message" => %{
+          "type" => "message",
+          "role" => "assistant",
+          "content" => [],
+          "usage" => %{"input_tokens" => 14, "output_tokens" => 1}
+        }
+      }
+
+      text_event = %{
+        "type" => "content_block_delta",
+        "index" => 0,
+        "delta" => %{"type" => "text_delta", "text" => "Here is the first step"}
+      }
+
+      stop_event = %{
+        "type" => "message_delta",
+        "delta" => %{
+          "stop_reason" => "refusal",
+          "stop_sequence" => nil,
+          "stop_details" => %{"type" => "refusal", "category" => "cyber"}
+        },
+        "usage" => %{"output_tokens" => 12}
+      }
+
+      deltas =
+        Enum.map(
+          [start_event, text_event, stop_event],
+          &ChatAnthropic.do_process_response(model, &1)
+        )
+
+      merged = MessageDelta.merge_deltas(deltas)
+      assert merged.status == :content_filtered
+      assert merged.metadata[:stop_details] == %{"type" => "refusal", "category" => "cyber"}
+
+      assert {:ok, %Message{} = message} = MessageDelta.to_message(merged)
+      assert message.status == :content_filtered
+      assert message.content == [ContentPart.text!("Here is the first step")]
+      assert message.metadata[:stop_details] == %{"type" => "refusal", "category" => "cyber"}
+      assert message.metadata[:usage].output == 13
     end
 
     test "handles receiving a content_block_start event for text", %{model: model} do

--- a/test/chat_models/chat_deepseek_test.exs
+++ b/test/chat_models/chat_deepseek_test.exs
@@ -928,7 +928,7 @@ defmodule LangChain.ChatModels.ChatDeepSeekTest do
       %{model: model}
     end
 
-    test "handles response with content_filter finish reason", %{model: model} do
+    test "reports a content_filter finish reason as :content_filtered", %{model: model} do
       response = %{
         "choices" => [
           %{
@@ -941,7 +941,7 @@ defmodule LangChain.ChatModels.ChatDeepSeekTest do
 
       assert [%Message{} = msg] = ChatDeepSeek.do_process_response(model, response)
       assert msg.role == :assistant
-      assert msg.status == :complete
+      assert msg.status == :content_filtered
     end
 
     test "handles response with logprobs data", %{model: model} do

--- a/test/chat_models/chat_req_llm_test.exs
+++ b/test/chat_models/chat_req_llm_test.exs
@@ -242,8 +242,8 @@ if Code.ensure_loaded?(ReqLLM) do
         assert :length == ChatReqLLM.translate_finish_reason(:length)
       end
 
-      test "maps :content_filter to :complete" do
-        assert :complete == ChatReqLLM.translate_finish_reason(:content_filter)
+      test "maps :content_filter to :content_filtered" do
+        assert :content_filtered == ChatReqLLM.translate_finish_reason(:content_filter)
       end
 
       test "maps nil to :complete" do

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -7,6 +7,7 @@ defmodule LangChain.MessageDeltaTest do
   alias LangChain.MessageDelta
   alias LangChain.Message.ToolCall
   alias LangChain.LangChainError
+  alias LangChain.TokenUsage
 
   describe "new/1" do
     test "works with minimal attrs" do
@@ -1436,6 +1437,98 @@ defmodule LangChain.MessageDeltaTest do
       result = MessageDelta.merge_deltas(accumulated, batch)
 
       assert result.status == :length
+    end
+  end
+
+  describe "terminal statuses" do
+    test "merging promotes :incomplete to :content_filtered" do
+      primary = MessageDelta.new!(%{role: :assistant, content: "Some partial "})
+      filtered = MessageDelta.new!(%{content: "resp", status: :content_filtered})
+
+      assert %MessageDelta{status: :content_filtered} =
+               MessageDelta.merge_delta(primary, filtered)
+    end
+
+    test "a terminal status is not overwritten by a later delta" do
+      filtered = MessageDelta.new!(%{role: :assistant, status: :content_filtered})
+      trailing = MessageDelta.new!(%{content: "more", status: :complete})
+
+      assert %MessageDelta{status: :content_filtered} =
+               MessageDelta.merge_delta(filtered, trailing)
+    end
+
+    test "a content filtered delta converts to a message carrying the partial content" do
+      delta = %MessageDelta{
+        role: :assistant,
+        merged_content: [ContentPart.text!("Some partial resp")],
+        status: :content_filtered
+      }
+
+      assert {:ok, %Message{} = msg} = MessageDelta.to_message(delta)
+      assert msg.status == :content_filtered
+      assert msg.content == [ContentPart.text!("Some partial resp")]
+    end
+  end
+
+  describe "merge_delta/2 metadata" do
+    test "carries provider metadata from an incoming delta onto the accumulated one" do
+      primary = MessageDelta.new!(%{role: :assistant, content: "partial"})
+
+      incoming =
+        MessageDelta.new!(%{
+          status: :content_filtered,
+          metadata: %{stop_details: %{"type" => "refusal", "category" => "cyber"}}
+        })
+
+      merged = MessageDelta.merge_delta(primary, incoming)
+
+      assert merged.metadata[:stop_details] == %{"type" => "refusal", "category" => "cyber"}
+    end
+
+    test "merges keys rather than replacing the accumulated metadata map" do
+      primary =
+        MessageDelta.new!(%{role: :assistant, content: "partial", metadata: %{model: "opus"}})
+
+      incoming = MessageDelta.new!(%{metadata: %{stop_details: %{"type" => "refusal"}}})
+
+      merged = MessageDelta.merge_delta(primary, incoming)
+
+      assert merged.metadata[:model] == "opus"
+      assert merged.metadata[:stop_details] == %{"type" => "refusal"}
+    end
+
+    test "usage is still summed rather than replaced by the incoming delta's value" do
+      primary =
+        MessageDelta.new!(%{
+          role: :assistant,
+          metadata: %{usage: TokenUsage.new!(%{input: 10, output: 5})}
+        })
+
+      incoming =
+        MessageDelta.new!(%{
+          metadata: %{
+            usage: TokenUsage.new!(%{input: 0, output: 7}),
+            stop_details: %{"type" => "refusal"}
+          }
+        })
+
+      merged = MessageDelta.merge_delta(primary, incoming)
+
+      assert merged.metadata[:usage].input == 10
+      assert merged.metadata[:usage].output == 12
+      assert merged.metadata[:stop_details] == %{"type" => "refusal"}
+    end
+
+    test "a delta carrying only usage leaves the accumulated metadata otherwise untouched" do
+      primary = MessageDelta.new!(%{role: :assistant, metadata: %{model: "opus"}})
+
+      incoming =
+        MessageDelta.new!(%{metadata: %{usage: TokenUsage.new!(%{input: 1, output: 2})}})
+
+      merged = MessageDelta.merge_delta(primary, incoming)
+
+      assert merged.metadata[:model] == "opus"
+      assert merged.metadata[:usage].output == 2
     end
   end
 

--- a/test/message_test.exs
+++ b/test/message_test.exs
@@ -147,6 +147,37 @@ defmodule LangChain.MessageTest do
     end
   end
 
+  describe "status" do
+    test "accepts each way a message can terminate" do
+      for status <- [:complete, :cancelled, :length, :content_filtered, :stream_error] do
+        assert {:ok, %Message{status: ^status}} =
+                 Message.new(%{role: :assistant, content: "Partial", status: status})
+      end
+    end
+
+    test "rejects an unknown status" do
+      assert {:error, changeset} =
+               Message.new(%{role: :assistant, content: "Partial", status: :made_up})
+
+      assert {"is invalid", _} = changeset.errors[:status]
+    end
+
+    test "defaults to :complete" do
+      assert {:ok, %Message{status: :complete}} = Message.new(%{role: :user, content: "Hi"})
+    end
+
+    test "only a :complete message has its tool call arguments parsed" do
+      # An unfinished message may hold a truncated arguments string, so parsing
+      # is skipped rather than failing the whole message.
+      truncated = ToolCall.new!(%{call_id: "1", name: "search", arguments: "{\"q\": \"eli"})
+
+      assert {:ok, %Message{} = message} =
+               Message.new(%{role: :assistant, tool_calls: [truncated], status: :length})
+
+      assert [%ToolCall{arguments: "{\"q\": \"eli", status: :incomplete}] = message.tool_calls
+    end
+  end
+
   describe "new_system/1" do
     test "creates a system message" do
       assert {:ok, %Message{role: :system} = msg} = Message.new_system("You are an AI.")


### PR DESCRIPTION
## Problem

`Message.status` could not express two distinct outcomes, so callers had no way to detect them.

A `"content_filter"` finish reason was mapped to `:complete` by every provider that reports one. A response the provider's safety filter stopped was indistinguishable from one the model finished on its own. Anthropic's refusals were worse off still: `stop_reason: "refusal"` was unrecognized, so it produced `status: nil` and logged an "Unsupported stop_reason" warning, and the `stop_details` object naming the policy category was dropped entirely.

Separately, `cancel_delta/2` used `:cancelled` for both a caller stopping a response and a stream dying mid-flight (provider `overloaded`, invalid request). Those are different events and callers should be able to tell them apart.

## Solution

Two new statuses, each naming a distinct cause so a caller can branch on `status` alone without inspecting metadata:

- `:content_filtered` — the provider's content filter stopped the response
- `:stream_error` — the stream died mid-flight; the `LangChainError` remains in `metadata[:streaming_error]`

Every provider's `finish_reason_to_status` now maps `"content_filter"` to `:content_filtered`, and `LLMChain.merge_delta/2` uses `:stream_error` on both error paths.

For Anthropic, a refusal arrives as a normal HTTP 200 with `stop_reason: "refusal"`, not an error, so it is handled in `do_process_response/2` rather than the error path. `stop_reason_to_status/1` maps it to `:content_filtered`, and `stop_details_metadata/1` places the policy category in `metadata[:stop_details]`. Because `stop_details` is null for every other stop reason, the key is simply absent on other messages.

Streaming needed two supporting changes. `MessageDelta` gained `:content_filtered` as a terminal status, and `LLMChain.delta_to_message_when_complete/1` now accepts it — a filtered stream has ended, so leaving the delta unfinished would hang it on the chain with the caller waiting on a message that never arrives. `MessageDelta.merge_delta/2` gained `merge_delta_metadata/2` so provider metadata carries onto the accumulated delta and reaches the assembled message; `:usage` is excluded since `accumulate_token_usage/2` sums it rather than replacing it.

Partial content is preserved throughout. A refusal that fires mid-output keeps the text produced up to that point.

## Changes

- `lib/message.ex` — Added `:content_filtered` and `:stream_error` to the status enum and `@type status`; documented the full set and what each means
- `lib/message_delta.ex` — Added `:content_filtered` as a terminal status; added `merge_delta_metadata/2` to carry provider metadata across deltas
- `lib/chains/llm_chain.ex` — `merge_delta/2` cancels with `:stream_error` on both error paths; `delta_to_message_when_complete/1` accepts `:content_filtered`
- `lib/chat_models/chat_anthropic.ex` — Recognized `"refusal"` as `:content_filtered`; captured `stop_details` into message metadata on both the complete-message and `message_delta` paths (reading it from either the delta or the event level)
- `lib/chat_models/chat_open_ai.ex`, `chat_deepseek.ex`, `chat_aws_mantle.ex`, `chat_orq.ex`, `chat_req_llm.ex` — Mapped `"content_filter"` to `:content_filtered`
- `lib/open_telemetry/attributes.ex` — Mapped the new statuses to `"content_filter"` and `"error"` finish reasons

Documentation:

- `lib/message.ex` (@moduledoc) — New "Status" section covering all five values and the rule that only `:complete` messages have tool call arguments parsed
- `lib/chat_models/chat_anthropic.ex` (@moduledoc) — New "Refusals" section with an example of reading `stop_details`
- `lib/chains/llm_chain.ex` — `cancel_delta/2` doc notes partial content is preserved and when to pass each status
- `lib/message_delta.ex`, `lib/open_telemetry/attributes.ex` — Inline docs updated for the widened status set

## Testing

Full suite passes: 2218 tests, 40 doctests, no failures.

New coverage:

- `test/chat_models/chat_anthropic_test.exs` — Refusal with empty content, refusal that stopped mid-output (partial content retained), non-refusal null `stop_details`, streamed refusal with `stop_details` at delta level and at event level, and a full `message_start` → text → `message_delta` sequence merged and converted to a Message with status, content, metadata, and summed usage intact
- `test/message_test.exs` — Each status value accepted, unknown status rejected, default is `:complete`, and tool call arguments left unparsed on a non-`:complete` message
- `test/message_delta_test.exs` — `:incomplete` promoted to `:content_filtered`, terminal status not overwritten by a later delta, conversion to a Message, and four metadata merge cases including usage summing and usage-only deltas
- `test/chains/llm_chain_test.exs` — `delta_to_message_when_complete/1` converts a filtered delta while keeping partial content, and leaves a genuinely incomplete delta on the chain

Existing tests asserting the old `:complete` / `:cancelled` values were updated to the new statuses.

Note: this changes the status value returned for content-filtered and stream-error responses. Callers matching on `:complete` or `:cancelled` for those cases need updating. CHANGELOG entry is intentionally omitted here and will be written after merge.