### PR TITLE
Make tool_call_ids unique.

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -962,11 +962,11 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
 
   def do_process_response(
         _model,
-        %{"functionCall" => %{"args" => raw_args, "name" => name}} = data,
+        %{"functionCall" => %{"args" => raw_args, "name" => name} = call} = data,
         _
       ) do
     %{
-      call_id: Utils.generate_tool_call_id(),
+      call_id: call["id"] || Utils.generate_tool_call_id(),
       name: name,
       arguments: raw_args,
       complete: true,
@@ -1007,18 +1007,11 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
      )}
   end
 
-  # Gemini's `functionCall` parts carry no position. The index assigned here
-  # keeps parallel calls to the same tool from merging into a single call
-  # during `MessageDelta` accumulation, which pairs calls by index.
   defp parse_tool_calls(model, parts) do
     parts
     |> filter_parts_for_types(["functionCall"])
-    |> Enum.with_index()
-    |> Enum.map(fn {part, index} ->
-      case do_process_response(model, part, nil) do
-        %ToolCall{} = call -> %ToolCall{call | index: index}
-        other -> other
-      end
+    |> Enum.map(fn part ->
+      do_process_response(model, part, nil)
     end)
   end
 

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -891,9 +891,8 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     tool_calls_from_parts =
       parts
       |> filter_parts_for_types(["functionCall"])
-      |> Enum.with_index()
-      |> Enum.map(fn {part, call_index} ->
-        do_process_response(model, part, call_index)
+      |> Enum.map(fn part ->
+        do_process_response(model, part, nil)
       end)
 
     tool_result_from_parts =
@@ -950,9 +949,8 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     tool_calls_from_parts =
       parts
       |> filter_parts_for_types(["functionCall"])
-      |> Enum.with_index()
-      |> Enum.map(fn {part, call_index} ->
-        do_process_response(model, part, call_index)
+      |> Enum.map(fn part ->
+        do_process_response(model, part, nil)
       end)
 
     %{
@@ -975,14 +973,14 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   def do_process_response(
         _model,
         %{"functionCall" => %{"args" => raw_args, "name" => name}} = data,
-        call_index
+        _
       ) do
     %{
       call_id: "call-#{name}-#{Utils.generate_short_id()}",
       name: name,
       arguments: raw_args,
       complete: true,
-      index: call_index,
+      index: data["index"],
       metadata:
         if(data["thoughtSignature"],
           do: %{thought_signature: data["thoughtSignature"]},

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -888,12 +888,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
         ContentPart.new!(%{type: type, content: part["text"]})
       end)
 
-    tool_calls_from_parts =
-      parts
-      |> filter_parts_for_types(["functionCall"])
-      |> Enum.map(fn part ->
-        do_process_response(model, part, nil)
-      end)
+    tool_calls_from_parts = parse_tool_calls(model, parts)
 
     tool_result_from_parts =
       parts
@@ -946,12 +941,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
           nil
       end
 
-    tool_calls_from_parts =
-      parts
-      |> filter_parts_for_types(["functionCall"])
-      |> Enum.map(fn part ->
-        do_process_response(model, part, nil)
-      end)
+    tool_calls_from_parts = parse_tool_calls(model, parts)
 
     %{
       role: unmap_role(role),
@@ -980,7 +970,6 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
       name: name,
       arguments: raw_args,
       complete: true,
-      index: data["index"],
       metadata:
         if(data["thoughtSignature"],
           do: %{thought_signature: data["thoughtSignature"]},
@@ -1016,6 +1005,24 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
        message: "Unexpected response",
        original: other
      )}
+  end
+
+  # Gemini's `functionCall` parts carry neither an id nor a position. Both are
+  # synthesized here: a unique `call_id` keeps parallel calls to the same tool
+  # distinct when a `ToolResult` is matched back to its call or the conversation
+  # is replayed against a provider that requires unique ids, and the positional
+  # `index` keeps those same calls from merging into one during `MessageDelta`
+  # accumulation, which pairs calls by index.
+  defp parse_tool_calls(model, parts) do
+    parts
+    |> filter_parts_for_types(["functionCall"])
+    |> Enum.with_index()
+    |> Enum.map(fn {part, index} ->
+      case do_process_response(model, part, nil) do
+        %ToolCall{} = call -> %ToolCall{call | index: index}
+        other -> other
+      end
+    end)
   end
 
   @doc false

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -966,7 +966,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
         _
       ) do
     %{
-      call_id: "call-#{name}-#{Utils.generate_short_id()}",
+      call_id: Utils.generate_tool_call_id(),
       name: name,
       arguments: raw_args,
       complete: true,
@@ -1007,12 +1007,9 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
      )}
   end
 
-  # Gemini's `functionCall` parts carry neither an id nor a position. Both are
-  # synthesized here: a unique `call_id` keeps parallel calls to the same tool
-  # distinct when a `ToolResult` is matched back to its call or the conversation
-  # is replayed against a provider that requires unique ids, and the positional
-  # `index` keeps those same calls from merging into one during `MessageDelta`
-  # accumulation, which pairs calls by index.
+  # Gemini's `functionCall` parts carry no position. The index assigned here
+  # keeps parallel calls to the same tool from merging into a single call
+  # during `MessageDelta` accumulation, which pairs calls by index.
   defp parse_tool_calls(model, parts) do
     parts
     |> filter_parts_for_types(["functionCall"])

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -891,8 +891,9 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     tool_calls_from_parts =
       parts
       |> filter_parts_for_types(["functionCall"])
-      |> Enum.map(fn part ->
-        do_process_response(model, part, nil)
+      |> Enum.with_index()
+      |> Enum.map(fn {part, call_index} ->
+        do_process_response(model, part, call_index)
       end)
 
     tool_result_from_parts =
@@ -949,8 +950,9 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     tool_calls_from_parts =
       parts
       |> filter_parts_for_types(["functionCall"])
-      |> Enum.map(fn part ->
-        do_process_response(model, part, nil)
+      |> Enum.with_index()
+      |> Enum.map(fn {part, call_index} ->
+        do_process_response(model, part, call_index)
       end)
 
     %{
@@ -973,14 +975,14 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   def do_process_response(
         _model,
         %{"functionCall" => %{"args" => raw_args, "name" => name}} = data,
-        _
+        call_index
       ) do
     %{
-      call_id: "call-#{name}",
+      call_id: "call-#{name}-#{Utils.generate_short_id()}",
       name: name,
       arguments: raw_args,
       complete: true,
-      index: data["index"],
+      index: call_index,
       metadata:
         if(data["thoughtSignature"],
           do: %{thought_signature: data["thoughtSignature"]},

--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -810,7 +810,7 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
         }
       }) do
     case ToolCall.new(%{
-           call_id: Ecto.UUID.generate(),
+           call_id: Utils.generate_tool_call_id(),
            type: :function,
            name: name,
            arguments: args

--- a/lib/chat_models/chat_perplexity.ex
+++ b/lib/chat_models/chat_perplexity.ex
@@ -595,7 +595,7 @@ defmodule LangChain.ChatModels.ChatPerplexity do
                 status: :complete,
                 name: call["name"],
                 arguments: args_json,
-                call_id: Ecto.UUID.generate()
+                call_id: Utils.generate_tool_call_id()
               })
 
             # Force arguments back to JSON string (validate_and_parse_arguments
@@ -622,7 +622,7 @@ defmodule LangChain.ChatModels.ChatPerplexity do
             status: :complete,
             name: List.first(tools).name,
             arguments: content,
-            call_id: Ecto.UUID.generate()
+            call_id: Utils.generate_tool_call_id()
           })
 
         case Message.new(%{
@@ -727,7 +727,7 @@ defmodule LangChain.ChatModels.ChatPerplexity do
                        status: :complete,
                        name: call["name"],
                        arguments: Jason.encode!(call["arguments"]),
-                       call_id: Ecto.UUID.generate()
+                       call_id: Utils.generate_tool_call_id()
                      })
 
                    # Force the arguments field to be a JSON string even if the ToolCall schema casts it

--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -456,7 +456,7 @@ if Code.ensure_loaded?(ReqLLM) do
            state
          )
          when is_binary(name) do
-      id = meta[:id] || "tool_#{:erlang.unique_integer([:positive])}"
+      id = meta[:id] || Utils.generate_tool_call_id()
       block_index = meta[:index] || 0
 
       tool_call =
@@ -498,7 +498,7 @@ if Code.ensure_loaded?(ReqLLM) do
            state
          )
          when is_binary(name) and is_integer(block_index) do
-      id = meta[:id] || "tool_#{:erlang.unique_integer([:positive])}"
+      id = meta[:id] || Utils.generate_tool_call_id()
 
       base_attrs = %{
         type: :function,
@@ -654,7 +654,7 @@ if Code.ensure_loaded?(ReqLLM) do
           metadata: meta
         })
         when is_binary(name) do
-      id = (meta || %{})[:id] || "tool_#{:erlang.unique_integer([:positive])}"
+      id = (meta || %{})[:id] || Utils.generate_tool_call_id()
 
       args_map = if is_map(args), do: args, else: %{}
 

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -785,8 +785,9 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     tool_calls_from_parts =
       parts
       |> filter_parts_for_types(["functionCall"])
-      |> Enum.map(fn part ->
-        do_process_response(model, part, nil)
+      |> Enum.with_index()
+      |> Enum.map(fn {part, call_index} ->
+        do_process_response(model, part, call_index)
       end)
 
     tool_result_from_parts =
@@ -837,8 +838,9 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     tool_calls_from_parts =
       parts
       |> filter_parts_for_types(["functionCall"])
-      |> Enum.map(fn part ->
-        do_process_response(model, part, nil)
+      |> Enum.with_index()
+      |> Enum.map(fn {part, call_index} ->
+        do_process_response(model, part, call_index)
       end)
 
     %{
@@ -861,14 +863,14 @@ defmodule LangChain.ChatModels.ChatVertexAI do
   def do_process_response(
         _model,
         %{"functionCall" => %{"args" => raw_args, "name" => name}} = data,
-        _
+        call_index
       ) do
     %{
-      call_id: "call-#{name}",
+      call_id: "call-#{name}-#{Utils.generate_short_id()}",
       name: name,
       arguments: raw_args,
       complete: true,
-      index: data["index"],
+      index: call_index,
       metadata:
         if(data["thoughtSignature"],
           do: %{thought_signature: data["thoughtSignature"]},

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -854,7 +854,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
         _
       ) do
     %{
-      call_id: "call-#{name}-#{Utils.generate_short_id()}",
+      call_id: Utils.generate_tool_call_id(),
       name: name,
       arguments: raw_args,
       complete: true,
@@ -939,12 +939,9 @@ defmodule LangChain.ChatModels.ChatVertexAI do
      )}
   end
 
-  # Gemini's `functionCall` parts carry neither an id nor a position. Both are
-  # synthesized here: a unique `call_id` keeps parallel calls to the same tool
-  # distinct when a `ToolResult` is matched back to its call or the conversation
-  # is replayed against a provider that requires unique ids, and the positional
-  # `index` keeps those same calls from merging into one during `MessageDelta`
-  # accumulation, which pairs calls by index.
+  # Gemini's `functionCall` parts carry no position. The index assigned here
+  # keeps parallel calls to the same tool from merging into a single call
+  # during `MessageDelta` accumulation, which pairs calls by index.
   defp parse_tool_calls(model, parts) do
     parts
     |> filter_parts_for_types(["functionCall"])

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -782,12 +782,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
         ContentPart.new!(%{type: type, content: part["text"]})
       end)
 
-    tool_calls_from_parts =
-      parts
-      |> filter_parts_for_types(["functionCall"])
-      |> Enum.map(fn part ->
-        do_process_response(model, part, nil)
-      end)
+    tool_calls_from_parts = parse_tool_calls(model, parts)
 
     tool_result_from_parts =
       parts
@@ -834,12 +829,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
       ContentPart.new!(%{type: :text, content: part["text"]})
     end)
 
-    tool_calls_from_parts =
-      parts
-      |> filter_parts_for_types(["functionCall"])
-      |> Enum.map(fn part ->
-        do_process_response(model, part, nil)
-      end)
+    tool_calls_from_parts = parse_tool_calls(model, parts)
 
     %{
       role: unmap_role(content_data["role"]),
@@ -868,7 +858,6 @@ defmodule LangChain.ChatModels.ChatVertexAI do
       name: name,
       arguments: raw_args,
       complete: true,
-      index: data["index"],
       metadata:
         if(data["thoughtSignature"],
           do: %{thought_signature: data["thoughtSignature"]},
@@ -948,6 +937,24 @@ defmodule LangChain.ChatModels.ChatVertexAI do
        message: "Unexpected response",
        original: other
      )}
+  end
+
+  # Gemini's `functionCall` parts carry neither an id nor a position. Both are
+  # synthesized here: a unique `call_id` keeps parallel calls to the same tool
+  # distinct when a `ToolResult` is matched back to its call or the conversation
+  # is replayed against a provider that requires unique ids, and the positional
+  # `index` keeps those same calls from merging into one during `MessageDelta`
+  # accumulation, which pairs calls by index.
+  defp parse_tool_calls(model, parts) do
+    parts
+    |> filter_parts_for_types(["functionCall"])
+    |> Enum.with_index()
+    |> Enum.map(fn {part, index} ->
+      case do_process_response(model, part, nil) do
+        %ToolCall{} = call -> %ToolCall{call | index: index}
+        other -> other
+      end
+    end)
   end
 
   @doc false

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -785,9 +785,8 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     tool_calls_from_parts =
       parts
       |> filter_parts_for_types(["functionCall"])
-      |> Enum.with_index()
-      |> Enum.map(fn {part, call_index} ->
-        do_process_response(model, part, call_index)
+      |> Enum.map(fn part ->
+        do_process_response(model, part, nil)
       end)
 
     tool_result_from_parts =
@@ -838,9 +837,8 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     tool_calls_from_parts =
       parts
       |> filter_parts_for_types(["functionCall"])
-      |> Enum.with_index()
-      |> Enum.map(fn {part, call_index} ->
-        do_process_response(model, part, call_index)
+      |> Enum.map(fn part ->
+        do_process_response(model, part, nil)
       end)
 
     %{
@@ -863,14 +861,14 @@ defmodule LangChain.ChatModels.ChatVertexAI do
   def do_process_response(
         _model,
         %{"functionCall" => %{"args" => raw_args, "name" => name}} = data,
-        call_index
+        _
       ) do
     %{
       call_id: "call-#{name}-#{Utils.generate_short_id()}",
       name: name,
       arguments: raw_args,
       complete: true,
-      index: call_index,
+      index: data["index"],
       metadata:
         if(data["thoughtSignature"],
           do: %{thought_signature: data["thoughtSignature"]},

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -850,11 +850,11 @@ defmodule LangChain.ChatModels.ChatVertexAI do
 
   def do_process_response(
         _model,
-        %{"functionCall" => %{"args" => raw_args, "name" => name}} = data,
+        %{"functionCall" => %{"args" => raw_args, "name" => name} = call} = data,
         _
       ) do
     %{
-      call_id: Utils.generate_tool_call_id(),
+      call_id: call["id"] || Utils.generate_tool_call_id(),
       name: name,
       arguments: raw_args,
       complete: true,
@@ -939,18 +939,11 @@ defmodule LangChain.ChatModels.ChatVertexAI do
      )}
   end
 
-  # Gemini's `functionCall` parts carry no position. The index assigned here
-  # keeps parallel calls to the same tool from merging into a single call
-  # during `MessageDelta` accumulation, which pairs calls by index.
   defp parse_tool_calls(model, parts) do
     parts
     |> filter_parts_for_types(["functionCall"])
-    |> Enum.with_index()
-    |> Enum.map(fn {part, index} ->
-      case do_process_response(model, part, nil) do
-        %ToolCall{} = call -> %ToolCall{call | index: index}
-        other -> other
-      end
+    |> Enum.map(fn part ->
+      do_process_response(model, part, nil)
     end)
   end
 

--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -394,10 +394,33 @@ defmodule LangChain.MessageDelta do
          %MessageDelta{tool_calls: primary_calls} = acc
        ) do
     calls = primary_calls || []
-    initial = Enum.find(calls, &(&1.index == delta_call.index))
-    merged_call = ToolCall.merge(initial, delta_call)
-    %MessageDelta{acc | tool_calls: upsert_by_index(calls, merged_call)}
+
+    case Enum.find_index(calls, &continues?(&1, delta_call)) do
+      nil ->
+        %MessageDelta{acc | tool_calls: calls ++ [delta_call]}
+
+      position ->
+        merged_call = ToolCall.merge(Enum.at(calls, position), delta_call)
+        %MessageDelta{acc | tool_calls: List.replace_at(calls, position, merged_call)}
+    end
   end
+
+  # A fragment continues the accumulated call sharing its index. Providers that
+  # report an id for every call but no index, as Gemini's function call parts
+  # do, leave every call on the same index, so two ids that disagree mark two
+  # separate calls. A fragment carrying no id of its own always continues the
+  # call at its index, which is how OpenAI streams argument fragments.
+  @spec continues?(ToolCall.t(), ToolCall.t()) :: boolean()
+  defp continues?(%ToolCall{} = call, %ToolCall{} = delta_call) do
+    call.index == delta_call.index and not separate_calls?(call, delta_call)
+  end
+
+  @spec separate_calls?(ToolCall.t(), ToolCall.t()) :: boolean()
+  defp separate_calls?(%ToolCall{call_id: id}, %ToolCall{call_id: delta_id})
+       when is_binary(id) and is_binary(delta_id),
+       do: id != delta_id
+
+  defp separate_calls?(_call, _delta_call), do: false
 
   @spec update_index(t(), t()) :: t()
   defp update_index(%MessageDelta{} = primary, %MessageDelta{index: idx}) when is_number(idx) do
@@ -431,15 +454,6 @@ defmodule LangChain.MessageDelta do
   end
 
   defp update_status(%MessageDelta{} = primary, %MessageDelta{}), do: primary
-
-  # Insert or update tool call in list by matching on index field
-  @spec upsert_by_index([ToolCall.t()], ToolCall.t()) :: [ToolCall.t()]
-  defp upsert_by_index(calls, call) do
-    case Enum.find_index(calls, &(&1.index == call.index)) do
-      nil -> calls ++ [call]
-      pos -> List.replace_at(calls, pos, call)
-    end
-  end
 
   @doc """
   Convert the MessageDelta's merged content to a string. Specify the type of

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -539,4 +539,15 @@ defmodule LangChain.Utils do
     |> String.replace("_", " ")
     |> String.capitalize()
   end
+
+  @doc """
+  Generates a short random hex string. Used for synthesizing a unique id when
+  a provider's API response doesn't include one, such as Gemini's function
+  call parts. Ecto.UUID.generate() would have been sufficient, but it's
+  unnecessarily too long.
+  """
+  @spec generate_short_id() :: String.t()
+  def generate_short_id do
+    :crypto.strong_rand_bytes(6) |> Base.encode16(case: :lower)
+  end
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -541,10 +541,10 @@ defmodule LangChain.Utils do
   end
 
   @doc """
-  Generates a short random hex string. Used for synthesizing a unique id when
-  a provider's API response doesn't include one, such as Gemini's function
-  call parts. Ecto.UUID.generate() would have been sufficient, but it's
-  unnecessarily too long.
+  Generate a short, random, lowercase hex string.
+
+  Used to synthesize an id when a provider's API response omits one, such as
+  Gemini's function call parts, which identify a tool call by name only.
   """
   @spec generate_short_id() :: String.t()
   def generate_short_id do

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -543,12 +543,13 @@ defmodule LangChain.Utils do
   @doc """
   Generate an id for a tool call.
 
-  Some providers identify a tool call by name only, such as Gemini's function
-  call parts. An id is synthesized for those so each call in a conversation
-  stays distinct from every other one.
+  Some providers omit an id for a tool call, or identify it by name only, as
+  Gemini's function call parts do. An id is synthesized for those so each call
+  stays distinct from every other one, including across a conversation that is
+  stored and later reloaded.
   """
   @spec generate_tool_call_id() :: String.t()
   def generate_tool_call_id do
-    "tool_#{:erlang.unique_integer([:positive])}"
+    Ecto.UUID.generate()
   end
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -541,13 +541,14 @@ defmodule LangChain.Utils do
   end
 
   @doc """
-  Generate a short, random, lowercase hex string.
+  Generate an id for a tool call.
 
-  Used to synthesize an id when a provider's API response omits one, such as
-  Gemini's function call parts, which identify a tool call by name only.
+  Some providers identify a tool call by name only, such as Gemini's function
+  call parts. An id is synthesized for those so each call in a conversation
+  stays distinct from every other one.
   """
-  @spec generate_short_id() :: String.t()
-  def generate_short_id do
-    :crypto.strong_rand_bytes(6) |> Base.encode16(case: :lower)
+  @spec generate_tool_call_id() :: String.t()
+  def generate_tool_call_id do
+    "tool_#{:erlang.unique_integer([:positive])}"
   end
 end

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -887,6 +887,64 @@ defmodule ChatModels.ChatGoogleAITest do
       assert call.metadata == nil
     end
 
+    test "gives each function call a unique id and its position", %{model: model} do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "role" => "model",
+              "parts" => [
+                %{"functionCall" => %{"args" => %{"city" => "Denver"}, "name" => "get_weather"}},
+                %{"functionCall" => %{"args" => %{"city" => "Moab"}, "name" => "get_weather"}}
+              ]
+            },
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ]
+      }
+
+      assert [%Message{} = msg] = ChatGoogleAI.do_process_response(model, response)
+
+      assert [
+               %ToolCall{name: "get_weather", arguments: %{"city" => "Denver"}, index: 0} = denver,
+               %ToolCall{name: "get_weather", arguments: %{"city" => "Moab"}, index: 1} = moab
+             ] = msg.tool_calls
+
+      assert denver.call_id != moab.call_id
+    end
+
+    test "keeps parallel function calls separate when merging deltas", %{model: model} do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "role" => "model",
+              "parts" => [
+                %{"functionCall" => %{"args" => %{"city" => "Denver"}, "name" => "get_weather"}},
+                %{"functionCall" => %{"args" => %{"city" => "Moab"}, "name" => "get_weather"}}
+              ]
+            },
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ]
+      }
+
+      assert [%MessageDelta{} = delta] =
+               ChatGoogleAI.do_process_response(model, response, MessageDelta)
+
+      assert {:ok, %Message{} = msg} =
+               [delta] |> MessageDelta.merge_deltas() |> MessageDelta.to_message()
+
+      assert [
+               %ToolCall{name: "get_weather", arguments: %{"city" => "Denver"}} = denver,
+               %ToolCall{name: "get_weather", arguments: %{"city" => "Moab"}} = moab
+             ] = msg.tool_calls
+
+      assert denver.call_id != moab.call_id
+    end
+
     test "handles no parts in content", %{model: model} do
       response = %{
         "candidates" => [

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -887,7 +887,33 @@ defmodule ChatModels.ChatGoogleAITest do
       assert call.metadata == nil
     end
 
-    test "gives each function call a unique id and its position", %{model: model} do
+    test "uses the id returned with a function call", %{model: model} do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "role" => "model",
+              "parts" => [
+                %{
+                  "functionCall" => %{
+                    "args" => %{"city" => "Denver"},
+                    "id" => "call_4162774",
+                    "name" => "get_weather"
+                  }
+                }
+              ]
+            },
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ]
+      }
+
+      assert [%Message{} = msg] = ChatGoogleAI.do_process_response(model, response)
+      assert [%ToolCall{call_id: "call_4162774", name: "get_weather"}] = msg.tool_calls
+    end
+
+    test "synthesizes a distinct id per call when the response omits one", %{model: model} do
       response = %{
         "candidates" => [
           %{
@@ -907,42 +933,49 @@ defmodule ChatModels.ChatGoogleAITest do
       assert [%Message{} = msg] = ChatGoogleAI.do_process_response(model, response)
 
       assert [
-               %ToolCall{name: "get_weather", arguments: %{"city" => "Denver"}, index: 0} = denver,
-               %ToolCall{name: "get_weather", arguments: %{"city" => "Moab"}, index: 1} = moab
+               %ToolCall{arguments: %{"city" => "Denver"}} = denver,
+               %ToolCall{arguments: %{"city" => "Moab"}} = moab
              ] = msg.tool_calls
 
+      assert is_binary(denver.call_id)
       assert denver.call_id != moab.call_id
     end
 
-    test "keeps parallel function calls separate when merging deltas", %{model: model} do
-      response = %{
-        "candidates" => [
-          %{
-            "content" => %{
-              "role" => "model",
-              "parts" => [
-                %{"functionCall" => %{"args" => %{"city" => "Denver"}, "name" => "get_weather"}},
-                %{"functionCall" => %{"args" => %{"city" => "Moab"}, "name" => "get_weather"}}
-              ]
-            },
-            "finishReason" => "STOP",
-            "index" => 0
-          }
-        ]
-      }
+    test "keeps parallel function calls separate when each arrives in its own chunk", %{
+      model: model
+    } do
+      chunk = fn city, id ->
+        %{
+          "candidates" => [
+            %{
+              "content" => %{
+                "role" => "model",
+                "parts" => [
+                  %{
+                    "functionCall" => %{
+                      "args" => %{"city" => city},
+                      "id" => id,
+                      "name" => "get_weather"
+                    }
+                  }
+                ]
+              },
+              "index" => 0
+            }
+          ]
+        }
+      end
 
-      assert [%MessageDelta{} = delta] =
-               ChatGoogleAI.do_process_response(model, response, MessageDelta)
+      deltas =
+        [chunk.("Denver", "call_1375045"), chunk.("Moab", "call_1375049")]
+        |> Enum.flat_map(&ChatGoogleAI.do_process_response(model, &1, MessageDelta))
 
-      assert {:ok, %Message{} = msg} =
-               [delta] |> MessageDelta.merge_deltas() |> MessageDelta.to_message()
+      merged = MessageDelta.merge_deltas(deltas)
 
       assert [
-               %ToolCall{name: "get_weather", arguments: %{"city" => "Denver"}} = denver,
-               %ToolCall{name: "get_weather", arguments: %{"city" => "Moab"}} = moab
-             ] = msg.tool_calls
-
-      assert denver.call_id != moab.call_id
+               %ToolCall{call_id: "call_1375045", arguments: %{"city" => "Denver"}},
+               %ToolCall{call_id: "call_1375049", arguments: %{"city" => "Moab"}}
+             ] = merged.tool_calls
     end
 
     test "handles no parts in content", %{model: model} do

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -16,7 +16,7 @@ defmodule ChatModels.ChatGoogleAITest do
   alias LangChain.LangChainError
   alias LangChain.ChatModels.ChatGoogleAI
 
-  @test_model "gemini-2.5-flash"
+  @test_model "gemini-3.7-flash"
 
   setup do
     {:ok, hello_world} =
@@ -1929,7 +1929,7 @@ defmodule ChatModels.ChatGoogleAITest do
       alias LangChain.Message
       alias LangChain.NativeTool
 
-      model = ChatGoogleAI.new!(%{temperature: 0, stream: false, model: "gemini-2.0-flash"})
+      model = ChatGoogleAI.new!(%{temperature: 0, stream: false, model: @test_model})
 
       {:ok, updated_chain} =
         %{llm: model, verbose: false, stream: false}
@@ -2105,7 +2105,7 @@ defmodule ChatModels.ChatGoogleAITest do
     alias LangChain.Message.ContentPart
     alias LangChain.Utils.ChainResult
 
-    model = ChatGoogleAI.new!(%{temperature: 0, stream: false, model: "gemini-1.5-flash"})
+    model = ChatGoogleAI.new!(%{temperature: 0, stream: false, model: @test_model})
 
     image_data =
       File.read!("test/support/images/barn_owl.jpg")

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -15,7 +15,7 @@ defmodule ChatModels.ChatVertexAITest do
   alias LangChain.LangChainError
   alias LangChain.TokenUsage
 
-  @test_model "gemini-2.5-flash"
+  @test_model "gemini-3.7-flash"
 
   setup do
     {:ok, hello_world} =

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -902,7 +902,33 @@ defmodule ChatModels.ChatVertexAITest do
       assert call.arguments == args
     end
 
-    test "gives each function call a unique id and its position", %{model: model} do
+    test "uses the id returned with a function call", %{model: model} do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "role" => "model",
+              "parts" => [
+                %{
+                  "functionCall" => %{
+                    "args" => %{"city" => "Denver"},
+                    "id" => "call_4162774",
+                    "name" => "get_weather"
+                  }
+                }
+              ]
+            },
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ]
+      }
+
+      assert [%Message{} = msg] = ChatVertexAI.do_process_response(model, response)
+      assert [%ToolCall{call_id: "call_4162774", name: "get_weather"}] = msg.tool_calls
+    end
+
+    test "synthesizes a distinct id per call when the response omits one", %{model: model} do
       response = %{
         "candidates" => [
           %{
@@ -922,41 +948,49 @@ defmodule ChatModels.ChatVertexAITest do
       assert [%Message{} = msg] = ChatVertexAI.do_process_response(model, response)
 
       assert [
-               %ToolCall{name: "get_weather", arguments: %{"city" => "Denver"}, index: 0} = denver,
-               %ToolCall{name: "get_weather", arguments: %{"city" => "Moab"}, index: 1} = moab
+               %ToolCall{arguments: %{"city" => "Denver"}} = denver,
+               %ToolCall{arguments: %{"city" => "Moab"}} = moab
              ] = msg.tool_calls
 
+      assert is_binary(denver.call_id)
       assert denver.call_id != moab.call_id
     end
 
-    test "keeps parallel function calls separate when merging deltas", %{model: model} do
-      response = %{
-        "candidates" => [
-          %{
-            "content" => %{
-              "role" => "model",
-              "parts" => [
-                %{"functionCall" => %{"args" => %{"city" => "Denver"}, "name" => "get_weather"}},
-                %{"functionCall" => %{"args" => %{"city" => "Moab"}, "name" => "get_weather"}}
-              ]
-            },
-            "finishReason" => "STOP",
-            "index" => 0
-          }
-        ]
-      }
+    test "keeps parallel function calls separate when each arrives in its own chunk", %{
+      model: model
+    } do
+      chunk = fn city, id ->
+        %{
+          "candidates" => [
+            %{
+              "content" => %{
+                "role" => "model",
+                "parts" => [
+                  %{
+                    "functionCall" => %{
+                      "args" => %{"city" => city},
+                      "id" => id,
+                      "name" => "get_weather"
+                    }
+                  }
+                ]
+              },
+              "index" => 0
+            }
+          ]
+        }
+      end
 
-      assert [%MessageDelta{} = delta] =
-               ChatVertexAI.do_process_response(model, response, MessageDelta)
+      deltas =
+        [chunk.("Denver", "call_1375045"), chunk.("Moab", "call_1375049")]
+        |> Enum.flat_map(&ChatVertexAI.do_process_response(model, &1, MessageDelta))
 
-      merged = MessageDelta.merge_deltas([delta])
+      merged = MessageDelta.merge_deltas(deltas)
 
       assert [
-               %ToolCall{name: "get_weather", arguments: %{"city" => "Denver"}} = denver,
-               %ToolCall{name: "get_weather", arguments: %{"city" => "Moab"}} = moab
+               %ToolCall{call_id: "call_1375045", arguments: %{"city" => "Denver"}},
+               %ToolCall{call_id: "call_1375049", arguments: %{"city" => "Moab"}}
              ] = merged.tool_calls
-
-      assert denver.call_id != moab.call_id
     end
 
     test "handles receiving MessageDeltas as well", %{model: model} do

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -902,6 +902,63 @@ defmodule ChatModels.ChatVertexAITest do
       assert call.arguments == args
     end
 
+    test "gives each function call a unique id and its position", %{model: model} do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "role" => "model",
+              "parts" => [
+                %{"functionCall" => %{"args" => %{"city" => "Denver"}, "name" => "get_weather"}},
+                %{"functionCall" => %{"args" => %{"city" => "Moab"}, "name" => "get_weather"}}
+              ]
+            },
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ]
+      }
+
+      assert [%Message{} = msg] = ChatVertexAI.do_process_response(model, response)
+
+      assert [
+               %ToolCall{name: "get_weather", arguments: %{"city" => "Denver"}, index: 0} = denver,
+               %ToolCall{name: "get_weather", arguments: %{"city" => "Moab"}, index: 1} = moab
+             ] = msg.tool_calls
+
+      assert denver.call_id != moab.call_id
+    end
+
+    test "keeps parallel function calls separate when merging deltas", %{model: model} do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "role" => "model",
+              "parts" => [
+                %{"functionCall" => %{"args" => %{"city" => "Denver"}, "name" => "get_weather"}},
+                %{"functionCall" => %{"args" => %{"city" => "Moab"}, "name" => "get_weather"}}
+              ]
+            },
+            "finishReason" => "STOP",
+            "index" => 0
+          }
+        ]
+      }
+
+      assert [%MessageDelta{} = delta] =
+               ChatVertexAI.do_process_response(model, response, MessageDelta)
+
+      merged = MessageDelta.merge_deltas([delta])
+
+      assert [
+               %ToolCall{name: "get_weather", arguments: %{"city" => "Denver"}} = denver,
+               %ToolCall{name: "get_weather", arguments: %{"city" => "Moab"}} = moab
+             ] = merged.tool_calls
+
+      assert denver.call_id != moab.call_id
+    end
+
     test "handles receiving MessageDeltas as well", %{model: model} do
       response = %{
         "candidates" => [

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -1980,4 +1980,38 @@ defmodule LangChain.MessageDeltaTest do
       refute MessageDelta.all_tools_terminal?(%MessageDelta{role: :assistant, tool_calls: []})
     end
   end
+
+  describe "merge_delta/2 with tool calls" do
+    test "merges an argument fragment into the call sharing its index" do
+      first = %MessageDelta{
+        role: :assistant,
+        tool_calls: [ToolCall.new!(%{call_id: "call_abc", name: "get_weather", index: 0})]
+      }
+
+      fragment = %MessageDelta{
+        role: :assistant,
+        tool_calls: [ToolCall.new!(%{arguments: "{\"city\":", index: 0})]
+      }
+
+      merged = MessageDelta.merge_delta(first, fragment)
+
+      assert [%ToolCall{call_id: "call_abc", arguments: "{\"city\":"}] = merged.tool_calls
+    end
+
+    test "keeps calls apart when their ids disagree on the same index" do
+      denver = %MessageDelta{
+        role: :assistant,
+        tool_calls: [ToolCall.new!(%{call_id: "call_1", name: "get_weather"})]
+      }
+
+      moab = %MessageDelta{
+        role: :assistant,
+        tool_calls: [ToolCall.new!(%{call_id: "call_2", name: "get_weather"})]
+      }
+
+      merged = MessageDelta.merge_delta(denver, moab)
+
+      assert [%ToolCall{call_id: "call_1"}, %ToolCall{call_id: "call_2"}] = merged.tool_calls
+    end
+  end
 end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -557,13 +557,13 @@ defmodule LangChain.UtilsTest do
     end
   end
 
-  describe "generate_short_id/0" do
-    test "returns a short lowercase hex string" do
-      assert Utils.generate_short_id() =~ ~r/^[0-9a-f]{12}$/
+  describe "generate_tool_call_id/0" do
+    test "returns a prefixed id" do
+      assert Utils.generate_tool_call_id() =~ ~r/^tool_\d+$/
     end
 
     test "returns a different value on each call" do
-      ids = Enum.map(1..100, fn _ -> Utils.generate_short_id() end)
+      ids = Enum.map(1..100, fn _ -> Utils.generate_tool_call_id() end)
 
       assert ids == Enum.uniq(ids)
     end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -556,4 +556,16 @@ defmodule LangChain.UtilsTest do
       assert nil == Ecto.Changeset.get_change(result, :content)
     end
   end
+
+  describe "generate_short_id/0" do
+    test "returns a short lowercase hex string" do
+      assert Utils.generate_short_id() =~ ~r/^[0-9a-f]{12}$/
+    end
+
+    test "returns a different value on each call" do
+      ids = Enum.map(1..100, fn _ -> Utils.generate_short_id() end)
+
+      assert ids == Enum.uniq(ids)
+    end
+  end
 end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -558,8 +558,8 @@ defmodule LangChain.UtilsTest do
   end
 
   describe "generate_tool_call_id/0" do
-    test "returns a prefixed id" do
-      assert Utils.generate_tool_call_id() =~ ~r/^tool_\d+$/
+    test "returns a UUID" do
+      assert {:ok, _uuid} = Ecto.UUID.cast(Utils.generate_tool_call_id())
     end
 
     test "returns a different value on each call" do


### PR DESCRIPTION
Unlike anthropic's method where they generate the tool_call_id themselves, Google's tool_call_id is implemented here by langchain. Unfortunately it is not unique. the id is just the name of the function.

Sometimes, we might need to switch model providers on one particular conversation.
Anthropic complains if we ask it to continue gemini's conversation because the tool call ids are not unique.

This PR fixes that.