### PR TITLE
Expose the exception LangChain rescues from a raising tool

### DIFF
--- a/lib/chains/chain_callbacks.ex
+++ b/lib/chains/chain_callbacks.ex
@@ -215,15 +215,45 @@ defmodule LangChain.Chains.ChainCallbacks do
   @typedoc """
   Executed when a single tool execution fails.
 
-  Fires when tool execution raises an exception or returns an error result.
+  Fires when tool execution raises an exception, returns an error result, names a
+  tool that doesn't exist, or is rejected during human review.
 
   - First argument: LLMChain.t()
   - Second argument: ToolCall that failed
-  - Third argument: Error reason or exception
+  - Third argument: The error content returned to the model
 
   The handler's return value is discarded.
   """
   @type chain_tool_execution_failed :: (LLMChain.t(), ToolCall.t(), term() -> any())
+
+  @typedoc """
+  Executed when a tool execution raises an exception that LangChain rescues.
+
+  Fires in addition to `:on_tool_execution_failed`, not instead of it. That
+  callback receives the message the model sees; this one receives the exception
+  itself, which is what an error tracker needs in order to group and fingerprint
+  the failure.
+
+  Does not fire for `{:error, reason}` results, tool calls naming a tool that
+  doesn't exist, human rejections, or interrupts. None of those involve a rescued
+  exception.
+
+  - First argument: LLMChain.t()
+  - Second argument: ToolCall that raised
+  - Third argument: The rescued exception
+  - Fourth argument: The exception's stacktrace
+
+  Fires after the tool's OpenTelemetry span has closed, so attributes set here land
+  on the enclosing chain span rather than on `execute_tool`.
+
+  Exceptions and stacktraces can carry application data from the frames they
+  captured. LangChain never sends them to the model, but handlers should not expose
+  them to untrusted clients.
+
+  The handler's return value is discarded.
+  """
+  @type chain_tool_execution_exception ::
+          (LLMChain.t(), ToolCall.t(), Exception.t(), Exception.stacktrace() -> any())
 
   @typedoc """
   Executed when one or more tools return an interrupt signal.
@@ -342,6 +372,7 @@ defmodule LangChain.Chains.ChainCallbacks do
           optional(:on_tool_pre_execution) => chain_tool_pre_execution(),
           optional(:on_tool_execution_completed) => chain_tool_execution_completed(),
           optional(:on_tool_execution_failed) => chain_tool_execution_failed(),
+          optional(:on_tool_execution_exception) => chain_tool_execution_exception(),
           optional(:on_tool_interrupted) => chain_tool_interrupted(),
           optional(:on_tool_response_created) => chain_tool_response_created(),
           optional(:on_llm_error) => chain_llm_error(),

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1524,22 +1524,7 @@ defmodule LangChain.Chains.LLMChain do
       # Fire completed/failed callbacks for async tools and extract results
       async_tool_results =
         Enum.map(async_results, fn {call, _func, result} ->
-          cond do
-            result.is_interrupt ->
-              :ok
-
-            result.is_error ->
-              Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [
-                chain,
-                call,
-                result.content
-              ])
-
-            true ->
-              Callbacks.fire(chain.callbacks, :on_tool_execution_completed, [chain, call, result])
-          end
-
-          result
+          fire_tool_execution_callbacks(chain, call, result)
         end)
 
       # Execute sync tools with immediate callbacks
@@ -1548,23 +1533,7 @@ defmodule LangChain.Chains.LLMChain do
           Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [chain, call, func])
           result = execute_tool_call(call, func, verbose: verbose, context: use_context)
 
-          # Fire completed/failed callback immediately after execution
-          cond do
-            result.is_interrupt ->
-              :ok
-
-            result.is_error ->
-              Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [
-                chain,
-                call,
-                result.content
-              ])
-
-            true ->
-              Callbacks.fire(chain.callbacks, :on_tool_execution_completed, [chain, call, result])
-          end
-
-          result
+          fire_tool_execution_callbacks(chain, call, result)
         end)
 
       # log invalid tool calls (can't augment - no func available)
@@ -1684,27 +1653,7 @@ defmodule LangChain.Chains.LLMChain do
                 result =
                   execute_tool_call(tool_call, func, verbose: verbose, context: use_context)
 
-                # Fire completed/failed callback after execution (skip interrupts)
-                cond do
-                  result.is_interrupt ->
-                    :ok
-
-                  result.is_error ->
-                    Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [
-                      chain,
-                      tool_call,
-                      result.content
-                    ])
-
-                  true ->
-                    Callbacks.fire(chain.callbacks, :on_tool_execution_completed, [
-                      chain,
-                      tool_call,
-                      result
-                    ])
-                end
-
-                result
+                fire_tool_execution_callbacks(chain, tool_call, result)
 
               nil ->
                 error_msg = "Tool '#{tool_call.name}' not found"
@@ -1747,27 +1696,7 @@ defmodule LangChain.Chains.LLMChain do
                 result =
                   execute_tool_call(edited_call, func, verbose: verbose, context: use_context)
 
-                # Fire completed/failed callback after execution (skip interrupts)
-                cond do
-                  result.is_interrupt ->
-                    :ok
-
-                  result.is_error ->
-                    Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [
-                      chain,
-                      edited_call,
-                      result.content
-                    ])
-
-                  true ->
-                    Callbacks.fire(chain.callbacks, :on_tool_execution_completed, [
-                      chain,
-                      edited_call,
-                      result
-                    ])
-                end
-
-                result
+                fire_tool_execution_callbacks(chain, edited_call, result)
 
               nil ->
                 error_msg = "Tool '#{tool_call.name}' not found"
@@ -1867,6 +1796,45 @@ defmodule LangChain.Chains.LLMChain do
     :ok
   end
 
+  # Fires the per-result tool callbacks for one executed tool call and returns the
+  # result unchanged, so call sites can use it inline.
+  #
+  # `:on_tool_execution_exception` fires in addition to `:on_tool_execution_failed`
+  # rather than instead of it. A rescued exception is still a failure, and handlers
+  # registered for the lifecycle event must keep seeing it.
+  @spec fire_tool_execution_callbacks(t(), ToolCall.t(), ToolResult.t()) :: ToolResult.t()
+  defp fire_tool_execution_callbacks(
+         %LLMChain{} = chain,
+         %ToolCall{} = call,
+         %ToolResult{} = result
+       ) do
+    cond do
+      result.is_interrupt ->
+        :ok
+
+      result.is_error ->
+        Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [chain, call, result.content])
+
+      true ->
+        Callbacks.fire(chain.callbacks, :on_tool_execution_completed, [chain, call, result])
+    end
+
+    case result.exception do
+      {exception, stacktrace} ->
+        Callbacks.fire(chain.callbacks, :on_tool_execution_exception, [
+          chain,
+          call,
+          exception,
+          stacktrace
+        ])
+
+      nil ->
+        :ok
+    end
+
+    result
+  end
+
   @doc """
   Execute the tool call with the tool. Returns the tool's message response.
   """
@@ -1960,18 +1928,35 @@ defmodule LangChain.Chains.LLMChain do
                 display_text: function.display_text,
                 is_error: true
               })
+
+            {:error, reason, {_exception, _stacktrace} = rescued} when is_binary(reason) ->
+              if verbose, do: IO.inspect(reason, label: "FUNCTION RAISED")
+
+              ToolResult.new!(%{
+                tool_call_id: call.call_id,
+                content: reason,
+                name: function.name,
+                display_text: function.display_text,
+                is_error: true,
+                is_exception: true,
+                exception: rescued
+              })
           end
         rescue
           err ->
+            stacktrace = __STACKTRACE__
+
             Logger.warning(fn ->
-              "Function #{function.name} failed in execution. Exception: #{LangChainError.format_exception(err, __STACKTRACE__)}"
+              "Function #{function.name} failed in execution. Exception: #{LangChainError.format_exception(err, stacktrace)}"
             end)
 
             ToolResult.new!(%{
               tool_call_id: call.call_id,
               name: function.name,
               content: "ERROR executing tool: #{inspect(err)}",
-              is_error: true
+              is_error: true,
+              is_exception: true,
+              exception: {err, stacktrace}
             })
         end
       end,

--- a/lib/function.ex
+++ b/lib/function.ex
@@ -300,6 +300,12 @@ defmodule LangChain.Function do
   @type context :: nil | %{atom() => any()}
 
   @typedoc """
+  A rescued exception and its stacktrace, as returned alongside the model-facing
+  message in a `{:error, message, execution_exception()}` result.
+  """
+  @type execution_exception :: {Exception.t(), Exception.stacktrace()}
+
+  @typedoc """
   Return shape for a `:parse_args` callback. See module doc for full details.
   """
   @type parse_result ::
@@ -366,6 +372,21 @@ defmodule LangChain.Function do
   Execute the function passing in arguments and additional optional context.
   This is called by a `LangChain.Chains.LLMChain` when a `Function` execution is
   requested by the LLM.
+
+  ## Return shapes
+
+  - `{:ok, llm_result}` - success
+  - `{:ok, llm_result, processed_content}` - success, keeping a native Elixir result
+  - `{:interrupt, display_message, interrupt_data}` - paused for review
+  - `{:error, message}` - the tool returned an error, or a check rejected the arguments
+  - `{:error, message, {exception, stacktrace}}` - the tool, or its `:parse_args`
+    parser, raised and the exception was rescued
+
+  The last shape mirrors `{:ok, llm_result, processed_content}`: the second element
+  is the message the model sees, and the third is the native Elixir detail kept for
+  the application. It only appears when an exception was actually rescued, so
+  matching on `{:error, message}` still covers every error a tool returns
+  deliberately.
   """
   @spec execute(t(), arguments(), context()) :: any() | no_return()
   def execute(%Function{function: fun} = function, arguments, context) do
@@ -391,7 +412,10 @@ defmodule LangChain.Function do
   # `:on_tool_response_created` callbacks and `[:langchain, :tool, :call]`
   # telemetry firing on parse failures, which downstream consumers rely on for
   # token usage accounting and trajectory analysis.
-  @spec run_parse_args(t(), arguments()) :: {:ok, map()} | {:error, String.t()}
+  @spec run_parse_args(t(), arguments()) ::
+          {:ok, map()}
+          | {:error, String.t()}
+          | {:error, String.t(), execution_exception()}
   defp run_parse_args(%Function{parse_args: nil}, arguments), do: {:ok, arguments}
 
   defp run_parse_args(%Function{parse_args: parser, name: name}, arguments)
@@ -406,7 +430,8 @@ defmodule LangChain.Function do
             LangChainError.format_exception(err, __STACKTRACE__)
         end)
 
-        {:error, "ERROR: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"}
+        {:error, "ERROR: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}",
+         {err, __STACKTRACE__}}
     end
   end
 
@@ -614,6 +639,7 @@ defmodule LangChain.Function do
           | {:ok, any(), any()}
           | {:interrupt, String.t(), any()}
           | {:error, String.t()}
+          | {:error, String.t(), execution_exception()}
   defp execute_with_error_handling(function, fun, arguments, context) do
     fun.(arguments, context)
     |> normalize_execution_result(function)
@@ -623,10 +649,13 @@ defmodule LangChain.Function do
         "Function! #{function.name} failed in execution. Exception: #{LangChainError.format_exception(err, __STACKTRACE__)}"
       end)
 
-      case argument_error_message(err, function, fun, arguments) do
-        nil -> {:error, "ERROR: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"}
-        message -> {:error, message}
-      end
+      message =
+        case argument_error_message(err, function, fun, arguments) do
+          nil -> "ERROR: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"
+          message -> message
+        end
+
+      {:error, message, {err, __STACKTRACE__}}
   end
 
   # The required-parameter check can't reach a tool that reads an *optional*

--- a/lib/message/tool_result.ex
+++ b/lib/message/tool_result.ex
@@ -16,6 +16,23 @@ defmodule LangChain.Message.ToolResult do
   Advanced use: You can use the `options` field for LLM-specific features like
   cache control.
 
+  ## Errors and rescued exceptions
+
+  `is_error` marks any failed result: a tool that returned `{:error, reason}`, a
+  tool call naming a tool that doesn't exist, a rejected human review, or a tool
+  that raised.
+
+  `is_exception` narrows that to results where LangChain rescued an exception, and
+  `exception` holds the `{exception, stacktrace}` pair it rescued. The exception is
+  never sent to the LLM — only the formatted message in `content` is — and it is
+  never persisted: `exception` is a virtual field, so a result restored from
+  storage carries `is_exception: true` with `exception: nil`. Code that needs the
+  exception itself should read it during the run, most conveniently through the
+  `:on_tool_execution_exception` callback.
+
+  Because `content` carries LangChain's formatted exception message and source
+  location, tools should not put secrets in exception messages.
+
   To do this, the Elixir function's result should be a `{:ok, "String response
   for LLM", native_elixir_data}`. See `LangChain.Function` for details and
   examples.
@@ -42,6 +59,11 @@ defmodule LangChain.Message.ToolResult do
     field :display_text, :string
     # flag if the result is an error
     field :is_error, :boolean, default: false
+    # flag if the result came from an exception LangChain rescued
+    field :is_exception, :boolean, default: false
+    # the rescued `{exception, stacktrace}`. Not sent to the LLM, virtual only, and
+    # absent from a result restored from storage even when `is_exception` is true.
+    field :exception, :any, virtual: true
     # flag indicating this tool result represents a paused/interrupted tool
     field :is_interrupt, :boolean, default: false
     # opaque interrupt data (not sent to LLM, virtual only)
@@ -60,6 +82,8 @@ defmodule LangChain.Message.ToolResult do
     :processed_content,
     :display_text,
     :is_error,
+    :is_exception,
+    :exception,
     :is_interrupt,
     :interrupt_data,
     :options

--- a/lib/open_telemetry/enrich.ex
+++ b/lib/open_telemetry/enrich.ex
@@ -35,8 +35,7 @@ defmodule LangChain.OpenTelemetry.Enrich do
   | Called from | Span it enriches |
   |---|---|
   | A tool's own function body | `execute_tool {tool}` |
-  | `:on_tool_pre_execution`, `:on_tool_execution_completed`, `:on_tool_execution_failed` | `execute_tool {tool}` |
-  | `:on_message_processed`, `:on_llm_token_usage` | `invoke_agent {chain_type}` |
+  | `:on_message_processed`, `:on_llm_token_usage`, and the tool callbacks (`:on_tool_pre_execution`, `:on_tool_execution_completed`, `:on_tool_execution_failed`, `:on_tool_execution_exception`) | `invoke_agent {chain_type}` |
   | Outside any LangChain operation | Whatever span your app has open, or nothing |
 
   Attributes set this way apply to that one span. They are not inherited by sibling

--- a/lib/open_telemetry/span_handler.ex
+++ b/lib/open_telemetry/span_handler.ex
@@ -275,7 +275,12 @@ if Code.ensure_loaded?(:opentelemetry) do
           Attributes.tool_call_stop(metadata, config)
         end)
 
-      end_span(metadata, stop_attrs)
+      # A tool that raised is rescued by `LLMChain` and reported through the normal
+      # `:stop` event, so without this the span closes unset and a crashing tool is
+      # indistinguishable from a working one. `:stop` is the only point at which the
+      # span is still open — the tool callbacks all fire after `end_span/3` — so the
+      # exception has to be recorded here or not at all.
+      end_span(metadata, stop_attrs, rescued_exception(metadata))
     end
 
     defp do_handle_event(
@@ -288,6 +293,16 @@ if Code.ensure_loaded?(:opentelemetry) do
     end
 
     # --- Private helpers ---
+
+    # Only a rescued exception marks the span errored. A tool returning
+    # `{:error, reason}` is a handled outcome the model is expected to react to, and
+    # flagging those would make error rates meaningless.
+    defp rescued_exception(metadata) do
+      case metadata[:tool_result] do
+        %{is_exception: true, exception: {exception, stacktrace}} -> {exception, stacktrace}
+        _other -> nil
+      end
+    end
 
     # The subset of a chain's attributes that nested `chat` and `execute_tool` spans
     # should also carry: everything the caller put in `:otel_attributes`, plus the
@@ -401,7 +416,7 @@ if Code.ensure_loaded?(:opentelemetry) do
       end
     end
 
-    defp end_span(metadata, extra_attributes) do
+    defp end_span(metadata, extra_attributes, rescued \\ nil) do
       call_id = metadata[:call_id]
 
       case pop_span(call_id) do
@@ -414,6 +429,8 @@ if Code.ensure_loaded?(:opentelemetry) do
             if extra_attributes != [] do
               OpenTelemetry.Span.set_attributes(span_ctx, extra_attributes)
             end
+
+            record_rescued(span_ctx, rescued)
           after
             OpenTelemetry.Span.end_span(span_ctx)
             OpenTelemetry.Ctx.detach(token)
@@ -446,6 +463,22 @@ if Code.ensure_loaded?(:opentelemetry) do
         end)
 
         []
+    end
+
+    # Mirrors the recording half of `end_span_on_exception/1`. Kept separate because a
+    # rescued exception rides a `:stop` event, where the status and attributes derived
+    # from the result have already been applied.
+    defp record_rescued(_span_ctx, nil), do: :ok
+
+    defp record_rescued(span_ctx, {exception, stacktrace}) do
+      OpenTelemetry.Span.set_status(
+        span_ctx,
+        OpenTelemetry.status(:error, Exception.message(exception))
+      )
+
+      OpenTelemetry.Span.set_attributes(span_ctx, [{"error.type", error_type(exception)}])
+      OpenTelemetry.Span.record_exception(span_ctx, exception, stacktrace)
+      :ok
     end
 
     defp end_span_on_exception(metadata) do

--- a/lib/trajectory.ex
+++ b/lib/trajectory.ex
@@ -544,7 +544,8 @@ defmodule LangChain.Trajectory do
         %{
           name: tr.name,
           content: ContentPart.content_to_string(tr.content),
-          is_error: tr.is_error
+          is_error: tr.is_error,
+          is_exception: tr.is_exception
         }
       end)
     )

--- a/test/chains/llm_chain_tool_callbacks_test.exs
+++ b/test/chains/llm_chain_tool_callbacks_test.exs
@@ -833,4 +833,217 @@ defmodule LangChain.Chains.LLMChainToolCallbacksTest do
       assert_received {:pre, %{"x" => 99}}
     end
   end
+
+  describe "on_tool_execution_exception" do
+    defp raising_chain(callbacks, opts \\ []) do
+      tool =
+        Function.new!(
+          Enum.into(opts, %{
+            name: "raising_tool",
+            description: "Always raises",
+            parameters_schema: %{type: "object", properties: %{}},
+            function: fn _args, _ctx -> raise RuntimeError, "tool blew up" end
+          })
+        )
+
+      LLMChain.new!(%{
+        llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+        tools: [tool],
+        callbacks: [callbacks]
+      })
+    end
+
+    defp tool_call_message(call_id) do
+      Message.new_assistant!(%{
+        content: "calling",
+        tool_calls: [
+          ToolCall.new!(%{call_id: call_id, name: "raising_tool", arguments: %{}})
+        ]
+      })
+    end
+
+    defp exception_callbacks(test_pid) do
+      %{
+        on_tool_execution_exception: fn _chain, tool_call, exception, stacktrace ->
+          send(test_pid, {:exception, tool_call.name, exception, stacktrace})
+        end,
+        on_tool_execution_failed: fn _chain, tool_call, error ->
+          send(test_pid, {:failed, tool_call.name, error})
+        end,
+        on_tool_execution_completed: fn _chain, tool_call, _result ->
+          send(test_pid, {:completed, tool_call.name})
+        end
+      }
+    end
+
+    test "fires with the exception and stacktrace for a sync tool" do
+      test_pid = self()
+
+      updated_chain =
+        exception_callbacks(test_pid)
+        |> raising_chain()
+        |> LLMChain.add_message(tool_call_message("call_sync"))
+        |> LLMChain.execute_tool_calls()
+
+      assert_received {:exception, "raising_tool", %RuntimeError{message: "tool blew up"},
+                       stacktrace}
+
+      assert [_ | _] = stacktrace
+
+      # The lifecycle callback still fires, with the message the model sees.
+      assert_received {:failed, "raising_tool", failed_content}
+      assert [%LangChain.Message.ContentPart{type: :text, content: text}] = failed_content
+      assert text =~ "RuntimeError"
+      refute_received {:completed, "raising_tool"}
+
+      assert [%{is_error: true, is_exception: true, exception: {%RuntimeError{}, [_ | _]}}] =
+               updated_chain.last_message.tool_results
+    end
+
+    test "fires in the calling process for an async tool" do
+      test_pid = self()
+
+      updated_chain =
+        exception_callbacks(test_pid)
+        |> raising_chain(async: true)
+        |> LLMChain.add_message(tool_call_message("call_async"))
+        |> LLMChain.execute_tool_calls()
+
+      assert_received {:exception, "raising_tool", %RuntimeError{message: "tool blew up"},
+                       [_ | _]}
+
+      assert [%{is_exception: true, exception: {%RuntimeError{}, [_ | _]}}] =
+               updated_chain.last_message.tool_results
+    end
+
+    test "fires for an approved tool in human review" do
+      test_pid = self()
+
+      tool_call =
+        ToolCall.new!(%{call_id: "call_hitl", name: "raising_tool", arguments: %{}})
+
+      updated_chain =
+        exception_callbacks(test_pid)
+        |> raising_chain()
+        |> LLMChain.execute_tool_calls_with_decisions([tool_call], [%{type: :approve}])
+
+      assert_received {:exception, "raising_tool", %RuntimeError{message: "tool blew up"},
+                       [_ | _]}
+
+      assert [%{is_exception: true}] = updated_chain.last_message.tool_results
+    end
+
+    test "fires for an edited tool call in human review" do
+      test_pid = self()
+
+      tool_call =
+        ToolCall.new!(%{call_id: "call_edited", name: "raising_tool", arguments: %{}})
+
+      decisions = [%{type: :edit, args: %{"x" => 1}}]
+
+      updated_chain =
+        exception_callbacks(test_pid)
+        |> raising_chain()
+        |> LLMChain.execute_tool_calls_with_decisions([tool_call], decisions)
+
+      assert_received {:exception, "raising_tool", %RuntimeError{message: "tool blew up"},
+                       [_ | _]}
+
+      assert [%{is_exception: true}] = updated_chain.last_message.tool_results
+    end
+
+    test "fires when a :parse_args parser raises" do
+      test_pid = self()
+
+      tool =
+        Function.new!(%{
+          name: "raising_tool",
+          parse_args: fn _args -> raise ArgumentError, "unparseable" end,
+          function: fn _args, _ctx -> {:ok, "unreachable"} end
+        })
+
+      updated_chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: [exception_callbacks(test_pid)]
+        })
+        |> LLMChain.add_message(tool_call_message("call_parse"))
+        |> LLMChain.execute_tool_calls()
+
+      assert_received {:exception, "raising_tool", %ArgumentError{message: "unparseable"},
+                       [_ | _]}
+
+      assert [%{is_exception: true}] = updated_chain.last_message.tool_results
+    end
+
+    test "does not fire for an error the tool returns deliberately" do
+      test_pid = self()
+
+      tool =
+        Function.new!(%{
+          name: "returns_error",
+          function: fn _args, _ctx -> {:error, "not found"} end
+        })
+
+      updated_chain =
+        LLMChain.new!(%{
+          llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+          tools: [tool],
+          callbacks: [exception_callbacks(test_pid)]
+        })
+        |> LLMChain.add_message(
+          Message.new_assistant!(%{
+            tool_calls: [
+              ToolCall.new!(%{call_id: "call_err", name: "returns_error", arguments: %{}})
+            ]
+          })
+        )
+        |> LLMChain.execute_tool_calls()
+
+      assert_received {:failed, "returns_error", _content}
+      refute_received {:exception, "returns_error", _exception, _stacktrace}
+
+      assert [%{is_error: true, is_exception: false, exception: nil}] =
+               updated_chain.last_message.tool_results
+    end
+
+    test "does not fire for a tool call naming a tool that does not exist" do
+      test_pid = self()
+
+      updated_chain =
+        exception_callbacks(test_pid)
+        |> raising_chain()
+        |> LLMChain.add_message(
+          Message.new_assistant!(%{
+            tool_calls: [
+              ToolCall.new!(%{call_id: "call_missing", name: "nope", arguments: %{}})
+            ]
+          })
+        )
+        |> LLMChain.execute_tool_calls()
+
+      assert_received {:failed, "nope", _content}
+      refute_received {:exception, "nope", _exception, _stacktrace}
+
+      assert [%{is_error: true, is_exception: false}] = updated_chain.last_message.tool_results
+    end
+
+    test "does not fire for a tool rejected in human review" do
+      test_pid = self()
+
+      tool_call =
+        ToolCall.new!(%{call_id: "call_reject", name: "raising_tool", arguments: %{}})
+
+      updated_chain =
+        exception_callbacks(test_pid)
+        |> raising_chain()
+        |> LLMChain.execute_tool_calls_with_decisions([tool_call], [%{type: :reject}])
+
+      assert_received {:failed, "raising_tool", _content}
+      refute_received {:exception, "raising_tool", _exception, _stacktrace}
+
+      assert [%{is_exception: false}] = updated_chain.last_message.tool_results
+    end
+  end
 end

--- a/test/chat_models/telemetry_test.exs
+++ b/test/chat_models/telemetry_test.exs
@@ -15,6 +15,7 @@ defmodule LangChain.ChatModels.TelemetryTest do
   alias LangChain.Message
   alias LangChain.MessageDelta
   alias LangChain.Message.ToolCall
+  alias LangChain.Message.ToolResult
   alias LangChain.TokenUsage
 
   # Setup for test
@@ -773,6 +774,42 @@ defmodule LangChain.ChatModels.TelemetryTest do
       assert start_metadata.call_id == stop_metadata.call_id
 
       :telemetry.detach("test-tool-custom-context")
+    end
+
+    test "tool stop metadata carries the rescued exception for the OTel handler" do
+      test_pid = self()
+
+      :telemetry.attach(
+        "test-tool-rescued-exception",
+        [:langchain, :tool, :call, :stop],
+        fn _name, _measurements, metadata, _config ->
+          send(test_pid, {:tool_stop, metadata})
+        end,
+        nil
+      )
+
+      fun =
+        Function.new!(%{
+          name: "raising_tool",
+          function: fn _args, _ctx -> raise RuntimeError, "telemetry boom" end
+        })
+
+      call = ToolCall.new!(%{call_id: "call-exception", name: "raising_tool", arguments: %{}})
+      result = LLMChain.execute_tool_call(call, fun)
+
+      assert_received {:tool_stop, metadata}
+
+      # Deliberately NOT scrubbed. The `:stop` event is the only point at which the
+      # tool span is still open, so this is the OpenTelemetry handler's one chance to
+      # record the exception with real stack frames.
+      assert %ToolResult{is_error: true, is_exception: true, exception: {exception, stacktrace}} =
+               metadata.tool_result
+
+      assert %RuntimeError{message: "telemetry boom"} = exception
+      assert [_ | _] = stacktrace
+      assert metadata.tool_result == result
+
+      :telemetry.detach("test-tool-rescued-exception")
     end
   end
 

--- a/test/function_test.exs
+++ b/test/function_test.exs
@@ -139,9 +139,10 @@ defmodule LangChain.FunctionTest do
       # rescues an exception and returns as string text
       result = Function.execute(function, %{}, %{result: :exception})
 
-      assert result ==
-               {:error,
-                "ERROR: (RuntimeError) fake exception at test/function_test.exs:15: LangChain.FunctionTest.returns_context/2"}
+      assert {:error, message, {%RuntimeError{}, [_ | _]}} = result
+
+      assert message ==
+               "ERROR: (RuntimeError) fake exception at test/function_test.exs:15: LangChain.FunctionTest.returns_context/2"
 
       # returns an error when anything else is returned
       result = Function.execute(function, %{}, %{result: 123})
@@ -613,6 +614,60 @@ defmodule LangChain.FunctionTest do
                Function.execute(function, %{}, nil)
     end
 
+    test "a rescued exception is returned alongside the model-facing message" do
+      function =
+        Function.new!(%{
+          name: "raiser",
+          function: fn _args, _ctx -> raise RuntimeError, "kaboom" end
+        })
+
+      assert {:error, message, {exception, stacktrace}} = Function.execute(function, %{}, nil)
+      assert %RuntimeError{message: "kaboom"} = exception
+      assert [{LangChain.FunctionTest, _fun, _arity, _loc} | _] = stacktrace
+      assert message =~ "RuntimeError"
+      assert message =~ "kaboom"
+    end
+
+    test "a rescued :parse_args exception is returned alongside the message" do
+      function =
+        Function.new!(%{
+          name: "raiser",
+          function: &echo_args/2,
+          parse_args: fn _args -> raise ArgumentError, "bad args" end
+        })
+
+      assert {:error, message, {%ArgumentError{message: "bad args"}, [_ | _]}} =
+               Function.execute(function, %{}, nil)
+
+      assert message =~ "bad args"
+    end
+
+    test "an error the tool returns deliberately stays a two-element tuple" do
+      function =
+        Function.new!(%{
+          name: "returns_error",
+          function: fn _args, _ctx -> {:error, "not found"} end
+        })
+
+      assert {:error, "not found"} = Function.execute(function, %{}, nil)
+    end
+
+    test "a missing required parameter stays a two-element tuple" do
+      function =
+        Function.new!(%{
+          name: "needs_path",
+          parameters_schema: %{
+            type: "object",
+            properties: %{path: %{type: "string"}},
+            required: ["path"]
+          },
+          function: fn _args, _ctx -> {:ok, "unreachable"} end
+        })
+
+      assert {:error, message} = Function.execute(function, %{}, nil)
+      assert message =~ "path"
+    end
+
     test "an exception raised inside :parse_args is caught and reported" do
       function =
         Function.new!(%{
@@ -621,7 +676,9 @@ defmodule LangChain.FunctionTest do
           parse_args: fn _args -> raise ArgumentError, "boom" end
         })
 
-      assert {:error, "ERROR: " <> message} = Function.execute(function, %{}, nil)
+      assert {:error, "ERROR: " <> message, {_exception, _stacktrace}} =
+               Function.execute(function, %{}, nil)
+
       assert message =~ "boom"
     end
 
@@ -682,7 +739,9 @@ defmodule LangChain.FunctionTest do
           parse_args: fn args -> {:ok, args} end
         })
 
-      assert {:error, message} = Function.execute(function, %{"path" => "/a.md"}, nil)
+      assert {:error, message, {_exception, _stacktrace}} =
+               Function.execute(function, %{"path" => "/a.md"}, nil)
+
       assert message =~ "KeyError"
       refute message =~ "does not accept"
     end
@@ -780,7 +839,7 @@ defmodule LangChain.FunctionTest do
           function: &fetches_optional/2
         })
 
-      assert {:error, message} =
+      assert {:error, message, {_exception, _stacktrace}} =
                Function.execute(function, %{"path" => "/a.md", "lim" => 5}, %{})
 
       assert message =~ "does not accept"
@@ -803,7 +862,9 @@ defmodule LangChain.FunctionTest do
           function: &fetches_optional/2
         })
 
-      assert {:error, message} = Function.execute(function, %{"path" => "/a.md"}, %{})
+      assert {:error, message, {_exception, _stacktrace}} =
+               Function.execute(function, %{"path" => "/a.md"}, %{})
+
       assert message =~ "needs the \"limit\" argument"
       assert message =~ "Accepted parameters:"
       refute message =~ "KeyError"
@@ -821,7 +882,9 @@ defmodule LangChain.FunctionTest do
           function: &head_matches_path/2
         })
 
-      assert {:error, message} = Function.execute(function, %{"file_path" => "/a.md"}, %{})
+      assert {:error, message, {_exception, _stacktrace}} =
+               Function.execute(function, %{"file_path" => "/a.md"}, %{})
+
       assert message =~ "does not accept"
       assert message =~ "did you mean \"path\"?"
       refute message =~ "FunctionClauseError"
@@ -839,7 +902,9 @@ defmodule LangChain.FunctionTest do
           function: &fetches_unrelated_map/2
         })
 
-      assert {:error, message} = Function.execute(function, %{"path" => "/a.md"}, %{})
+      assert {:error, message, {_exception, _stacktrace}} =
+               Function.execute(function, %{"path" => "/a.md"}, %{})
+
       assert message =~ "KeyError"
       assert message =~ "totally_unrelated"
     end
@@ -847,7 +912,9 @@ defmodule LangChain.FunctionTest do
     test "falls back to the original formatting when no parameters are declared" do
       function = Function.new!(%{name: "read_document", function: &fetches_optional/2})
 
-      assert {:error, message} = Function.execute(function, %{"path" => "/a.md"}, %{})
+      assert {:error, message, {_exception, _stacktrace}} =
+               Function.execute(function, %{"path" => "/a.md"}, %{})
+
       assert message =~ "KeyError"
     end
   end

--- a/test/message/tool_result_test.exs
+++ b/test/message/tool_result_test.exs
@@ -80,6 +80,28 @@ defmodule LangChain.Message.ToolResultTest do
       assert msg.is_error == true
     end
 
+    test "defaults is_exception to false with no exception" do
+      assert {:ok, %ToolResult{is_exception: false, exception: nil}} =
+               ToolResult.new(%{tool_call_id: "call_1", content: "fine"})
+    end
+
+    test "accepts a rescued exception and its stacktrace" do
+      rescued = {%RuntimeError{message: "boom"}, [{Mod, :fun, 2, [file: ~c"a.ex", line: 1]}]}
+
+      assert {:ok, %ToolResult{} = msg} =
+               ToolResult.new(%{
+                 tool_call_id: "call_1",
+                 content: "ERROR executing tool: boom",
+                 is_error: true,
+                 is_exception: true,
+                 exception: rescued
+               })
+
+      assert msg.is_error == true
+      assert msg.is_exception == true
+      assert msg.exception == rescued
+    end
+
     test "returns errors when invalid" do
       {:error, changeset} =
         ToolResult.new(%{tool_call_id: nil, content: nil})

--- a/test/open_telemetry/tool_exception_span_test.exs
+++ b/test/open_telemetry/tool_exception_span_test.exs
@@ -1,0 +1,129 @@
+defmodule LangChain.OpenTelemetry.ToolExceptionSpanTest do
+  use ExUnit.Case, async: false
+
+  require Record
+
+  Record.defrecord(
+    :span,
+    Record.extract(:span, from_lib: "opentelemetry/include/otel_span.hrl")
+  )
+
+  # NOTE: intentionally NOT aliasing `LangChain.OpenTelemetry` — doing so would
+  # shadow the real `OpenTelemetry` SDK module this test drives directly.
+  alias LangChain.Chains.LLMChain
+  alias LangChain.ChatModels.ChatAnthropic
+  alias LangChain.Function
+  alias LangChain.Message
+  alias LangChain.Message.ToolCall
+
+  setup do
+    :application.stop(:opentelemetry)
+
+    :application.set_env(:opentelemetry, :processors, [
+      {:otel_batch_processor, %{scheduled_delay_ms: 1}}
+    ])
+
+    {:ok, _} = :application.ensure_all_started(:opentelemetry)
+
+    tid = :ets.new(:test_spans, [:bag, :public])
+    :otel_batch_processor.set_exporter(:otel_exporter_tab, tid)
+
+    LangChain.OpenTelemetry.setup(enable_metrics: false)
+
+    on_exit(fn ->
+      LangChain.OpenTelemetry.teardown()
+
+      try do
+        :ets.delete(tid)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    %{tid: tid}
+  end
+
+  defp flush_spans(tid) do
+    Process.sleep(100)
+
+    :otel_batch_processor.force_flush(%{
+      reg_name: {:via, :gproc, {:n, :l, {:otel_batch_processor, :global}}}
+    })
+
+    Process.sleep(100)
+
+    Enum.map(:ets.tab2list(tid), fn record ->
+      %{
+        name: span(record, :name),
+        status: span(record, :status),
+        events: span(record, :events),
+        attributes: :otel_attributes.map(span(record, :attributes))
+      }
+    end)
+  end
+
+  defp run_tool(tool) do
+    LLMChain.new!(%{
+      llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+      tools: [tool]
+    })
+    |> LLMChain.add_message(
+      Message.new_assistant!(%{
+        tool_calls: [ToolCall.new!(%{call_id: "c1", name: tool.name, arguments: %{}})]
+      })
+    )
+    |> LLMChain.execute_tool_calls()
+  end
+
+  test "a rescued tool exception closes the tool span with an error status", %{tid: tid} do
+    tool =
+      Function.new!(%{
+        name: "raising_tool",
+        function: fn _args, _ctx -> raise RuntimeError, "span boom" end
+      })
+
+    run_tool(tool)
+
+    assert [tool_span] = flush_spans(tid)
+    assert tool_span.name == "execute_tool raising_tool"
+    assert tool_span.status != nil
+    assert tool_span.attributes["error.type"] == "RuntimeError"
+  end
+
+  test "the rescued exception is recorded as a span event", %{tid: tid} do
+    tool =
+      Function.new!(%{
+        name: "raising_tool",
+        function: fn _args, _ctx -> raise RuntimeError, "recorded boom" end
+      })
+
+    run_tool(tool)
+
+    assert [tool_span] = flush_spans(tid)
+    assert {:events, _, _, _, _, [{:event, _time, :exception, attrs_record}]} = tool_span.events
+
+    attrs = :otel_attributes.map(attrs_record)
+    assert attrs[:"exception.type"] == "Elixir.RuntimeError"
+    assert attrs[:"exception.message"] == "recorded boom"
+
+    # The real stacktrace reaches the backend, which is the point of the feature:
+    # error trackers group by frames, not by a formatted message.
+    assert attrs[:"exception.stacktrace"] =~ "tool_exception_span_test.exs"
+    assert attrs[:"exception.stacktrace"] =~ "execute_with_error_handling"
+  end
+
+  test "an error the tool returns deliberately leaves the span unset", %{tid: tid} do
+    tool =
+      Function.new!(%{
+        name: "returns_error",
+        function: fn _args, _ctx -> {:error, "not found"} end
+      })
+
+    run_tool(tool)
+
+    assert [tool_span] = flush_spans(tid)
+    assert tool_span.name == "execute_tool returns_error"
+    assert tool_span.status == :undefined
+    refute Map.has_key?(tool_span.attributes, "error.type")
+  end
+end

--- a/test/trajectory_test.exs
+++ b/test/trajectory_test.exs
@@ -310,7 +310,18 @@ defmodule LangChain.TrajectoryTest do
 
       result = Trajectory.to_map(trajectory)
 
-      assert [%{tool_results: [%{name: "search", content: "Result text", is_error: false}]}] =
+      assert [
+               %{
+                 tool_results: [
+                   %{
+                     name: "search",
+                     content: "Result text",
+                     is_error: false,
+                     is_exception: false
+                   }
+                 ]
+               }
+             ] =
                result.messages
     end
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -118,6 +118,7 @@ This pattern allows:
 - `:on_message_processed` — Message complete and processed (use for persistence)
 - `:on_tool_call_identified` — Tool name detected during streaming (args may be incomplete)
 - `:on_tool_execution_started/completed/failed` — Tool execution lifecycle
+- `:on_tool_execution_exception` — The exception and stacktrace LangChain rescued from a raising tool
 - `:on_tool_response_created` — Tool results compiled into message
 - `:on_message_processing_error` — Message processor failure
 


### PR DESCRIPTION
Supersedes #615, which identified the problem. Same goal, different mechanism, plus the OpenTelemetry half.

## The problem

A tool that raises is rescued so one bad tool cannot kill the chain. That rescue formatted the exception into a string for the model and threw away the exception struct and the stacktrace.

The chain then continued, telemetry reported a normal `:stop`, and the `execute_tool` span closed with no status. A crashing tool was indistinguishable from a working one: nothing reached an error tracker, and the only record was a `Logger.warning`.

Error trackers — Sentry, Tower, Appsignal, OpenTelemetry's `record_exception` — group and fingerprint by stack frames. A pre-formatted string cannot support that. It has to be the real stacktrace.

Three cases a developer's own `try/rescue` around their tool body cannot cover:

1. Tools they don't own — `Calculator`, `DeepResearch`, middleware-supplied tools, anything from MCP.
2. `:parse_args` exceptions, which raise inside LangChain before the tool body runs.
3. The raise nobody anticipated — a `FunctionClauseError` after a dependency upgrade, a `DBConnection.ConnectionError` under load. Precisely the ones that were being swallowed.

## The mechanism

`Function.execute/3` returns a third element when it rescues:

```elixir
{:ok, llm_result, processed_content}        # already existed
{:error, message, {exception, stacktrace}}  # new
```

This restores a symmetry the success path already had: the second element is what the model sees, the third is the native Elixir detail kept for the application. It's not a new concept, just the error path catching up.

`LLMChain` carries the pair to `ToolResult`, which gains `is_exception` and a virtual `exception` field, and fires a new `:on_tool_execution_exception` callback with `(chain, tool_call, exception, stacktrace)`. It fires **in addition to** `:on_tool_execution_failed`, not instead of it — a rescued exception is still a failure and existing lifecycle handlers keep seeing it.

The four call sites that fire per-result tool callbacks (sync, async, and both human-review paths) now share one funnel, so the exception reaches the callback from all of them. That removes four copies of the same `cond`.

## OpenTelemetry

The `:stop` handler now sets an error status, an `error.type` attribute, and records the exception with its real stacktrace when the result carries one.

`:stop` is the only point at which the tool span is still open — the tool callbacks all fire after `end_span` has ended the span and detached its context. Verified by capturing `Tracer.current_span_ctx()` inside the tool body (a live span) and inside the callbacks (`:undefined`).

Only a rescued exception marks the span errored. A tool returning `{:error, reason}` is a handled outcome the model is expected to react to; flagging those would make error rates meaningless.

The same measurement showed the span table in `LangChain.OpenTelemetry.Enrich` was wrong about which span the tool callbacks enrich. Corrected in its own commit.

## Breaking change

Code calling `Function.execute/3` directly and matching `{:error, reason}` on a tool that **raises** now needs a `{:error, reason, {exception, stacktrace}}` clause. Errors a tool returns deliberately, and argument checks that reject a call, still return `{:error, reason}` unchanged.

In this repository the change touched 8 assertions, all in `test/function_test.exs`, all raising-tool cases. Nothing else in `lib/` noticed.

Migration notes belong in `CHANGELOG.md` and are left for the post-merge step.

## Why not #615's approach

#615 added `Function.execute_with_exception/3` and a private `LLMChain.execute_tool_call_with_exception/3`, each returning `{result, exception}`, with the original functions delegating and dropping the second element. That kept full backwards compatibility, at the cost of leaving `Function.execute/3` and `LLMChain.execute_tool_call/3` with no callers in `lib/` — public API that the library itself no longer exercised, free to drift from the real path.

Carrying the exception on the `ToolResult` removes both parallel functions. `execute_tool_call/3` keeps returning `ToolResult.t()`, and the human-review paths need no per-site change.

## Notes on containment

The exception never reaches the model. Providers render only `content`, `tool_call_id`, `is_error`, and `cache_control`.

It is deliberately **not** scrubbed from `[:langchain, :tool, :call, :stop]` metadata, since that is the OTel handler's only chance to record it. Telemetry handlers are in-process and registered by the application itself.

`exception` is virtual, so a result restored from storage carries `is_exception: true` with `exception: nil`. Serializing an exception and a stacktrace would need `term_to_binary` and stacktraces can be large; the boolean is the part worth keeping. Documented on the struct.

## Tests

18 new tests. Full suite: 2246 passing, `mix precommit` clean.

- `Function.execute/3` — the three-element shape for a raising tool and a raising `:parse_args`; two-element shapes unchanged for returned errors and rejected arguments
- The callback across sync, async, human-review-approved, human-review-edited, and `:parse_args`; and **not** firing for returned errors, unknown tools, or rejected reviews
- Tool stop telemetry metadata carries the exception
- End-to-end OTel: errored span with `error.type`, the recorded exception event with real frames, and an unset span for a deliberately returned error