### PR TITLE
Return an error tuple when a streamed request fails mid-stream

### DIFF
--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -308,22 +308,11 @@ if Code.ensure_loaded?(ReqLLM) do
               result
           end
 
-        {:error, %Req.TransportError{reason: :timeout} = err} ->
-          {:error,
-           LangChainError.exception(type: "timeout", message: "Request timed out", original: err)}
-
-        {:error, %Req.TransportError{reason: :closed}} ->
-          Logger.debug(fn ->
-            "Mint connection closed: retry count = #{inspect(retry_count)}"
-          end)
-
-          do_api_request(model, messages, tools, retry_count - 1)
-
         {:error, %LangChainError{}} = error ->
           error
 
         {:error, error} ->
-          translate_req_llm_error(error)
+          handle_request_failure(model, messages, tools, retry_count, error, true)
 
         other ->
           Logger.warning(fn -> "Unexpected response from ReqLLM: #{inspect(other)}" end)
@@ -355,44 +344,39 @@ if Code.ensure_loaded?(ReqLLM) do
 
       case ReqLLM.stream_text(model.model, context, opts) do
         {:ok, stream_response} ->
-          # Stateful reduce: assigns a monotonic content index to each new content
-          # block type (thinking, text, etc.) so that MessageDelta merging places
-          # each type in the correct merged_content slot. Tool call argument
-          # fragments are emitted incrementally (mirroring ChatAnthropic's approach).
-          initial_state = %{next_content_index: 0, type_index_map: %{}}
+          # req_llm builds the stream lazily, so `stream_text` reports success
+          # before any bytes move. A transport failure surfaces later, as a
+          # ReqLLM.Error.API.Stream raised from inside the stream, and is
+          # classified here so streaming and non-streaming share one contract.
+          delivered = :counters.new(1, [])
 
-          {all_deltas, _final_state} =
-            stream_response.stream
-            |> Enum.reduce({[], initial_state}, fn chunk, {acc_deltas, state} ->
-              {new_deltas, new_state} = process_stream_chunk(chunk, state)
-              if new_deltas != [], do: Utils.fire_streamed_callback(model, new_deltas)
-              {acc_deltas ++ new_deltas, new_state}
-            end)
+          try do
+            all_deltas = consume_stream(model, stream_response, delivered)
 
-          LangChain.Telemetry.emit_event(
-            [:langchain, :llm, :response],
-            %{system_time: System.system_time()},
-            %{model: model.model, streaming: true}
-          )
+            LangChain.Telemetry.emit_event(
+              [:langchain, :llm, :response],
+              %{system_time: System.system_time()},
+              %{model: model.model, streaming: true}
+            )
 
-          all_deltas
-
-        {:error, %Req.TransportError{reason: :timeout} = err} ->
-          {:error,
-           LangChainError.exception(type: "timeout", message: "Request timed out", original: err)}
-
-        {:error, %Req.TransportError{reason: :closed}} ->
-          Logger.debug(fn ->
-            "Mint connection closed: retry count = #{inspect(retry_count)}"
-          end)
-
-          do_api_request(model, messages, tools, retry_count - 1)
+            all_deltas
+          rescue
+            err in ReqLLM.Error.API.Stream ->
+              handle_request_failure(
+                model,
+                messages,
+                tools,
+                retry_count,
+                err.cause || err,
+                :counters.get(delivered, 1) == 0
+              )
+          end
 
         {:error, %LangChainError{}} = error ->
           error
 
         {:error, error} ->
-          translate_req_llm_error(error)
+          handle_request_failure(model, messages, tools, retry_count, error, true)
 
         other ->
           Logger.warning(fn -> "Unexpected response from ReqLLM stream: #{inspect(other)}" end)
@@ -405,6 +389,69 @@ if Code.ensure_loaded?(ReqLLM) do
            )}
       end
     end
+
+    # Reduce the lazy stream into MessageDeltas, firing the streaming callback as
+    # each one is produced.
+    #
+    # Stateful reduce: assigns a monotonic content index to each new content
+    # block type (thinking, text, etc.) so that MessageDelta merging places
+    # each type in the correct merged_content slot. Tool call argument
+    # fragments are emitted incrementally (mirroring ChatAnthropic's approach).
+    #
+    # `delivered` counts the deltas handed to the callback. The count survives an
+    # exception raised mid-stream, which the retry decision depends on.
+    defp consume_stream(model, stream_response, delivered) do
+      initial_state = %{next_content_index: 0, type_index_map: %{}}
+
+      {all_deltas, _final_state} =
+        stream_response.stream
+        |> Enum.reduce({[], initial_state}, fn chunk, {acc_deltas, state} ->
+          {new_deltas, new_state} = process_stream_chunk(chunk, state)
+
+          if new_deltas != [] do
+            :counters.add(delivered, 1, length(new_deltas))
+            Utils.fire_streamed_callback(model, new_deltas)
+          end
+
+          {acc_deltas ++ new_deltas, new_state}
+        end)
+
+      all_deltas
+    end
+
+    # Turn a failed request into the same shape regardless of which library
+    # reported it. `retry_allowed?` is false once a streamed turn has already
+    # delivered deltas to the callback: re-requesting would replay content the
+    # consumer has seen, so the failure is reported instead.
+    defp handle_request_failure(model, messages, tools, retry_count, error, retry_allowed?) do
+      case transport_reason(error) do
+        :timeout ->
+          {:error,
+           LangChainError.exception(
+             type: "timeout",
+             message: "Request timed out",
+             original: error
+           )}
+
+        :closed when retry_allowed? ->
+          Logger.debug(fn ->
+            "Mint connection closed: retry count = #{inspect(retry_count)}"
+          end)
+
+          do_api_request(model, messages, tools, retry_count - 1)
+
+        _other ->
+          translate_req_llm_error(error)
+      end
+    end
+
+    # The same network event arrives as a different struct depending on how far
+    # down the stack it was caught: Req wraps Finch, which wraps Mint. All three
+    # carry the reason atom in the same field.
+    @transport_error_modules [Req.TransportError, Finch.TransportError, Mint.TransportError]
+
+    defp transport_reason(%mod{reason: reason}) when mod in @transport_error_modules, do: reason
+    defp transport_reason(_error), do: nil
 
     # Process a stream chunk with state tracking.
     # Assigns a monotonic content index per chunk type so each content block type

--- a/test/chat_models/chat_req_llm_test.exs
+++ b/test/chat_models/chat_req_llm_test.exs
@@ -1394,6 +1394,159 @@ if Code.ensure_loaded?(ReqLLM) do
     end
 
     # ============================================================
+    # Streaming transport failures (raised during consumption)
+    # ============================================================
+
+    describe "do_api_request/4 streaming transport failures" do
+      # Mirrors req_llm: the lazy stream yields chunks, then raises
+      # ReqLLM.Error.API.Stream when the transport fails mid-consumption.
+      defp failing_stream(chunks, cause) do
+        Stream.concat(
+          chunks,
+          Stream.map([:boom], fn _ ->
+            raise %ReqLLM.Error.API.Stream{
+              reason: "Stream failed: #{inspect(cause)}",
+              cause: cause
+            }
+          end)
+        )
+      end
+
+      defp failing_stream_response(chunks, cause) do
+        %ReqLLM.StreamResponse{
+          stream: failing_stream(chunks, cause),
+          metadata_handle: self(),
+          cancel: fn -> :ok end,
+          model: nil,
+          context: ReqLLM.Context.new([])
+        }
+      end
+
+      test "returns an error tuple when the transport refuses the connection" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true, retry_count: 0})
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok,
+           failing_stream_response([], %Finch.TransportError{
+             reason: :econnrefused,
+             source: %Mint.TransportError{reason: :econnrefused}
+           })}
+        end)
+
+        assert {:error, %LangChainError{} = error} =
+                 ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 1)
+
+        assert error.original.reason == :econnrefused
+      end
+
+      test "call/3 returns an error tuple instead of raising" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true, retry_count: 0})
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok,
+           failing_stream_response([], %Finch.TransportError{reason: :econnrefused, source: nil})}
+        end)
+
+        assert {:error, %LangChainError{}} = ChatReqLLM.call(model, "hi", [])
+      end
+
+      test "classifies a mid-stream timeout as a timeout error" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true, retry_count: 0})
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, failing_stream_response([], %Finch.TransportError{reason: :timeout, source: nil})}
+        end)
+
+        assert {:error, %LangChainError{type: "timeout"}} =
+                 ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 1)
+      end
+
+      test "classifies an HTTP error surfaced mid-stream by status" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true, retry_count: 0})
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok,
+           failing_stream_response(
+             [],
+             ReqLLM.Error.API.Request.exception(reason: "Unauthorized", status: 401)
+           )}
+        end)
+
+        assert {:error, %LangChainError{type: "authentication_error"}} =
+                 ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 1)
+      end
+
+      test "retries a closed connection when no deltas were delivered" do
+        call_count = :counters.new(1, [])
+
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          count = :counters.get(call_count, 1) + 1
+          :counters.put(call_count, 1, count)
+
+          if count < 2 do
+            {:ok,
+             failing_stream_response([], %Finch.TransportError{reason: :closed, source: nil})}
+          else
+            {:ok,
+             fake_stream_response([
+               %ReqLLM.StreamChunk{type: :content, text: "Recovered!"},
+               %ReqLLM.StreamChunk{
+                 type: :meta,
+                 metadata: %{finish_reason: :stop, terminal?: true}
+               }
+             ])}
+          end
+        end)
+
+        assert [%MessageDelta{} | _] =
+                 ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
+
+        assert :counters.get(call_count, 1) == 2
+      end
+
+      test "does not retry a closed connection after deltas were delivered" do
+        call_count = :counters.new(1, [])
+        test_pid = self()
+
+        model =
+          %{
+            ChatReqLLM.new!(%{model: @live_model, stream: true})
+            | callbacks: [%{on_llm_new_delta: fn deltas -> send(test_pid, {:delta, deltas}) end}]
+          }
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          count = :counters.get(call_count, 1) + 1
+          :counters.put(call_count, 1, count)
+
+          {:ok,
+           failing_stream_response(
+             [%ReqLLM.StreamChunk{type: :content, text: "partial"}],
+             %Finch.TransportError{reason: :closed, source: nil}
+           )}
+        end)
+
+        assert {:error, %LangChainError{}} =
+                 ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
+
+        assert :counters.get(call_count, 1) == 1
+        assert_received {:delta, [%MessageDelta{content: _}]}
+      end
+
+      test "retries_exceeded surfaces as an error tuple, not a raised exception" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true, retry_count: 0})
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, failing_stream_response([], %Finch.TransportError{reason: :closed, source: nil})}
+        end)
+
+        assert {:error, %LangChainError{type: "retries_exceeded"}} =
+                 ChatReqLLM.call(model, "hi", [])
+      end
+    end
+
+    # ============================================================
     # Live API Tests (tagged :live_call — excluded by default)
     # ============================================================
 


### PR DESCRIPTION
Closes #622

## Problem

`ChatReqLLM` had two different error contracts for the same transport failure:

- `stream: false` returns `{:error, %LangChain.LangChainError{}}`
- `stream: true` raised `ReqLLM.Error.API.Stream` out of `call/3`

`ReqLLM.stream_text/3` returns `{:ok, stream_response}` as soon as the **lazy** stream is built, before any bytes move. Consumption happens inside the `{:ok, _}` branch of the `case`, so the `{:error, _}` clauses below it were unreachable for anything that failed during transport. req_llm raises from inside `Stream.resource`, and `call/3`'s `rescue err in LangChainError` doesn't match a `ReqLLM.Error.API.Stream`, so it unwound past `LLMChain.run/2` into the caller's process.

Downstream effects, all fixed by this change:

1. `LLMChain.run/2` did not contain it — its rescue is `rescue err in LangChainError`.
2. `on_error` callbacks never fired, since they fire from that same non-matching rescue.
3. `ChatReqLLM`'s own `retry_count` was effectively ignored while streaming, because the `:closed` retry clause was unreachable.
4. `with_fallbacks/2` caught the exception in its blanket `rescue err ->` and advanced to the next LLM **without** consulting `retry_on_fallback?/1`, so a non-retryable streaming failure burned through every configured fallback.

## Fix

Stream consumption moves into `consume_stream/3` and runs inside a `rescue` that routes `ReqLLM.Error.API.Stream` through `handle_request_failure/6` — the same classifier the non-streaming path now uses. Both modes return `{:error, %LangChainError{}}`.

**Shared transport classifier.** The same network event arrives as a different struct depending on how far down the stack it was caught: non-streaming surfaces `%Req.TransportError{}`, streaming surfaces `%Finch.TransportError{reason: ..., source: %Mint.TransportError{}}` wrapped in the raised exception's `:cause`. `transport_reason/1` reads the reason from all three, so `:timeout` and `:closed` classify identically in both modes and `retry_on_fallback?/1` sees the right `LangChainError` type. The module list is matched as plain atoms via `%mod{} when mod in @transport_error_modules`, so there is no compile-time coupling to Finch or Mint.

An HTTP error that arrives mid-stream (req_llm builds a `ReqLLM.Error.API.Request` with a `:status` when the response body follows a 4xx/5xx) unwraps to the existing `translate_req_llm_error/1` clauses, so a mid-stream 401 classifies as `authentication_error` just as it does non-streaming.

**Retry after partial output.** A `:closed` connection retries only when no deltas have reached the callback. `consume_stream/3` counts delivered deltas in a `:counters` ref, which survives the exception unwinding the reduce. Once a consumer has rendered part of a streamed message, re-requesting would duplicate content, so those failures are reported rather than replayed.

## Tests

Seven tests in `test/chat_models/chat_req_llm_test.exs` covering `do_api_request/4` and `call/3`. The stubbed stream mirrors req_llm: it yields chunks, then raises `ReqLLM.Error.API.Stream` mid-consumption.

- connection refused returns an error tuple carrying the transport reason
- `call/3` returns a tuple instead of raising
- mid-stream timeout classifies as `type: "timeout"`
- mid-stream HTTP 401 classifies as `type: "authentication_error"`
- `:closed` with no deltas delivered retries and succeeds on the second attempt
- `:closed` after deltas were delivered does **not** retry, and returns an error
- exhausted retries surface as `{:error, type: "retries_exceeded"}` from `call/3`

All 7 fail on `main` with the raised `ReqLLM.Error.API.Stream`. `mix precommit` is clean: 2253 tests pass.

## Note for a possible follow-up

A connection refusal still classifies as `type: "unhandled_error"` (with a `Logger.warning`), which is what `main` already does for the non-streaming path — this PR makes streaming match it rather than changing it. That means `retry_on_fallback?/1` returns `false` for a dead endpoint, so `with_fallbacks/2` will not try the next LLM when the first provider is unreachable. Giving transport failures their own `LangChainError` type and making it fallback-retryable looks correct, but it changes an existing contract for both modes, so I left it out of this fix.