### PR TITLE
Report streamed token usage once, and from every provider that sends it

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -715,9 +715,8 @@ defmodule LangChain.Chains.LLMChain do
       %Message{role: :assistant} = msg, acc ->
         # Each assembled assistant message's usage is already the final total for
         # that message, so these are per-message totals being summed rather than
-        # two readings of one message. `add_total/2` is the accumulation that
-        # models that, including clearing the delta-merge `:cumulative` flag that
-        # would otherwise make the total collapse to the last turn.
+        # several readings of one message. `add_total/2` is the combination that
+        # models that; `add/2` would keep the largest turn instead of the sum.
         LangChain.TokenUsage.add_total(acc, LangChain.TokenUsage.get(msg))
 
       _, acc ->

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -714,21 +714,16 @@ defmodule LangChain.Chains.LLMChain do
     |> Enum.reduce(nil, fn
       %Message{role: :assistant} = msg, acc ->
         # Each assembled assistant message's usage is already the final total for
-        # that message. The `:cumulative` flag is a *delta-merge* signal — it tells
-        # `TokenUsage.add/2` that a streaming delta already includes the prior
-        # deltas of the *same* message. Carried across messages it makes `add/2`
-        # discard the accumulator and keep only the latest turn, so strip it before
-        # summing per-turn totals. (Streaming providers such as Google AI set it.)
-        usage = msg |> LangChain.TokenUsage.get() |> clear_cumulative()
-        LangChain.TokenUsage.add(acc, usage)
+        # that message, so these are per-message totals being summed rather than
+        # two readings of one message. `add_total/2` is the accumulation that
+        # models that, including clearing the delta-merge `:cumulative` flag that
+        # would otherwise make the total collapse to the last turn.
+        LangChain.TokenUsage.add_total(acc, LangChain.TokenUsage.get(msg))
 
       _, acc ->
         acc
     end)
   end
-
-  defp clear_cumulative(%LangChain.TokenUsage{} = usage), do: %{usage | cumulative: false}
-  defp clear_cumulative(other), do: other
 
   defp initial_run_logging(%LLMChain{verbose: false} = _chain), do: :ok
 

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -1437,7 +1437,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     }
     |> Map.merge(stop_details_metadata(delta["stop_details"] || data["stop_details"]))
     |> MessageDelta.new()
-    |> TokenUsage.set_wrapped(get_token_usage(usage, true))
+    |> TokenUsage.set_wrapped(get_token_usage(usage))
     |> to_response()
   end
 
@@ -2348,17 +2348,17 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     return
   end
 
-  # `cumulative` distinguishes a running total for the whole message from an
-  # increment. The `message_delta` event reports cumulative counts, so its usage
-  # replaces what `message_start` reported instead of adding to it.
-  defp get_token_usage(usage_data, cumulative \\ false) do
+  # A stream reports usage twice. `message_start` opens the message with the
+  # input classes and `message_delta` closes it with the totals for the whole
+  # message, so `TokenUsage.add/2` keeps the larger reading per class rather
+  # than adding the two together.
+  defp get_token_usage(usage_data) do
     # if prompt caching has been used the response will also contain
     # "cache_creation_input_tokens" and "cache_read_input_tokens"
     TokenUsage.new!(%{
       input: Map.get(usage_data, "input_tokens"),
       output: Map.get(usage_data, "output_tokens"),
-      raw: usage_data,
-      cumulative: cumulative
+      raw: usage_data
     })
   end
 

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -1437,7 +1437,7 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     }
     |> Map.merge(stop_details_metadata(delta["stop_details"] || data["stop_details"]))
     |> MessageDelta.new()
-    |> TokenUsage.set_wrapped(get_token_usage(usage))
+    |> TokenUsage.set_wrapped(get_token_usage(usage, true))
     |> to_response()
   end
 
@@ -2348,13 +2348,17 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     return
   end
 
-  defp get_token_usage(usage_data) do
+  # `cumulative` distinguishes a running total for the whole message from an
+  # increment. The `message_delta` event reports cumulative counts, so its usage
+  # replaces what `message_start` reported instead of adding to it.
+  defp get_token_usage(usage_data, cumulative \\ false) do
     # if prompt caching has been used the response will also contain
     # "cache_creation_input_tokens" and "cache_read_input_tokens"
     TokenUsage.new!(%{
       input: Map.get(usage_data, "input_tokens"),
       output: Map.get(usage_data, "output_tokens"),
-      raw: usage_data
+      raw: usage_data,
+      cumulative: cumulative
     })
   end
 

--- a/lib/chat_models/chat_aws_mantle.ex
+++ b/lib/chat_models/chat_aws_mantle.ex
@@ -145,6 +145,7 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
   alias LangChain.Message.ContentPart
   alias LangChain.MessageDelta
   alias LangChain.Callbacks
+  alias LangChain.TokenUsage
   alias LangChain.Utils
 
   @behaviour ChatModel
@@ -669,9 +670,12 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
   end
 
   # Usage-only terminal event (when stream_options.include_usage is set, Mantle
-  # sends a final chunk with empty `choices` and a `usage` map).
-  def do_process_response(_model, %{"choices" => [], "usage" => _} = _msg) do
-    :skip
+  # sends a final chunk with empty `choices` and a `usage` map). Returning the
+  # `%TokenUsage{}` hands it to `LangChain.Chains.LLMChain.merge_delta/2`, which
+  # folds it into the final delta. Skipping the chunk instead would discard the
+  # only usage a streamed turn reports.
+  def do_process_response(_model, %{"choices" => [], "usage" => usage} = _msg) do
+    get_token_usage(usage)
   end
 
   def do_process_response(_model, %{"error" => %{"message" => message}} = body) do
@@ -822,17 +826,21 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
   defp maybe_add_reasoning(%Message{} = msg, _), do: msg
 
   defp attach_usage(%Message{} = msg, %{"usage" => usage}) when is_map(usage) do
-    token_usage = %LangChain.TokenUsage{
-      input: Map.get(usage, "prompt_tokens"),
-      output: Map.get(usage, "completion_tokens"),
-      raw: usage
-    }
-
-    metadata = Map.merge(msg.metadata || %{}, %{usage: token_usage})
-    %{msg | metadata: metadata}
+    TokenUsage.set(msg, get_token_usage(usage))
   end
 
   defp attach_usage(%Message{} = msg, _), do: msg
+
+  # Mantle reports usage once per response, whether streamed or not, so no
+  # cumulative marking is needed. Nested detail maps such as
+  # `prompt_tokens_details` are carried through in `:raw`.
+  defp get_token_usage(usage) when is_map(usage) do
+    TokenUsage.new!(%{
+      input: Map.get(usage, "prompt_tokens"),
+      output: Map.get(usage, "completion_tokens"),
+      raw: usage
+    })
+  end
 
   # Resolve API key from struct or app config. Currently unused (auth_opts/1
   # uses the struct field directly), kept for future config-based auth.

--- a/lib/chat_models/chat_aws_mantle.ex
+++ b/lib/chat_models/chat_aws_mantle.ex
@@ -647,6 +647,14 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
   # ---------------------------------------------------------------------------
 
   @doc false
+  @spec do_process_response(t(), data :: map()) ::
+          :skip
+          | TokenUsage.t()
+          | Message.t()
+          | [Message.t()]
+          | MessageDelta.t()
+          | [MessageDelta.t()]
+          | {:error, LangChainError.t()}
   # Streaming delta chunk — matched first because each choice has a "delta" key.
   def do_process_response(
         %ChatAwsMantle{} = model,
@@ -831,9 +839,8 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
 
   defp attach_usage(%Message{} = msg, _), do: msg
 
-  # Mantle reports usage once per response, whether streamed or not, so no
-  # cumulative marking is needed. Nested detail maps such as
-  # `prompt_tokens_details` are carried through in `:raw`.
+  # Mantle reports usage once per response, whether streamed or not. Nested
+  # detail maps such as `prompt_tokens_details` are carried through in `:raw`.
   defp get_token_usage(usage) when is_map(usage) do
     TokenUsage.new!(%{
       input: Map.get(usage, "prompt_tokens"),

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -848,9 +848,9 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   def do_process_response(model, %{"candidates" => candidates} = data, message_type)
       when is_list(candidates) do
     # Google is odd in that it returns token usage for each MessageDelta as it
-    # goes, incrementing the number of generated tokens. I haven't seen anyone
+    # goes, repeating the totals for the message so far. I haven't seen anyone
     # else do this. For now, we fire each and every TokenUsage we receive.
-    token_usage = get_token_usage(data, message_type)
+    token_usage = get_token_usage(data)
 
     case token_usage do
       %TokenUsage{} = usage ->
@@ -1112,20 +1112,19 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     ChatGoogleAI.new(data)
   end
 
-  defp get_token_usage(%{"usageMetadata" => usage} = _response_body, message_type) do
+  # Empirically, each delta's token usage includes the total token usage so far,
+  # so `TokenUsage.add/2` keeps the largest reading across a stream rather than
+  # summing the readings.
+  defp get_token_usage(%{"usageMetadata" => usage} = _response_body) do
     # extract out the reported response token usage
     TokenUsage.new!(%{
       input: Map.get(usage, "promptTokenCount", 0),
       output: Map.get(usage, "candidatesTokenCount", 0),
-      raw: usage,
-      # Empirically, each delta's token usage includes the total token usage so
-      # far, so merging deltas keeps the latest reading rather than summing
-      # them. A whole response reports once and needs no such marking.
-      cumulative: message_type == MessageDelta
+      raw: usage
     })
   end
 
-  defp get_token_usage(_response_body, _message_type), do: nil
+  defp get_token_usage(_response_body), do: nil
 
   # A full list of finish reasons and their meanings can be found here:
   # https://ai.google.dev/api/generate-content#FinishReason

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -850,7 +850,7 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     # Google is odd in that it returns token usage for each MessageDelta as it
     # goes, incrementing the number of generated tokens. I haven't seen anyone
     # else do this. For now, we fire each and every TokenUsage we receive.
-    token_usage = get_token_usage(data)
+    token_usage = get_token_usage(data, message_type)
 
     case token_usage do
       %TokenUsage{} = usage ->
@@ -1112,18 +1112,20 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     ChatGoogleAI.new(data)
   end
 
-  defp get_token_usage(%{"usageMetadata" => usage} = _response_body) do
+  defp get_token_usage(%{"usageMetadata" => usage} = _response_body, message_type) do
     # extract out the reported response token usage
     TokenUsage.new!(%{
       input: Map.get(usage, "promptTokenCount", 0),
       output: Map.get(usage, "candidatesTokenCount", 0),
       raw: usage,
-      # Empirically, each delta's token usage includes the total token usage so far.
-      cumulative: true
+      # Empirically, each delta's token usage includes the total token usage so
+      # far, so merging deltas keeps the latest reading rather than summing
+      # them. A whole response reports once and needs no such marking.
+      cumulative: message_type == MessageDelta
     })
   end
 
-  defp get_token_usage(_response_body), do: nil
+  defp get_token_usage(_response_body, _message_type), do: nil
 
   # A full list of finish reasons and their meanings can be found here:
   # https://ai.google.dev/api/generate-content#FinishReason

--- a/lib/chat_models/chat_model.ex
+++ b/lib/chat_models/chat_model.ex
@@ -6,8 +6,13 @@ defmodule LangChain.ChatModels.ChatModel do
   alias LangChain.TokenUsage
   alias LangChain.Utils
 
+  # A streamed call answers with the deltas it decoded. OpenAI-shaped providers
+  # report the usage-only terminal chunk as a bare `%TokenUsage{}` that rides
+  # back in that same list rather than on a delta's metadata, so consumers of a
+  # streamed response have to be ready for either shape.
   @type call_response ::
-          {:ok, Message.t() | [Message.t()] | [MessageDelta.t()]} | {:error, LangChainError.t()}
+          {:ok, Message.t() | [Message.t()] | [MessageDelta.t() | TokenUsage.t()]}
+          | {:error, LangChainError.t()}
 
   @type tool :: Function.t()
   @type tools :: [tool()]
@@ -133,12 +138,22 @@ defmodule LangChain.ChatModels.ChatModel do
     end)
   end
 
-  # Usage from a streamed result: fold every delta's `%TokenUsage{}` with
-  # `TokenUsage.add/2`, which is cumulative-aware (replaces on `cumulative: true`,
-  # sums otherwise) — the same accumulation `MessageDelta.merge_deltas/2` performs.
+  # Usage from a streamed result: fold every `%TokenUsage{}` the stream carried
+  # with `TokenUsage.add/2`, which is cumulative-aware (replaces on
+  # `cumulative: true`, sums otherwise), the same accumulation
+  # `MessageDelta.merge_deltas/2` performs.
+  #
+  # A stream carries usage in either of two shapes and both have to be read
+  # here. Most providers hang it off a delta's metadata. OpenAI-shaped providers
+  # answer the usage-only terminal chunk (empty `choices`, populated `usage`)
+  # with a bare `%TokenUsage{}` instead, which `LangChain.Utils` leaves in the
+  # response body because only `:skip` is filtered out. Reading just the delta
+  # shape reports `token_usage: nil` on the `[:langchain, :llm, :call, :stop]`
+  # event for every streamed call those providers make.
   defp accumulate_delta_usage(items) do
     Enum.reduce(items, nil, fn
       %MessageDelta{metadata: %{usage: %TokenUsage{} = usage}}, acc -> TokenUsage.add(acc, usage)
+      %TokenUsage{} = usage, acc -> TokenUsage.add(acc, usage)
       _, acc -> acc
     end)
   end

--- a/lib/chat_models/chat_model.ex
+++ b/lib/chat_models/chat_model.ex
@@ -106,9 +106,18 @@ defmodule LangChain.ChatModels.ChatModel do
     #       - Google/Vertex tag *every* delta with a `cumulative: true` running
     #         total; `add/2` keeps the latest (the final total). Taking the first
     #         would report an early partial total.
-    #       - Anthropic splits input tokens (`message_start`) from final output
-    #         tokens (`message_delta`) across two deltas; `add/2` combines them.
-    usage = message_usage(flat) || accumulate_delta_usage(flat)
+    #       - Anthropic reports usage twice: `message_start` opens with the input
+    #         classes, and `message_delta` closes with a `cumulative: true` total
+    #         for the whole message. `add/2` keeps the closing total and carries
+    #         forward any class it leaves unreported. Summing the two would
+    #         double every input-class count.
+    # The result is one completed call either way, so the `:cumulative` flag,
+    # which only describes how deltas of this message relate to each other, is
+    # settled here. Emitting it would invite a consumer summing usage across
+    # calls to have `add/2` keep only the last one.
+    usage =
+      (message_usage(flat) || accumulate_delta_usage(flat))
+      |> TokenUsage.clear_cumulative()
 
     %{token_usage: usage}
   end

--- a/lib/chat_models/chat_model.ex
+++ b/lib/chat_models/chat_model.ex
@@ -6,12 +6,29 @@ defmodule LangChain.ChatModels.ChatModel do
   alias LangChain.TokenUsage
   alias LangChain.Utils
 
-  # A streamed call answers with the deltas it decoded. OpenAI-shaped providers
-  # report the usage-only terminal chunk as a bare `%TokenUsage{}` that rides
-  # back in that same list rather than on a delta's metadata, so consumers of a
-  # streamed response have to be ready for either shape.
+  @typedoc """
+  One item of a streamed response.
+
+  Most of them are deltas. OpenAI-shaped providers report the usage-only
+  terminal chunk as a bare `%TokenUsage{}` that rides back in the same list
+  rather than on a delta's metadata, and a mid-stream failure arrives as an
+  error tuple in that list too.
+  """
+  @type stream_item :: MessageDelta.t() | TokenUsage.t() | {:error, LangChainError.t()}
+
+  @typedoc """
+  What a chat model's `call/3` answers with.
+
+  A streamed call collects one list of `t:stream_item/0` per received chunk, so
+  its items arrive nested one level deep. `LangChain.Chains.LLMChain` and
+  `token_usage_from_result/1` both flatten before reading them.
+  """
   @type call_response ::
-          {:ok, Message.t() | [Message.t()] | [MessageDelta.t() | TokenUsage.t()]}
+          {:ok,
+           Message.t()
+           | [Message.t()]
+           | [stream_item()]
+           | [[stream_item()]]}
           | {:error, LangChainError.t()}
 
   @type tool :: Function.t()
@@ -108,23 +125,15 @@ defmodule LangChain.ChatModels.ChatModel do
     #     list, which must be accumulated with `TokenUsage.add/2` (mirroring
     #     `MessageDelta.merge_deltas/2`). A plain "first delta with usage" scan is
     #     wrong whenever more than the final delta reports usage:
-    #       - Google/Vertex tag *every* delta with a `cumulative: true` running
-    #         total; `add/2` keeps the latest (the final total). Taking the first
-    #         would report an early partial total.
+    #       - Google/Vertex report a running total on *every* delta; `add/2`
+    #         keeps the largest (the final total). Taking the first would report
+    #         an early partial total.
     #       - Anthropic reports usage twice: `message_start` opens with the input
-    #         classes, and `message_delta` closes with a `cumulative: true` total
-    #         for the whole message. `add/2` keeps the closing total and carries
-    #         forward any class it leaves unreported. Summing the two would
-    #         double every input-class count.
-    # The result is one completed call either way, so the `:cumulative` flag,
-    # which only describes how deltas of this message relate to each other, is
-    # settled here. Emitting it would invite a consumer summing usage across
-    # calls to have `add/2` keep only the last one.
-    usage =
-      (message_usage(flat) || accumulate_delta_usage(flat))
-      |> TokenUsage.clear_cumulative()
-
-    %{token_usage: usage}
+    #         classes and `message_delta` closes with a total for the whole
+    #         message. `add/2` keeps the closing total and carries forward any
+    #         class it leaves unreported. Summing the two would double every
+    #         input-class count.
+    %{token_usage: message_usage(flat) || accumulate_delta_usage(flat)}
   end
 
   def token_usage_from_result(_result), do: %{token_usage: nil}
@@ -139,9 +148,9 @@ defmodule LangChain.ChatModels.ChatModel do
   end
 
   # Usage from a streamed result: fold every `%TokenUsage{}` the stream carried
-  # with `TokenUsage.add/2`, which is cumulative-aware (replaces on
-  # `cumulative: true`, sums otherwise), the same accumulation
-  # `MessageDelta.merge_deltas/2` performs.
+  # with `TokenUsage.add/2`, the same combination `MessageDelta.merge_deltas/2`
+  # performs. Every reading belongs to the one message the call produced, so the
+  # fold keeps the largest count per field rather than summing readings.
   #
   # A stream carries usage in either of two shapes and both have to be read
   # here. Most providers hang it off a delta's metadata. OpenAI-shaped providers

--- a/lib/chat_models/chat_perplexity.ex
+++ b/lib/chat_models/chat_perplexity.ex
@@ -905,12 +905,43 @@ defmodule LangChain.ChatModels.ChatPerplexity do
     ChatPerplexity.new(data)
   end
 
+  defp process_stream_chunk(perplexity, chunk) do
+    chunk
+    |> decode_stream_chunk()
+    |> attach_stream_usage(perplexity, chunk)
+  end
+
+  # Perplexity reports usage once, on the chunk that closes the stream, riding
+  # alongside the final content delta rather than on a chunk of its own.
+  # Attaching it to the deltas that chunk produced is what carries it onto the
+  # assembled message, and from there to the
+  # `[:langchain, :llm, :call, :stop]` telemetry event and the OTEL span.
+  # `TokenUsage.add/2` combines several readings of one message by keeping the
+  # larger count per field, so a delta pair that both carry it still reports it
+  # once.
+  defp attach_stream_usage(deltas, perplexity, %{"usage" => usage}) when is_map(usage) do
+    case get_token_usage(%{"usage" => usage}) do
+      %TokenUsage{} = token_usage ->
+        Callbacks.fire(perplexity.callbacks, :on_llm_token_usage, [token_usage])
+        apply_stream_usage(deltas, token_usage)
+
+      nil ->
+        deltas
+    end
+  end
+
+  defp attach_stream_usage(deltas, _perplexity, _chunk), do: deltas
+
+  defp apply_stream_usage(deltas, usage) when is_list(deltas),
+    do: Enum.map(deltas, &TokenUsage.set(&1, usage))
+
+  defp apply_stream_usage(delta, usage), do: TokenUsage.set(delta, usage)
+
   # Content delta on the final chunk (finish_reason: "stop"). Also extract
   # citations from the chunk since Perplexity includes them on every chunk
   # but we only need to process them once at completion. Returns a list
   # [citation_delta, content_delta] so both flow through the pipeline.
-  defp process_stream_chunk(
-         _perplexity,
+  defp decode_stream_chunk(
          %{
            "choices" => [
              %{
@@ -931,7 +962,7 @@ defmodule LangChain.ChatModels.ChatPerplexity do
 
   # Content delta on intermediate chunks (no finish_reason or nil).
   # Ignore citations here since they repeat on every chunk.
-  defp process_stream_chunk(_perplexity, %{
+  defp decode_stream_chunk(%{
          "choices" => [
            %{"delta" => %{"content" => content}} | _
          ]
@@ -940,8 +971,7 @@ defmodule LangChain.ChatModels.ChatPerplexity do
   end
 
   # Completion chunk with no content delta.
-  defp process_stream_chunk(
-         _perplexity,
+  defp decode_stream_chunk(
          %{
            "choices" => [
              %{"finish_reason" => "stop"} | _
@@ -956,7 +986,7 @@ defmodule LangChain.ChatModels.ChatPerplexity do
     end
   end
 
-  defp process_stream_chunk(_perplexity, _chunk) do
+  defp decode_stream_chunk(_chunk) do
     %MessageDelta{}
   end
 

--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -733,7 +733,7 @@ if Code.ensure_loaded?(ReqLLM) do
             []
 
           usage_map ->
-            case translate_usage(usage_map) do
+            case translate_usage(usage_map, true) do
               nil ->
                 []
 
@@ -1220,15 +1220,28 @@ if Code.ensure_loaded?(ReqLLM) do
 
     @doc """
     Translate a `req_llm` usage map to a `LangChain.TokenUsage` struct.
-    """
-    @spec translate_usage(map() | nil) :: TokenUsage.t() | nil
-    def translate_usage(nil), do: nil
 
-    def translate_usage(usage) when is_map(usage) do
+    `cumulative` marks the usage as a running total for the message rather than
+    an increment. Pass `true` for usage read off a stream chunk: req_llm hands
+    every provider's usage over as a complete snapshot of the message so far,
+    and a provider may report more than one. Anthropic reports two, one opening
+    the message and one closing it, and summing those doubles every input class.
+    """
+    @spec translate_usage(map() | nil, boolean()) :: TokenUsage.t() | nil
+    def translate_usage(usage, cumulative \\ false)
+
+    def translate_usage(nil, _cumulative), do: nil
+
+    def translate_usage(usage, cumulative) when is_map(usage) do
       input = usage[:input_tokens] || 0
       output = usage[:output_tokens] || 0
 
-      case TokenUsage.new(%{input: input, output: output, raw: usage}) do
+      case TokenUsage.new(%{
+             input: input,
+             output: output,
+             raw: usage,
+             cumulative: cumulative
+           }) do
         {:ok, token_usage} -> token_usage
         _ -> nil
       end

--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -733,7 +733,7 @@ if Code.ensure_loaded?(ReqLLM) do
             []
 
           usage_map ->
-            case translate_usage(usage_map, true) do
+            case translate_usage(usage_map) do
               nil ->
                 []
 
@@ -1221,27 +1221,23 @@ if Code.ensure_loaded?(ReqLLM) do
     @doc """
     Translate a `req_llm` usage map to a `LangChain.TokenUsage` struct.
 
-    `cumulative` marks the usage as a running total for the message rather than
-    an increment. Pass `true` for usage read off a stream chunk: req_llm hands
-    every provider's usage over as a complete snapshot of the message so far,
-    and a provider may report more than one. Anthropic reports two, one opening
-    the message and one closing it, and summing those doubles every input class.
+    req_llm hands every provider's usage over as a complete snapshot of the
+    message so far, and a provider may report more than one over a stream.
+    Anthropic reports two, one opening the message and one closing it, which
+    `TokenUsage.add/2` combines by keeping the larger count per class.
+
+    An unreported class arrives normalized to zero rather than omitted, so the
+    derived `:total_tokens` a snapshot carries describes only that snapshot.
+    Read a combined total from `TokenUsage.total/1`.
     """
-    @spec translate_usage(map() | nil, boolean()) :: TokenUsage.t() | nil
-    def translate_usage(usage, cumulative \\ false)
+    @spec translate_usage(map() | nil) :: TokenUsage.t() | nil
+    def translate_usage(nil), do: nil
 
-    def translate_usage(nil, _cumulative), do: nil
-
-    def translate_usage(usage, cumulative) when is_map(usage) do
+    def translate_usage(usage) when is_map(usage) do
       input = usage[:input_tokens] || 0
       output = usage[:output_tokens] || 0
 
-      case TokenUsage.new(%{
-             input: input,
-             output: output,
-             raw: usage,
-             cumulative: cumulative
-           }) do
+      case TokenUsage.new(%{input: input, output: output, raw: usage}) do
         {:ok, token_usage} -> token_usage
         _ -> nil
       end

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -747,7 +747,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
 
   def do_process_response(model, %{"candidates" => candidates} = data, message_type)
       when is_list(candidates) do
-    token_usage = get_token_usage(data, message_type)
+    token_usage = get_token_usage(data)
 
     case token_usage do
       %TokenUsage{} = usage ->
@@ -991,21 +991,19 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     end
   end
 
-  defp get_token_usage(%{"usageMetadata" => usage} = _response_body, message_type) do
+  # Every streamed chunk repeats the totals for the message so far rather than
+  # reporting only what that chunk added, so `TokenUsage.add/2` keeps the largest
+  # reading across a stream instead of summing the readings.
+  defp get_token_usage(%{"usageMetadata" => usage} = _response_body) do
     # extract out the reported response token usage
     TokenUsage.new!(%{
       input: Map.get(usage, "promptTokenCount", 0),
       output: Map.get(usage, "candidatesTokenCount", 0),
-      raw: usage,
-      # Every streamed chunk repeats the totals for the message so far rather
-      # than reporting only what that chunk added, so merging deltas must keep
-      # the latest reading instead of summing them. A whole response reports
-      # once and needs no such marking.
-      cumulative: message_type == MessageDelta
+      raw: usage
     })
   end
 
-  defp get_token_usage(_response_body, _message_type), do: nil
+  defp get_token_usage(_response_body), do: nil
 
   defp unmap_role("model"), do: "assistant"
   defp unmap_role("function"), do: "tool"

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -747,7 +747,7 @@ defmodule LangChain.ChatModels.ChatVertexAI do
 
   def do_process_response(model, %{"candidates" => candidates} = data, message_type)
       when is_list(candidates) do
-    token_usage = get_token_usage(data)
+    token_usage = get_token_usage(data, message_type)
 
     case token_usage do
       %TokenUsage{} = usage ->
@@ -991,16 +991,21 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     end
   end
 
-  defp get_token_usage(%{"usageMetadata" => usage} = _response_body) do
+  defp get_token_usage(%{"usageMetadata" => usage} = _response_body, message_type) do
     # extract out the reported response token usage
     TokenUsage.new!(%{
       input: Map.get(usage, "promptTokenCount", 0),
       output: Map.get(usage, "candidatesTokenCount", 0),
-      raw: usage
+      raw: usage,
+      # Every streamed chunk repeats the totals for the message so far rather
+      # than reporting only what that chunk added, so merging deltas must keep
+      # the latest reading instead of summing them. A whole response reports
+      # once and needs no such marking.
+      cumulative: message_type == MessageDelta
     })
   end
 
-  defp get_token_usage(_response_body), do: nil
+  defp get_token_usage(_response_body, _message_type), do: nil
 
   defp unmap_role("model"), do: "assistant"
   defp unmap_role("function"), do: "tool"

--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -490,6 +490,7 @@ defmodule LangChain.MessageDelta do
       delta
       |> Map.from_struct()
       |> Map.put(:content, content)
+      |> settle_token_usage()
 
     case Message.new(attrs) do
       {:ok, message} ->
@@ -499,6 +500,17 @@ defmodule LangChain.MessageDelta do
         {:error, Utils.changeset_error_to_string(changeset)}
     end
   end
+
+  # `:cumulative` describes how one delta's usage relates to the other deltas of
+  # the same message. Those deltas are now merged, so the flag has no remaining
+  # meaning, and a message that kept it would make a later `TokenUsage.add/2`
+  # across messages report only this one. This makes a streamed message's usage
+  # indistinguishable from a non-streamed one's.
+  defp settle_token_usage(%{metadata: %{usage: %TokenUsage{} = usage}} = attrs) do
+    put_in(attrs, [:metadata, :usage], TokenUsage.clear_cumulative(usage))
+  end
+
+  defp settle_token_usage(attrs), do: attrs
 
   # Filter nil values from list (from index padding during delta merging)
   @spec reject_nil(list() | any()) :: list() | any()

--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -431,7 +431,8 @@ defmodule LangChain.MessageDelta do
 
   # Carry provider metadata from an incoming delta onto the accumulated one so
   # it reaches the assembled message. `:usage` is excluded because
-  # `accumulate_token_usage/2` sums it across deltas rather than replacing it.
+  # `accumulate_token_usage/2` combines it across deltas rather than replacing
+  # it.
   @spec merge_delta_metadata(t(), t()) :: t()
   defp merge_delta_metadata(%MessageDelta{} = primary, %MessageDelta{metadata: incoming})
        when is_map(incoming) do
@@ -490,7 +491,6 @@ defmodule LangChain.MessageDelta do
       delta
       |> Map.from_struct()
       |> Map.put(:content, content)
-      |> settle_token_usage()
 
     case Message.new(attrs) do
       {:ok, message} ->
@@ -501,45 +501,39 @@ defmodule LangChain.MessageDelta do
     end
   end
 
-  # `:cumulative` describes how one delta's usage relates to the other deltas of
-  # the same message. Those deltas are now merged, so the flag has no remaining
-  # meaning, and a message that kept it would make a later `TokenUsage.add/2`
-  # across messages report only this one. This makes a streamed message's usage
-  # indistinguishable from a non-streamed one's.
-  defp settle_token_usage(%{metadata: %{usage: %TokenUsage{} = usage}} = attrs) do
-    put_in(attrs, [:metadata, :usage], TokenUsage.clear_cumulative(usage))
-  end
-
-  defp settle_token_usage(attrs), do: attrs
-
   # Filter nil values from list (from index padding during delta merging)
   @spec reject_nil(list() | any()) :: list() | any()
   defp reject_nil(list) when is_list(list), do: Enum.reject(list, &is_nil/1)
   defp reject_nil(other), do: other
 
   @doc """
-  Accumulates token usage from delta messages. Uses `LangChain.TokenUsage.add/2` to combine
-  the usage data from both deltas.
+  Combines the token usage of two deltas of the same message with
+  `LangChain.TokenUsage.add/2`.
+
+  Every reading a stream carries describes the message so far rather than one
+  delta's share, so the combination keeps the larger count per field. A reading
+  that omits a class, or reports it as zero, leaves what an earlier reading
+  established standing.
 
   ## Example
 
       iex> alias LangChain.TokenUsage
       iex> alias LangChain.MessageDelta
-      iex> delta1 = %MessageDelta{
+      iex> opening = %MessageDelta{
       ...>   metadata: %{
-      ...>     usage: %TokenUsage{input: 10, output: 5}
+      ...>     usage: %TokenUsage{input: 25, output: 1}
       ...>   }
       ...> }
-      iex> delta2 = %MessageDelta{
+      iex> closing = %MessageDelta{
       ...>   metadata: %{
-      ...>     usage: %TokenUsage{input: 5, output: 15}
+      ...>     usage: %TokenUsage{output: 15}
       ...>   }
       ...> }
-      iex> result = MessageDelta.accumulate_token_usage(delta1, delta2)
+      iex> result = MessageDelta.accumulate_token_usage(opening, closing)
       iex> result.metadata.usage.input
-      15
+      25
       iex> result.metadata.usage.output
-      20
+      15
 
   """
   @spec accumulate_token_usage(t(), t()) :: t()

--- a/lib/token_usage.ex
+++ b/lib/token_usage.ex
@@ -17,6 +17,19 @@ defmodule LangChain.TokenUsage do
 
   Refer to the `raw` token usage information for access to LLM-specific information that may be available.
 
+  ## Combining usage
+
+  Two different questions call for two different combinations, and the caller
+  knows which one it is asking:
+
+    * `add/2` combines several readings of the **same** message, as a streamed
+      response produces. Each reading is a snapshot of the message so far, so
+      the combination keeps the largest count per field.
+
+    * `add_total/2` combines the final usage of **different** messages into a
+      running total for a conversation. Each operand is already settled for its
+      own message, so the combination sums them.
+
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -28,15 +41,11 @@ defmodule LangChain.TokenUsage do
     field :input, :integer
     field :output, :integer
     field :raw, :map, default: %{}
-    # For token usage attached to a MessageDelta, whether the token usage is cumulative
-    # (all tokens for the message so far) or just the token usage for this delta.
-    # Varies by model.
-    field :cumulative, :boolean, default: false
   end
 
   @type t :: %TokenUsage{}
 
-  @create_fields [:input, :output, :raw, :cumulative]
+  @create_fields [:input, :output, :raw]
   # Anthropic returns only the output token count when streaming deltas
   @required_fields []
 
@@ -85,37 +94,50 @@ defmodule LangChain.TokenUsage do
   end
 
   @doc """
-  Combines two TokenUsage structs by adding their respective input and output
-  values. The raw maps are merged, with numeric values added at every depth, so
-  map-valued usage details such as `prompt_tokens_details` and
-  `completion_tokens_details` accumulate per-key rather than the later map
-  replacing the earlier one. A detail reported as a *list* of per-modality
-  objects, the shape Gemini uses for `promptTokensDetails`, offers no key to
-  accumulate against and is taken from the later usage whole.
+  Combines two readings of the same message into one.
 
-  When the second argument is marked `cumulative: true` it is a running total for
-  the message rather than an increment, so it supersedes the accumulator instead
-  of being added to it. Because a running total never decreases, the larger of
-  the two readings is kept per field: a reading that omits a class, or reports it
-  as zero, cannot erase what an earlier reading already established.
+  A streamed response reports usage more than once, and each reading is a
+  snapshot of the message so far rather than a description of one delta's share.
+  Anthropic opens with the input classes on `message_start` and closes with a
+  total on `message_delta`; Gemini repeats the running totals on every chunk;
+  OpenAI-shaped providers answer with a single snapshot on a usage-only terminal
+  chunk. Combining snapshots keeps the larger of the two readings per field.
 
-  This combines two readings of the *same* message. To total usage across
-  different messages, use `add_total/2`.
+  Token counts are counters, so a count never decreases while a message is being
+  generated. Providers differ in how completely each reading repeats the
+  picture: some report every class every time, some report only the classes that
+  changed, and some normalize an unreported class to zero. Keeping the larger
+  reading is correct under all three -- a fuller reading advances the total, and
+  a partial one cannot erase a class it never meant to describe.
+
+  The `raw` maps are merged the same way, at every depth, so map-valued usage
+  details such as `prompt_tokens_details` and `completion_tokens_details` advance
+  per-key rather than the later map replacing the earlier one. A detail reported
+  as a *list* of per-modality objects, the shape Gemini uses for
+  `promptTokensDetails`, offers no key to advance against and is taken from the
+  later usage whole.
+
+  Keeping the larger count is sound for a primitive counter. A `raw` key holding
+  a value *derived* from other counts within a single reading, such as a
+  `total_tokens` an adapter computes as input + output, is only meaningful
+  alongside the reading it came from and does not survive the merge intact. Read
+  the total from `total/1` rather than from `raw`.
+
+  To total usage across different messages, use `add_total/2`.
 
   If both arguments are nil, returns nil.
   If one argument is nil, returns the non-nil argument.
 
   ## Example
 
-      iex> usage1 = LangChain.TokenUsage.new!(%{input: 10, output: 20, raw: %{"total_tokens" => 30}})
-      iex> usage2 = LangChain.TokenUsage.new!(%{input: 5, output: 15, raw: %{"total_tokens" => 20}})
-      iex> combined = LangChain.TokenUsage.add(usage1, usage2)
-      iex> combined.input
-      15
-      iex> combined.output
-      35
-      iex> combined.raw["total_tokens"]
-      50
+      iex> alias LangChain.TokenUsage
+      iex> opening = TokenUsage.new!(%{input: 25, output: 1, raw: %{"input_tokens" => 25}})
+      iex> closing = TokenUsage.new!(%{output: 15, raw: %{"output_tokens" => 15}})
+      iex> combined = TokenUsage.add(opening, closing)
+      iex> {combined.input, combined.output}
+      {25, 15}
+      iex> combined.raw
+      %{"input_tokens" => 25, "output_tokens" => 15}
 
   """
   @spec add(t() | nil, t() | nil) :: t() | nil
@@ -123,72 +145,46 @@ defmodule LangChain.TokenUsage do
   def add(nil, usage), do: usage
   def add(usage, nil), do: usage
 
-  # A `cumulative: true` usage is a running total for the message so far, not an
-  # increment, so it supersedes the accumulator instead of being added to it.
-  #
-  # Token counts are counters, so a running total never decreases while a message
-  # is being generated. Providers differ in how completely each reading repeats
-  # the picture: some report every class every time, some report only the classes
-  # that changed, and some normalize an unreported class to zero. Keeping the
-  # larger of the two readings per field is correct under all three -- a fuller
-  # reading advances the total, and a partial one cannot erase a class it never
-  # meant to describe.
-  def add(%TokenUsage{} = usage1, %TokenUsage{cumulative: true} = usage2) do
+  def add(%TokenUsage{} = usage1, %TokenUsage{} = usage2) do
     %TokenUsage{
       usage2
       | input: running_max(usage1.input, usage2.input),
         output: running_max(usage1.output, usage2.output),
-        raw: merge_cumulative_raw(usage1.raw || %{}, usage2.raw || %{})
+        raw: merge_snapshot_raw(usage1.raw || %{}, usage2.raw || %{})
     }
   end
-
-  def add(%TokenUsage{} = usage1, %TokenUsage{} = usage2) do
-    new!(%{
-      input: (usage1.input || 0) + (usage2.input || 0),
-      output: (usage1.output || 0) + (usage2.output || 0),
-      raw: merge_raw_values(usage1.raw || %{}, usage2.raw || %{})
-    })
-  end
-
-  @doc """
-  Returns the usage with the `:cumulative` flag cleared.
-
-  `:cumulative` describes the relationship between a streaming delta and the
-  *other deltas of the same message*. Once deltas are merged into a message the
-  flag has served its purpose, and carrying it into a total across messages makes
-  `add/2` supersede the accumulator and report only the last message.
-
-  Returns non-`TokenUsage` values (including `nil`) unchanged.
-  """
-  # Two specs, because the catch-all clause makes this intentionally total: a
-  # caller can pipe a `get/1` result straight through without a nil check, and
-  # anything that is not a `%TokenUsage{}` comes back as the type it went in as.
-  @spec clear_cumulative(t()) :: t()
-  @spec clear_cumulative(other) :: other when other: any()
-  def clear_cumulative(%TokenUsage{} = usage), do: %TokenUsage{usage | cumulative: false}
-  def clear_cumulative(other), do: other
 
   @doc """
   Adds one completed message's usage to a running total across messages.
 
   Use this, rather than `add/2`, whenever the two operands are totals for
   *different* messages. Each assembled message's usage is already final for that
-  message, so the values are summed, and `:cumulative` is cleared first because
-  it only describes delta-to-delta relationships within a single message.
+  message, so the values are summed, at every depth of the `raw` map.
+
+  If both arguments are nil, returns nil.
+  If one argument is nil, returns the non-nil argument.
 
   ## Example
 
       iex> alias LangChain.TokenUsage
-      iex> first = TokenUsage.new!(%{input: 100, output: 20, cumulative: true})
-      iex> second = TokenUsage.new!(%{input: 150, output: 35, cumulative: true})
+      iex> first = TokenUsage.new!(%{input: 100, output: 20})
+      iex> second = TokenUsage.new!(%{input: 150, output: 35})
       iex> total = TokenUsage.add_total(first, second)
-      iex> {total.input, total.output, total.cumulative}
-      {250, 55, false}
+      iex> {total.input, total.output}
+      {250, 55}
 
   """
   @spec add_total(t() | nil, t() | nil) :: t() | nil
-  def add_total(accumulator, usage) do
-    add(clear_cumulative(accumulator), clear_cumulative(usage))
+  def add_total(nil, nil), do: nil
+  def add_total(nil, usage), do: usage
+  def add_total(usage, nil), do: usage
+
+  def add_total(%TokenUsage{} = usage1, %TokenUsage{} = usage2) do
+    new!(%{
+      input: (usage1.input || 0) + (usage2.input || 0),
+      output: (usage1.output || 0) + (usage2.output || 0),
+      raw: sum_raw_values(usage1.raw || %{}, usage2.raw || %{})
+    })
   end
 
   # Raw usage maps nest: OpenAI-shaped providers report cached and reasoning
@@ -198,25 +194,25 @@ defmodule LangChain.TokenUsage do
   # later one. Only maps are traversed. Gemini reports the same class of detail
   # as a list of per-modality objects, which has no key to accumulate against,
   # so the later value is taken whole.
-  defp merge_raw_values(raw1, raw2) do
+  defp sum_raw_values(raw1, raw2) do
     Map.merge(raw1, raw2, fn
       _k, v1, v2 when is_number(v1) and is_number(v2) ->
         v1 + v2
 
       _k, v1, v2 ->
-        if plain_map?(v1) and plain_map?(v2), do: merge_raw_values(v1, v2), else: v2
+        if plain_map?(v1) and plain_map?(v2), do: sum_raw_values(v1, v2), else: v2
     end)
   end
 
-  # Same traversal as `merge_raw_values/2`, but keeping the larger of two counts
-  # rather than their sum, because both sides describe the same running total.
-  defp merge_cumulative_raw(raw1, raw2) do
+  # Same traversal as `sum_raw_values/2`, but keeping the larger of two counts
+  # rather than their sum, because both sides describe the same message.
+  defp merge_snapshot_raw(raw1, raw2) do
     Map.merge(raw1, raw2, fn
       _k, v1, v2 when is_number(v1) and is_number(v2) ->
         max(v1, v2)
 
       _k, v1, v2 ->
-        if plain_map?(v1) and plain_map?(v2), do: merge_cumulative_raw(v1, v2), else: v2
+        if plain_map?(v1) and plain_map?(v2), do: merge_snapshot_raw(v1, v2), else: v2
     end)
   end
 
@@ -227,7 +223,7 @@ defmodule LangChain.TokenUsage do
   defp running_max(v1, v2), do: max(v1, v2)
 
   # Structs are maps, but merging them key-by-key would produce a malformed
-  # struct rather than a sum, so only bare maps recurse.
+  # struct rather than a combination, so only bare maps recurse.
   defp plain_map?(value), do: is_map(value) and not is_struct(value)
 
   @doc """

--- a/lib/token_usage.ex
+++ b/lib/token_usage.ex
@@ -81,8 +81,19 @@ defmodule LangChain.TokenUsage do
   end
 
   @doc """
-  Combines two TokenUsage structs by adding their respective input and output values.
-  The raw maps are merged, with values being added if they are numeric.
+  Combines two TokenUsage structs by adding their respective input and output
+  values. The raw maps are merged, with numeric values added at every depth so
+  nested usage details (`prompt_tokens_details`, `completion_tokens_details`, and
+  friends) accumulate per-key rather than the later map replacing the earlier one.
+
+  When the second argument is marked `cumulative: true` it is a running total for
+  the message rather than an increment, so it supersedes the accumulator instead
+  of being added to it. Because a running total never decreases, the larger of
+  the two readings is kept per field: a reading that omits a class, or reports it
+  as zero, cannot erase what an earlier reading already established.
+
+  This combines two readings of the *same* message. To total usage across
+  different messages, use `add_total/2`.
 
   If both arguments are nil, returns nil.
   If one argument is nil, returns the non-nil argument.
@@ -105,21 +116,106 @@ defmodule LangChain.TokenUsage do
   def add(nil, usage), do: usage
   def add(usage, nil), do: usage
 
-  def add(_, %TokenUsage{cumulative: true} = usage), do: usage
+  # A `cumulative: true` usage is a running total for the message so far, not an
+  # increment, so it supersedes the accumulator instead of being added to it.
+  #
+  # Token counts are counters, so a running total never decreases while a message
+  # is being generated. Providers differ in how completely each reading repeats
+  # the picture: some report every class every time, some report only the classes
+  # that changed, and some normalize an unreported class to zero. Keeping the
+  # larger of the two readings per field is correct under all three -- a fuller
+  # reading advances the total, and a partial one cannot erase a class it never
+  # meant to describe.
+  def add(%TokenUsage{} = usage1, %TokenUsage{cumulative: true} = usage2) do
+    %TokenUsage{
+      usage2
+      | input: running_max(usage1.input, usage2.input),
+        output: running_max(usage1.output, usage2.output),
+        raw: merge_cumulative_raw(usage1.raw || %{}, usage2.raw || %{})
+    }
+  end
 
   def add(%TokenUsage{} = usage1, %TokenUsage{} = usage2) do
     new!(%{
       input: (usage1.input || 0) + (usage2.input || 0),
       output: (usage1.output || 0) + (usage2.output || 0),
-      raw: merge_raw_values(usage1.raw, usage2.raw)
+      raw: merge_raw_values(usage1.raw || %{}, usage2.raw || %{})
     })
   end
 
+  @doc """
+  Returns the usage with the `:cumulative` flag cleared.
+
+  `:cumulative` describes the relationship between a streaming delta and the
+  *other deltas of the same message*. Once deltas are merged into a message the
+  flag has served its purpose, and carrying it into a total across messages makes
+  `add/2` supersede the accumulator and report only the last message.
+
+  Returns non-`TokenUsage` values (including `nil`) unchanged.
+  """
+  @spec clear_cumulative(t() | nil) :: t() | nil
+  def clear_cumulative(%TokenUsage{} = usage), do: %TokenUsage{usage | cumulative: false}
+  def clear_cumulative(other), do: other
+
+  @doc """
+  Adds one completed message's usage to a running total across messages.
+
+  Use this, rather than `add/2`, whenever the two operands are totals for
+  *different* messages. Each assembled message's usage is already final for that
+  message, so the values are summed, and `:cumulative` is cleared first because
+  it only describes delta-to-delta relationships within a single message.
+
+  ## Example
+
+      iex> alias LangChain.TokenUsage
+      iex> first = TokenUsage.new!(%{input: 100, output: 20, cumulative: true})
+      iex> second = TokenUsage.new!(%{input: 150, output: 35, cumulative: true})
+      iex> total = TokenUsage.add_total(first, second)
+      iex> {total.input, total.output, total.cumulative}
+      {250, 55, false}
+
+  """
+  @spec add_total(t() | nil, t() | nil) :: t() | nil
+  def add_total(accumulator, usage) do
+    add(clear_cumulative(accumulator), clear_cumulative(usage))
+  end
+
+  # Raw usage maps nest: OpenAI-shaped providers report cached and reasoning
+  # tokens under `prompt_tokens_details` / `input_tokens_details` /
+  # `completion_tokens_details`. Recursing means those inner counts are summed
+  # per-key at every depth instead of the earlier map being dropped for the
+  # later one.
   defp merge_raw_values(raw1, raw2) do
-    Map.merge(raw1, raw2, fn _k, v1, v2 ->
-      if is_number(v1) and is_number(v2), do: v1 + v2, else: v2
+    Map.merge(raw1, raw2, fn
+      _k, v1, v2 when is_number(v1) and is_number(v2) ->
+        v1 + v2
+
+      _k, v1, v2 ->
+        if plain_map?(v1) and plain_map?(v2), do: merge_raw_values(v1, v2), else: v2
     end)
   end
+
+  # Same traversal as `merge_raw_values/2`, but keeping the larger of two counts
+  # rather than their sum, because both sides describe the same running total.
+  defp merge_cumulative_raw(raw1, raw2) do
+    Map.merge(raw1, raw2, fn
+      _k, v1, v2 when is_number(v1) and is_number(v2) ->
+        max(v1, v2)
+
+      _k, v1, v2 ->
+        if plain_map?(v1) and plain_map?(v2), do: merge_cumulative_raw(v1, v2), else: v2
+    end)
+  end
+
+  # `max/2` compares across types, and every atom sorts above every number, so a
+  # bare `max(nil, 5)` returns `nil`. An unreported count is not a larger count.
+  defp running_max(nil, value), do: value
+  defp running_max(value, nil), do: value
+  defp running_max(v1, v2), do: max(v1, v2)
+
+  # Structs are maps, but merging them key-by-key would produce a malformed
+  # struct rather than a sum, so only bare maps recurse.
+  defp plain_map?(value), do: is_map(value) and not is_struct(value)
 
   @doc """
   Extracts token usage information from a `LangChain.Message` or

--- a/lib/token_usage.ex
+++ b/lib/token_usage.ex
@@ -74,17 +74,24 @@ defmodule LangChain.TokenUsage do
 
   @doc """
   Return the total token usage amount. The total is the sum of input and output.
+
+  A count a provider never reported is `nil` and contributes nothing to the
+  total. Anthropic's closing `message_delta` event, for one, carries only
+  `output_tokens`, so a usage built from it alone has no input count.
   """
   @spec total(t()) :: integer()
   def total(%TokenUsage{} = usage) do
-    usage.input + usage.output
+    (usage.input || 0) + (usage.output || 0)
   end
 
   @doc """
   Combines two TokenUsage structs by adding their respective input and output
-  values. The raw maps are merged, with numeric values added at every depth so
-  nested usage details (`prompt_tokens_details`, `completion_tokens_details`, and
-  friends) accumulate per-key rather than the later map replacing the earlier one.
+  values. The raw maps are merged, with numeric values added at every depth, so
+  map-valued usage details such as `prompt_tokens_details` and
+  `completion_tokens_details` accumulate per-key rather than the later map
+  replacing the earlier one. A detail reported as a *list* of per-modality
+  objects, the shape Gemini uses for `promptTokensDetails`, offers no key to
+  accumulate against and is taken from the later usage whole.
 
   When the second argument is marked `cumulative: true` it is a running total for
   the message rather than an increment, so it supersedes the accumulator instead
@@ -153,7 +160,11 @@ defmodule LangChain.TokenUsage do
 
   Returns non-`TokenUsage` values (including `nil`) unchanged.
   """
-  @spec clear_cumulative(t() | nil) :: t() | nil
+  # Two specs, because the catch-all clause makes this intentionally total: a
+  # caller can pipe a `get/1` result straight through without a nil check, and
+  # anything that is not a `%TokenUsage{}` comes back as the type it went in as.
+  @spec clear_cumulative(t()) :: t()
+  @spec clear_cumulative(other) :: other when other: any()
   def clear_cumulative(%TokenUsage{} = usage), do: %TokenUsage{usage | cumulative: false}
   def clear_cumulative(other), do: other
 
@@ -184,7 +195,9 @@ defmodule LangChain.TokenUsage do
   # tokens under `prompt_tokens_details` / `input_tokens_details` /
   # `completion_tokens_details`. Recursing means those inner counts are summed
   # per-key at every depth instead of the earlier map being dropped for the
-  # later one.
+  # later one. Only maps are traversed. Gemini reports the same class of detail
+  # as a list of per-modality objects, which has no key to accumulate against,
+  # so the later value is taken whole.
   defp merge_raw_values(raw1, raw2) do
     Map.merge(raw1, raw2, fn
       _k, v1, v2 when is_number(v1) and is_number(v2) ->

--- a/lib/trajectory.ex
+++ b/lib/trajectory.ex
@@ -499,8 +499,8 @@ defmodule LangChain.Trajectory do
 
   defp aggregate_token_usage(messages) do
     # Each message carries its own final usage, so this sums per-message totals.
-    # `add_total/2` clears the delta-merge `:cumulative` flag first; left set, it
-    # makes the running total collapse to whichever message came last.
+    # `add/2` combines several readings of one message and would keep the
+    # largest message here instead of the sum.
     Enum.reduce(messages, nil, fn msg, acc ->
       TokenUsage.add_total(acc, TokenUsage.get(msg))
     end)
@@ -556,7 +556,7 @@ defmodule LangChain.Trajectory do
   defp token_usage_to_map(nil), do: nil
 
   # Intentionally serialize only input/output for a minimal, portable format.
-  # Provider-specific details in :raw and :cumulative are omitted.
+  # Provider-specific details in :raw are omitted.
   defp token_usage_to_map(%TokenUsage{} = usage) do
     %{input: usage.input, output: usage.output}
   end

--- a/lib/trajectory.ex
+++ b/lib/trajectory.ex
@@ -498,11 +498,11 @@ defmodule LangChain.Trajectory do
   end
 
   defp aggregate_token_usage(messages) do
+    # Each message carries its own final usage, so this sums per-message totals.
+    # `add_total/2` clears the delta-merge `:cumulative` flag first; left set, it
+    # makes the running total collapse to whichever message came last.
     Enum.reduce(messages, nil, fn msg, acc ->
-      case TokenUsage.get(msg) do
-        nil -> acc
-        usage -> TokenUsage.add(acc, usage)
-      end
+      TokenUsage.add_total(acc, TokenUsage.get(msg))
     end)
   end
 

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -988,8 +988,9 @@ defmodule LangChain.Chains.LLMChainTest do
       assert updated_chain.last_message.tool_calls == []
       assert updated_chain.needs_response == false
 
-      # Usage metadata should be preserved on the message
-      assert %LangChain.TokenUsage{input: 3, output: 6} =
+      # Both deltas report the same message's counts, the second further along,
+      # so the message carries the later reading rather than the two added up.
+      assert %LangChain.TokenUsage{input: 2, output: 4} =
                updated_chain.last_message.metadata.usage
     end
 

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -853,8 +853,7 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
                TokenUsage.new!(%{
                  input: nil,
                  output: 80,
-                 raw: %{"output_tokens" => 80},
-                 cumulative: true
+                 raw: %{"output_tokens" => 80}
                })
     end
 
@@ -937,12 +936,11 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
       assert message.status == :content_filtered
       assert message.content == [ContentPart.text!("Here is the first step")]
       assert message.metadata[:stop_details] == %{"type" => "refusal", "category" => "cyber"}
-      # `message_delta` closes with the cumulative total for the message, so its
-      # 12 output tokens replace the 1 opened with rather than adding to it. The
-      # input count it does not repeat carries forward from `message_start`.
+      # `message_delta` closes with the totals for the message, so its 12 output
+      # tokens replace the 1 opened with rather than adding to it. The input
+      # count it does not repeat carries forward from `message_start`.
       assert message.metadata[:usage].input == 14
       assert message.metadata[:usage].output == 12
-      refute message.metadata[:usage].cumulative
     end
 
     test "handles receiving a content_block_start event for text", %{model: model} do
@@ -1414,8 +1412,7 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
             usage: %LangChain.TokenUsage{
               input: nil,
               output: 80,
-              raw: %{"output_tokens" => 80},
-              cumulative: true
+              raw: %{"output_tokens" => 80}
             }
           }
         }
@@ -5201,8 +5198,8 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
 
     # The events below are transcribed from Anthropic's streaming documentation.
     # A stream reports usage twice: `message_start` opens the message and
-    # `message_delta` closes it with a total that is cumulative for the whole
-    # message, repeating the input classes rather than adding to them.
+    # `message_delta` closes it with the totals for the whole message, repeating
+    # the input classes rather than adding to them.
     defp stream_to_message(model, events) do
       {:ok, %Message{} = message} =
         events
@@ -5254,7 +5251,7 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
       }
     end
 
-    test "the closing cumulative total is the message's usage, not a sum", %{model: model} do
+    test "the closing total is the message's usage, not a sum", %{model: model} do
       message =
         stream_to_message(
           model,
@@ -5284,7 +5281,6 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
       assert usage.output == 510
       assert usage.raw["input_tokens"] == 10_682
       assert usage.raw["server_tool_use"] == %{"web_search_requests" => 1}
-      refute usage.cumulative
     end
 
     test "cache classes are reported once, not doubled", %{model: model} do

--- a/test/chat_models/chat_anthropic_test.exs
+++ b/test/chat_models/chat_anthropic_test.exs
@@ -853,7 +853,8 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
                TokenUsage.new!(%{
                  input: nil,
                  output: 80,
-                 raw: %{"output_tokens" => 80}
+                 raw: %{"output_tokens" => 80},
+                 cumulative: true
                })
     end
 
@@ -936,7 +937,12 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
       assert message.status == :content_filtered
       assert message.content == [ContentPart.text!("Here is the first step")]
       assert message.metadata[:stop_details] == %{"type" => "refusal", "category" => "cyber"}
-      assert message.metadata[:usage].output == 13
+      # `message_delta` closes with the cumulative total for the message, so its
+      # 12 output tokens replace the 1 opened with rather than adding to it. The
+      # input count it does not repeat carries forward from `message_start`.
+      assert message.metadata[:usage].input == 14
+      assert message.metadata[:usage].output == 12
+      refute message.metadata[:usage].cumulative
     end
 
     test "handles receiving a content_block_start event for text", %{model: model} do
@@ -1408,7 +1414,8 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
             usage: %LangChain.TokenUsage{
               input: nil,
               output: 80,
-              raw: %{"output_tokens" => 80}
+              raw: %{"output_tokens" => 80},
+              cumulative: true
             }
           }
         }
@@ -1527,12 +1534,12 @@ defmodule LangChain.ChatModels.ChatAnthropicTest do
                metadata: %{
                  usage: %LangChain.TokenUsage{
                    input: 99,
-                   output: 362,
+                   output: 234,
                    raw: %{
                      "cache_creation_input_tokens" => 0,
                      "cache_read_input_tokens" => 0,
                      "input_tokens" => 99,
-                     "output_tokens" => 362
+                     "output_tokens" => 234
                    }
                  }
                }
@@ -5184,6 +5191,189 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
       refute ChatAnthropic.retry_on_fallback?(
                LangChainError.exception(type: "something_else", message: "Unknown")
              )
+    end
+  end
+
+  describe "streamed token usage" do
+    setup do
+      %{model: ChatAnthropic.new!(%{stream: true})}
+    end
+
+    # The events below are transcribed from Anthropic's streaming documentation.
+    # A stream reports usage twice: `message_start` opens the message and
+    # `message_delta` closes it with a total that is cumulative for the whole
+    # message, repeating the input classes rather than adding to them.
+    defp stream_to_message(model, events) do
+      {:ok, %Message{} = message} =
+        events
+        |> Enum.filter(&ChatAnthropic.relevant_event?/1)
+        |> Enum.map(&ChatAnthropic.do_process_response(model, &1))
+        |> MessageDelta.merge_deltas()
+        |> MessageDelta.to_message()
+
+      message
+    end
+
+    defp message_start_event(usage) do
+      %{
+        "type" => "message_start",
+        "message" => %{
+          "id" => "msg_01G",
+          "type" => "message",
+          "role" => "assistant",
+          "model" => "claude-3-7-sonnet-20250219",
+          "content" => [],
+          "stop_reason" => nil,
+          "stop_sequence" => nil,
+          "usage" => usage
+        }
+      }
+    end
+
+    defp text_events do
+      [
+        %{
+          "type" => "content_block_start",
+          "index" => 0,
+          "content_block" => %{"type" => "text", "text" => ""}
+        },
+        %{
+          "type" => "content_block_delta",
+          "index" => 0,
+          "delta" => %{"type" => "text_delta", "text" => "Hello"}
+        },
+        %{"type" => "content_block_stop", "index" => 0}
+      ]
+    end
+
+    defp message_delta_event(usage) do
+      %{
+        "type" => "message_delta",
+        "delta" => %{"stop_reason" => "end_turn", "stop_sequence" => nil},
+        "usage" => usage
+      }
+    end
+
+    test "the closing cumulative total is the message's usage, not a sum", %{model: model} do
+      message =
+        stream_to_message(
+          model,
+          [
+            message_start_event(%{
+              "input_tokens" => 2679,
+              "cache_creation_input_tokens" => 0,
+              "cache_read_input_tokens" => 0,
+              "output_tokens" => 3
+            })
+          ] ++
+            text_events() ++
+            [
+              message_delta_event(%{
+                "input_tokens" => 10_682,
+                "cache_creation_input_tokens" => 0,
+                "cache_read_input_tokens" => 0,
+                "output_tokens" => 510,
+                "server_tool_use" => %{"web_search_requests" => 1}
+              })
+            ]
+        )
+
+      usage = TokenUsage.get(message)
+
+      assert usage.input == 10_682
+      assert usage.output == 510
+      assert usage.raw["input_tokens"] == 10_682
+      assert usage.raw["server_tool_use"] == %{"web_search_requests" => 1}
+      refute usage.cumulative
+    end
+
+    test "cache classes are reported once, not doubled", %{model: model} do
+      message =
+        stream_to_message(
+          model,
+          [
+            message_start_event(%{
+              "input_tokens" => 10,
+              "cache_creation_input_tokens" => 31_350,
+              "cache_read_input_tokens" => 0,
+              "output_tokens" => 1
+            })
+          ] ++
+            text_events() ++
+            [
+              message_delta_event(%{
+                "input_tokens" => 10,
+                "cache_creation_input_tokens" => 31_350,
+                "cache_read_input_tokens" => 0,
+                "output_tokens" => 93
+              })
+            ]
+        )
+
+      usage = TokenUsage.get(message)
+
+      assert usage.input == 10
+      assert usage.output == 93
+      assert usage.raw["cache_creation_input_tokens"] == 31_350
+      assert usage.raw["cache_read_input_tokens"] == 0
+    end
+
+    test "a closing total that omits the input classes keeps the opening ones", %{model: model} do
+      # Anthropic's documentation also shows `message_delta` carrying only
+      # `output_tokens`. Nothing is added, but nothing is lost either.
+      message =
+        stream_to_message(
+          model,
+          [
+            message_start_event(%{
+              "input_tokens" => 25,
+              "cache_creation_input_tokens" => 4096,
+              "cache_read_input_tokens" => 128,
+              "output_tokens" => 1
+            })
+          ] ++ text_events() ++ [message_delta_event(%{"output_tokens" => 15})]
+        )
+
+      usage = TokenUsage.get(message)
+
+      assert usage.input == 25
+      assert usage.output == 15
+      assert usage.raw["cache_creation_input_tokens"] == 4096
+      assert usage.raw["cache_read_input_tokens"] == 128
+    end
+
+    test "no input class exceeds the largest single event reporting it", %{model: model} do
+      start_usage = %{
+        "input_tokens" => 10,
+        "cache_creation_input_tokens" => 31_350,
+        "cache_read_input_tokens" => 7,
+        "output_tokens" => 1
+      }
+
+      delta_usage = %{
+        "input_tokens" => 10,
+        "cache_creation_input_tokens" => 31_350,
+        "cache_read_input_tokens" => 7,
+        "output_tokens" => 93
+      }
+
+      message =
+        stream_to_message(
+          model,
+          [message_start_event(start_usage)] ++
+            text_events() ++ [message_delta_event(delta_usage)]
+        )
+
+      usage = TokenUsage.get(message)
+
+      for key <- ["input_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"] do
+        largest_reported = max(start_usage[key], delta_usage[key])
+
+        assert usage.raw[key] <= largest_reported,
+               "#{key} accumulated to #{usage.raw[key]}, above the largest single reading of #{largest_reported}"
+      end
+
+      assert usage.input <= max(start_usage["input_tokens"], delta_usage["input_tokens"])
     end
   end
 end

--- a/test/chat_models/chat_aws_mantle_test.exs
+++ b/test/chat_models/chat_aws_mantle_test.exs
@@ -2,6 +2,7 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
   use LangChain.BaseCase
 
   alias LangChain.ChatModels.ChatAwsMantle
+  alias LangChain.Chains.LLMChain
   alias LangChain.Function
   alias LangChain.FunctionParam
   alias LangChain.LangChainError
@@ -505,13 +506,13 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
       assert %MessageDelta{status: :complete} = ChatAwsMantle.do_process_response(m, chunk)
     end
 
-    test "usage-only terminal event is :skip", %{model: m} do
+    test "usage-only terminal event reports the usage", %{model: m} do
       chunk = %{
         "choices" => [],
         "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 5, "total_tokens" => 15}
       }
 
-      assert :skip = ChatAwsMantle.do_process_response(m, chunk)
+      assert %TokenUsage{input: 10, output: 5} = ChatAwsMantle.do_process_response(m, chunk)
     end
 
     test "tool_call delta carries a ToolCall in the MessageDelta.tool_calls field", %{model: m} do
@@ -857,6 +858,72 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
       assert text =~ ~r/owl/i
 
       assert %TokenUsage{} = msg.metadata.usage
+    end
+  end
+
+  describe "streamed token usage" do
+    setup do
+      %{
+        model:
+          ChatAwsMantle.new!(%{
+            model: @kimi_model,
+            region: "us-east-1",
+            api_key: "key",
+            stream: true,
+            stream_options: %{include_usage: true}
+          })
+      }
+    end
+
+    @usage %{
+      "prompt_tokens" => 1100,
+      "completion_tokens" => 9,
+      "total_tokens" => 1109,
+      "prompt_tokens_details" => %{"cached_tokens" => 512}
+    }
+
+    test "the usage-only terminal chunk reports usage rather than being dropped", %{model: model} do
+      chunk = %{"choices" => [], "usage" => @usage}
+
+      assert %TokenUsage{} = usage = ChatAwsMantle.do_process_response(model, chunk)
+      assert usage.input == 1100
+      assert usage.output == 9
+      assert usage.raw["prompt_tokens_details"] == %{"cached_tokens" => 512}
+    end
+
+    test "a streamed turn's usage reaches the assembled message", %{model: model} do
+      chunks = [
+        %{
+          "choices" => [
+            %{
+              "index" => 0,
+              "delta" => %{"role" => "assistant", "content" => "Hel"},
+              "finish_reason" => nil
+            }
+          ]
+        },
+        %{
+          "choices" => [
+            %{"index" => 0, "delta" => %{"content" => "lo!"}, "finish_reason" => "stop"}
+          ]
+        },
+        %{"choices" => [], "usage" => @usage}
+      ]
+
+      chain =
+        Enum.reduce(chunks, LLMChain.new!(%{llm: model}), fn chunk, acc ->
+          case ChatAwsMantle.do_process_response(model, chunk) do
+            :skip -> acc
+            item -> LLMChain.merge_delta(acc, item)
+          end
+        end)
+
+      assert {:ok, %Message{} = message} = MessageDelta.to_message(chain.delta)
+
+      usage = TokenUsage.get(message)
+      assert usage.input == 1100
+      assert usage.output == 9
+      assert usage.raw["prompt_tokens_details"]["cached_tokens"] == 512
     end
   end
 end

--- a/test/chat_models/chat_model_test.exs
+++ b/test/chat_models/chat_model_test.exs
@@ -171,6 +171,37 @@ defmodule LangChain.ChatModels.ChatModelTest do
                ChatModel.token_usage_from_result({:ok, deltas})
     end
 
+    test "reads a bare %TokenUsage{} carried alongside the streamed deltas", %{usage: usage} do
+      # OpenAI-shaped providers (ChatOpenAI, ChatAwsMantle, ChatGrok) answer the
+      # usage-only terminal chunk with a bare `%TokenUsage{}` rather than hanging
+      # it off a delta's metadata, and `LangChain.Utils` leaves it in the response
+      # body because only `:skip` is filtered out. Scanning only delta metadata
+      # reports `token_usage: nil` for every streamed call those providers make.
+      items = [
+        %MessageDelta{role: :assistant, content: "hi", metadata: nil},
+        %MessageDelta{role: :assistant, content: " there", metadata: nil},
+        usage
+      ]
+
+      assert %{token_usage: ^usage} = ChatModel.token_usage_from_result({:ok, items})
+    end
+
+    test "combines a bare %TokenUsage{} with usage already on the deltas" do
+      # Nothing stops a provider from doing both, so the bare struct joins the
+      # same `TokenUsage.add/2` fold the delta-borne readings go through.
+      items = [
+        %MessageDelta{
+          role: :assistant,
+          content: "hi",
+          metadata: %{usage: %TokenUsage{input: 25, output: 0}}
+        },
+        %TokenUsage{input: 0, output: 15}
+      ]
+
+      assert %{token_usage: %TokenUsage{input: 25, output: 15}} =
+               ChatModel.token_usage_from_result({:ok, items})
+    end
+
     test "returns nil usage when none is present" do
       deltas = [%MessageDelta{role: :assistant, content: "hi", metadata: nil}]
       assert %{token_usage: nil} = ChatModel.token_usage_from_result({:ok, deltas})

--- a/test/chat_models/chat_model_test.exs
+++ b/test/chat_models/chat_model_test.exs
@@ -122,26 +122,27 @@ defmodule LangChain.ChatModels.ChatModelTest do
       assert %{token_usage: ^usage} = ChatModel.token_usage_from_result({:ok, messages})
     end
 
-    test "keeps the final cumulative total across streamed deltas (Google/Vertex)" do
-      # Google/Vertex tag *every* streamed delta with a `cumulative: true` running
-      # total — the final delta carries the full count, earlier ones carry
-      # partials. Regression: selecting the *first* delta with usage reported an
-      # early partial total, under-counting the `:stop` event and the OTEL span.
+    test "keeps the final running total across streamed deltas (Google/Vertex)" do
+      # Google/Vertex report a running total on *every* streamed delta. The
+      # final delta carries the full count, earlier ones carry partials.
+      # Selecting the *first* delta with usage reports an early partial total,
+      # under-counting the `:stop` event and the OTEL span; summing the deltas
+      # reports several times the truth.
       deltas = [
         %MessageDelta{
           role: :assistant,
           content: "a",
-          metadata: %{usage: %TokenUsage{input: 10, output: 1, cumulative: true}}
+          metadata: %{usage: %TokenUsage{input: 10, output: 1}}
         },
         %MessageDelta{
           role: :assistant,
           content: "b",
-          metadata: %{usage: %TokenUsage{input: 10, output: 3, cumulative: true}}
+          metadata: %{usage: %TokenUsage{input: 10, output: 3}}
         },
         %MessageDelta{
           role: :assistant,
           content: "c",
-          metadata: %{usage: %TokenUsage{input: 10, output: 5, cumulative: true}}
+          metadata: %{usage: %TokenUsage{input: 10, output: 5}}
         }
       ]
 
@@ -150,9 +151,9 @@ defmodule LangChain.ChatModels.ChatModelTest do
     end
 
     test "combines usage split across streamed deltas (Anthropic input/output split)" do
-      # Anthropic reports input tokens on the `message_start` delta and the final
-      # output tokens on the `message_delta` delta — two separate, partial deltas.
-      # Neither alone is the full total; `TokenUsage.add/2` combines them, matching
+      # Anthropic reports the input classes on the `message_start` delta and the
+      # final output tokens on the `message_delta` delta. Neither reading alone
+      # describes the whole message; `TokenUsage.add/2` combines them, matching
       # what `MessageDelta.merge_deltas/2` produces on the assembled message.
       deltas = [
         %MessageDelta{
@@ -186,16 +187,38 @@ defmodule LangChain.ChatModels.ChatModelTest do
       assert %{token_usage: ^usage} = ChatModel.token_usage_from_result({:ok, items})
     end
 
-    test "combines a bare %TokenUsage{} with usage already on the deltas" do
-      # Nothing stops a provider from doing both, so the bare struct joins the
-      # same `TokenUsage.add/2` fold the delta-borne readings go through.
+    test "a bare %TokenUsage{} repeating the deltas' usage is not counted twice" do
+      # An OpenAI-compatible server asked for `continuous_usage_stats` puts a
+      # running total on every content chunk *and* repeats it on the usage-only
+      # terminal chunk. Both carriers describe the same message, so the bare
+      # struct joins the same `TokenUsage.add/2` fold the delta-borne readings go
+      # through rather than being added on top of them.
+      items = [
+        %MessageDelta{
+          role: :assistant,
+          content: "Hel",
+          metadata: %{usage: %TokenUsage{input: 11, output: 1}}
+        },
+        %MessageDelta{
+          role: :assistant,
+          content: "lo!",
+          metadata: %{usage: %TokenUsage{input: 11, output: 2}}
+        },
+        %TokenUsage{input: 11, output: 2}
+      ]
+
+      assert %{token_usage: %TokenUsage{input: 11, output: 2}} =
+               ChatModel.token_usage_from_result({:ok, items})
+    end
+
+    test "a bare %TokenUsage{} fills in a class the deltas never reported" do
       items = [
         %MessageDelta{
           role: :assistant,
           content: "hi",
           metadata: %{usage: %TokenUsage{input: 25, output: 0}}
         },
-        %TokenUsage{input: 0, output: 15}
+        %TokenUsage{output: 15}
       ]
 
       assert %{token_usage: %TokenUsage{input: 25, output: 15}} =

--- a/test/chat_models/chat_perplexity_test.exs
+++ b/test/chat_models/chat_perplexity_test.exs
@@ -1172,5 +1172,67 @@ defmodule LangChain.ChatModels.ChatPerplexityTest do
 
       :telemetry.detach("test-perplexity-token-usage-stop")
     end
+
+    # Perplexity puts `usage` on the chunk that closes the stream, alongside the
+    # final content delta. Decoding that chunk without reading the usage leaves
+    # a streamed turn reporting nothing at all: no callback, no message
+    # metadata, and `token_usage: nil` on the LLM call :stop event.
+    test "streamed call persists token usage onto the message and stop event" do
+      test_pid = self()
+
+      perplexity =
+        ChatPerplexity.new!(%{
+          model: @test_model,
+          api_key: "test-key",
+          stream: true,
+          callbacks: [
+            %{on_llm_token_usage: fn usage -> send(test_pid, {:usage, usage}) end}
+          ]
+        })
+
+      chunks = [
+        ~s|data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"Hel"},"finish_reason":null}]}\n\n|,
+        ~s|data: {"usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13},"choices":[{"index":0,"delta":{"content":"lo!"},"finish_reason":"stop"}]}\n\n|
+      ]
+
+      expect(Req, :post, fn req, opts ->
+        collector = Keyword.fetch!(opts, :into)
+        start = {req, %Req.Response{status: 200, headers: %{}, body: ""}}
+
+        {_req, response} =
+          Enum.reduce(chunks, start, fn chunk, acc ->
+            case collector.({:data, chunk}, acc) do
+              {:cont, next} -> next
+              {:halt, next} -> next
+            end
+          end)
+
+        {:ok, response}
+      end)
+
+      :telemetry.attach(
+        "test-perplexity-streamed-token-usage-stop",
+        [:langchain, :llm, :call, :stop],
+        fn _name, _measurements, metadata, _config ->
+          send(test_pid, {:stop, metadata})
+        end,
+        nil
+      )
+
+      assert {:ok, items} = ChatPerplexity.call(perplexity, [Message.new_user!("Hi")], [])
+
+      # The usage rides on the deltas, so it survives into the assembled message.
+      assert {:ok, %Message{} = message} =
+               items |> List.flatten() |> MessageDelta.merge_deltas() |> MessageDelta.to_message()
+
+      assert %TokenUsage{input: 5, output: 8} = TokenUsage.get(message)
+
+      assert_received {:usage, %TokenUsage{input: 5, output: 8}}
+
+      assert_received {:stop, stop_metadata}
+      assert %TokenUsage{input: 5, output: 8} = stop_metadata.token_usage
+
+      :telemetry.detach("test-perplexity-streamed-token-usage-stop")
+    end
   end
 end

--- a/test/chat_models/chat_req_llm_test.exs
+++ b/test/chat_models/chat_req_llm_test.exs
@@ -1830,12 +1830,11 @@ if Code.ensure_loaded?(ReqLLM) do
         end
       end
 
-      test "a whole non-streamed response is not marked cumulative" do
+      test "a whole non-streamed response reports its usage once" do
         usage = ChatReqLLM.translate_usage(usage_snapshot(100, 20))
 
-        assert usage.input == 100
-        assert usage.output == 20
-        refute usage.cumulative
+        assert %TokenUsage{input: 100, output: 20} = usage
+        assert usage.raw[:total_tokens] == 120
       end
     end
   end

--- a/test/chat_models/chat_req_llm_test.exs
+++ b/test/chat_models/chat_req_llm_test.exs
@@ -1763,5 +1763,80 @@ if Code.ensure_loaded?(ReqLLM) do
 
       IO.inspect(last_msg, label: "LIVE STREAMING TOOL CHAIN FINAL MESSAGE")
     end
+
+    describe "streamed token usage" do
+      # req_llm hands usage over as a complete snapshot of the message so far,
+      # and a provider may report more than one. Anthropic reports two: one
+      # opening the message and one closing it.
+      defp usage_snapshot(input, output, opts \\ []) do
+        %{
+          input_tokens: input,
+          output_tokens: output,
+          total_tokens: input + output,
+          cached_tokens: Keyword.get(opts, :cache_read, 0),
+          cache_read_input_tokens: Keyword.get(opts, :cache_read, 0),
+          cache_creation_input_tokens: Keyword.get(opts, :cache_creation, 0),
+          reasoning_tokens: 0
+        }
+      end
+
+      defp merge_usage_chunks(snapshots) do
+        snapshots
+        |> Enum.map(&%ReqLLM.StreamChunk{type: :meta, metadata: %{usage: &1}})
+        |> Enum.flat_map(&ChatReqLLM.translate_stream_chunk/1)
+        |> MessageDelta.merge_deltas()
+        |> TokenUsage.get()
+      end
+
+      test "two snapshots report the later reading, not their sum" do
+        usage =
+          merge_usage_chunks([
+            usage_snapshot(10, 1, cache_creation: 31_350),
+            usage_snapshot(10, 93, cache_creation: 31_350)
+          ])
+
+        assert usage.input == 10
+        assert usage.output == 93
+        assert usage.raw[:cache_creation_input_tokens] == 31_350
+      end
+
+      test "a zero-filled snapshot does not erase a class an earlier one reported" do
+        # req_llm normalizes an unreported class to zero rather than omitting it,
+        # so a closing snapshot that only carries output tokens arrives with
+        # every other count set to 0.
+        usage =
+          merge_usage_chunks([
+            usage_snapshot(25, 1, cache_creation: 4096, cache_read: 128),
+            usage_snapshot(0, 15)
+          ])
+
+        assert usage.input == 25
+        assert usage.output == 15
+        assert usage.raw[:cache_creation_input_tokens] == 4096
+        assert usage.raw[:cache_read_input_tokens] == 128
+      end
+
+      test "no count exceeds the largest single snapshot reporting it" do
+        first = usage_snapshot(10, 1, cache_creation: 31_350)
+        second = usage_snapshot(10, 93, cache_creation: 31_350)
+
+        usage = merge_usage_chunks([first, second])
+
+        for key <- [:input_tokens, :output_tokens, :cache_creation_input_tokens] do
+          largest = max(first[key], second[key])
+
+          assert usage.raw[key] <= largest,
+                 "#{key} accumulated to #{usage.raw[key]}, above the largest snapshot of #{largest}"
+        end
+      end
+
+      test "a whole non-streamed response is not marked cumulative" do
+        usage = ChatReqLLM.translate_usage(usage_snapshot(100, 20))
+
+        assert usage.input == 100
+        assert usage.output == 20
+        refute usage.cumulative
+      end
+    end
   end
 end

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -1495,4 +1495,76 @@ defmodule ChatModels.ChatVertexAITest do
       verify!()
     end
   end
+
+  describe "streamed token usage" do
+    # Gemini repeats the running totals for the message on every streamed
+    # chunk rather than reporting only what that chunk added, so merging the
+    # deltas must keep the latest reading instead of summing them.
+    defp usage_chunk(text, output_tokens, opts \\ []) do
+      candidate =
+        %{"content" => %{"role" => "model", "parts" => [%{"text" => text}]}, "index" => 0}
+        |> then(fn c ->
+          if opts[:last], do: Map.put(c, "finishReason", "STOP"), else: c
+        end)
+
+      %{
+        "candidates" => [candidate],
+        "usageMetadata" => %{
+          "promptTokenCount" => 100,
+          "candidatesTokenCount" => output_tokens,
+          "totalTokenCount" => 100 + output_tokens
+        }
+      }
+    end
+
+    test "a per-chunk running total is not summed across chunks", %{model: model} do
+      chunks = [
+        usage_chunk("Hel", 1),
+        usage_chunk("lo", 5),
+        usage_chunk("!", 9, last: true)
+      ]
+
+      merged =
+        chunks
+        |> Enum.flat_map(&ChatVertexAI.do_process_response(model, &1, MessageDelta))
+        |> MessageDelta.merge_deltas()
+
+      usage = TokenUsage.get(merged)
+
+      assert usage.input == 100
+      assert usage.output == 9
+      assert usage.raw["promptTokenCount"] == 100
+      assert usage.raw["candidatesTokenCount"] == 9
+    end
+
+    test "no reported count exceeds the largest single chunk reporting it", %{model: model} do
+      chunks = [
+        usage_chunk("Hel", 1),
+        usage_chunk("lo", 5),
+        usage_chunk("!", 9, last: true)
+      ]
+
+      merged =
+        chunks
+        |> Enum.flat_map(&ChatVertexAI.do_process_response(model, &1, MessageDelta))
+        |> MessageDelta.merge_deltas()
+
+      usage = TokenUsage.get(merged)
+
+      assert usage.input <= 100
+      assert usage.output <= 9
+      assert usage.raw["totalTokenCount"] <= 109
+    end
+
+    test "a whole response is not marked cumulative", %{model: model} do
+      response = usage_chunk("Hello User!", 9, last: true)
+
+      assert [%Message{} = message] = ChatVertexAI.do_process_response(model, response, Message)
+
+      usage = TokenUsage.get(message)
+      assert usage.input == 100
+      assert usage.output == 9
+      refute usage.cumulative
+    end
+  end
 end

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -1556,15 +1556,12 @@ defmodule ChatModels.ChatVertexAITest do
       assert usage.raw["totalTokenCount"] <= 109
     end
 
-    test "a whole response is not marked cumulative", %{model: model} do
+    test "a whole response reports its usage once", %{model: model} do
       response = usage_chunk("Hello User!", 9, last: true)
 
       assert [%Message{} = message] = ChatVertexAI.do_process_response(model, response, Message)
 
-      usage = TokenUsage.get(message)
-      assert usage.input == 100
-      assert usage.output == 9
-      refute usage.cumulative
+      assert %TokenUsage{input: 100, output: 9} = TokenUsage.get(message)
     end
   end
 end

--- a/test/chat_models/streamed_token_usage_test.exs
+++ b/test/chat_models/streamed_token_usage_test.exs
@@ -1,0 +1,220 @@
+defmodule LangChain.ChatModels.StreamedTokenUsageTest do
+  @moduledoc """
+  A streamed turn must report its token usage, whatever carrier the provider
+  chose for it, and must report it once.
+
+  `ChatModel.token_usage_from_result/1` is what the `[:langchain, :llm, :call]`
+  span reads on stop, so a provider whose streaming decode drops usage silently
+  reports `token_usage: nil` to telemetry and to OpenTelemetry. A provider whose
+  readings are added instead of combined reports a multiple of the truth. Both
+  failures are invisible from inside one provider's own tests, so the invariant
+  is asserted here across all of them at once.
+  """
+  use LangChain.BaseCase
+  use Mimic
+
+  alias LangChain.ChatModels.{
+    ChatAnthropic,
+    ChatAwsMantle,
+    ChatDeepSeek,
+    ChatGoogleAI,
+    ChatMistralAI,
+    ChatModel,
+    ChatOpenAI,
+    ChatOpenAIResponses,
+    ChatOrq,
+    ChatPerplexity,
+    ChatVertexAI
+  }
+
+  alias LangChain.Message
+  alias LangChain.MessageDelta
+  alias LangChain.TokenUsage
+
+  setup :verify_on_exit!
+
+  # A streamed request hands Req an `:into` collector, so a mocked post has to
+  # drive that collector the way a real response would rather than handing back
+  # a buffered body.
+  defp expect_streamed_post(chunks) do
+    expect(Req, :post, fn req, opts ->
+      collector = Keyword.fetch!(opts, :into)
+      start = {req, %Req.Response{status: 200, headers: %{}, body: ""}}
+
+      {_req, response} =
+        Enum.reduce(chunks, start, fn chunk, acc ->
+          case collector.({:data, chunk}, acc) do
+            {:cont, next} -> next
+            {:halt, next} -> next
+          end
+        end)
+
+      {:ok, response}
+    end)
+  end
+
+  defp sse(payload), do: "data: " <> Jason.encode!(payload) <> "\n\n"
+
+  # An OpenAI-shaped stream: content chunks carry no usage, and a final chunk
+  # with empty `choices` carries usage alone.
+  defp openai_shaped_chunks do
+    [
+      sse(%{
+        "choices" => [
+          %{"index" => 0, "delta" => %{"role" => "assistant", "content" => "Hel"}}
+        ]
+      }),
+      sse(%{
+        "choices" => [
+          %{"index" => 0, "delta" => %{"content" => "lo!"}, "finish_reason" => "stop"}
+        ]
+      }),
+      sse(%{
+        "choices" => [],
+        "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 5, "total_tokens" => 15}
+      })
+    ]
+  end
+
+  # Mistral and Perplexity report usage on the chunk that closes the stream,
+  # riding alongside the final content delta rather than on a chunk of its own.
+  defp trailing_usage_chunks do
+    [
+      sse(%{
+        "choices" => [
+          %{"index" => 0, "delta" => %{"role" => "assistant", "content" => "Hel"}}
+        ]
+      }),
+      sse(%{
+        "choices" => [
+          %{"index" => 0, "delta" => %{"content" => "lo!"}, "finish_reason" => "stop"}
+        ],
+        "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 5, "total_tokens" => 15}
+      })
+    ]
+  end
+
+  # Gemini repeats the totals for the message so far on every chunk.
+  defp gemini_chunks do
+    for {text, output} <- [{"Hel", 2}, {"lo!", 5}] do
+      sse(%{
+        "candidates" => [
+          %{"content" => %{"role" => "model", "parts" => [%{"text" => text}]}}
+        ],
+        "usageMetadata" => %{
+          "promptTokenCount" => 10,
+          "candidatesTokenCount" => output,
+          "totalTokenCount" => 10 + output
+        }
+      })
+    end
+  end
+
+  # Anthropic opens the message with the input classes and closes it with the
+  # totals for the whole message.
+  defp anthropic_chunks do
+    [
+      sse(%{
+        "type" => "message_start",
+        "message" => %{
+          "id" => "msg_1",
+          "type" => "message",
+          "role" => "assistant",
+          "content" => [],
+          "usage" => %{
+            "input_tokens" => 10,
+            "cache_creation_input_tokens" => 0,
+            "cache_read_input_tokens" => 0,
+            "output_tokens" => 1
+          }
+        }
+      }),
+      sse(%{
+        "type" => "content_block_start",
+        "index" => 0,
+        "content_block" => %{"type" => "text", "text" => ""}
+      }),
+      sse(%{
+        "type" => "content_block_delta",
+        "index" => 0,
+        "delta" => %{"type" => "text_delta", "text" => "Hello!"}
+      }),
+      sse(%{
+        "type" => "message_delta",
+        "delta" => %{"stop_reason" => "end_turn"},
+        "usage" => %{"output_tokens" => 5}
+      })
+    ]
+  end
+
+  defp responses_chunks do
+    [
+      sse(%{
+        "type" => "response.output_text.delta",
+        "delta" => "Hello!",
+        "output_index" => 0,
+        "item_id" => "msg_1"
+      }),
+      sse(%{
+        "type" => "response.completed",
+        "response" => %{
+          "id" => "resp_1",
+          "usage" => %{"input_tokens" => 10, "output_tokens" => 5, "total_tokens" => 15}
+        }
+      })
+    ]
+  end
+
+  defp chunks_for(:openai_shaped), do: openai_shaped_chunks()
+  defp chunks_for(:trailing_usage), do: trailing_usage_chunks()
+  defp chunks_for(:gemini), do: gemini_chunks()
+  defp chunks_for(:anthropic), do: anthropic_chunks()
+  defp chunks_for(:responses), do: responses_chunks()
+
+  @providers [
+    {ChatOpenAI, %{model: "gpt-4o", api_key: "k"}, :openai_shaped},
+    {ChatOpenAIResponses, %{model: "gpt-4o", api_key: "k"}, :responses},
+    {ChatAnthropic, %{model: "claude-x", api_key: "k"}, :anthropic},
+    {ChatMistralAI, %{model: "mistral-small", api_key: "k"}, :trailing_usage},
+    {ChatPerplexity, %{model: "sonar-pro", api_key: "k"}, :trailing_usage},
+    {ChatDeepSeek, %{model: "deepseek-chat", api_key: "k"}, :openai_shaped},
+    {ChatOrq, %{model: "openai/gpt-4o", key: "k"}, :openai_shaped},
+    {ChatAwsMantle, %{model: "anthropic.claude", endpoint: "https://mantle.test", api_key: "k"},
+     :openai_shaped},
+    {ChatGoogleAI, %{model: "gemini-2.0-flash", api_key: "k"}, :gemini},
+    {ChatVertexAI, %{model: "gemini-2.0-flash", endpoint: "https://vertex.test", api_key: "k"},
+     :gemini}
+  ]
+
+  for {module, attrs, shape} <- @providers do
+    @module module
+    @attrs attrs
+    @shape shape
+
+    test "#{inspect(module)} reports a streamed turn's usage exactly once" do
+      model = @module.new!(Map.put(@attrs, :stream, true))
+      expect_streamed_post(chunks_for(@shape))
+
+      assert {:ok, items} = @module.call(model, [Message.new_user!("Hi")], []),
+             "#{inspect(@module)} did not answer a streamed call"
+
+      assert %{token_usage: %TokenUsage{input: 10, output: 5}} =
+               ChatModel.token_usage_from_result({:ok, items}),
+             "#{inspect(@module)} did not report input 10 / output 5 to the LLM call span"
+    end
+  end
+
+  test "a streamed result nests one list per received chunk" do
+    # `ChatModel.call_response/0` declares the nesting, and both
+    # `LangChain.Chains.LLMChain` and `token_usage_from_result/1` flatten before
+    # reading. A provider that flattened its own body would break neither, but
+    # the declared type would stop describing the common case.
+    model = ChatOpenAI.new!(%{model: "gpt-4o", api_key: "k", stream: true})
+    expect_streamed_post(openai_shaped_chunks())
+
+    assert {:ok, items} = ChatOpenAI.call(model, [Message.new_user!("Hi")], [])
+
+    assert [[%MessageDelta{} | _] | _] = items
+    assert Enum.any?(List.flatten(items), &match?(%TokenUsage{}, &1))
+  end
+end

--- a/test/chat_models/telemetry_test.exs
+++ b/test/chat_models/telemetry_test.exs
@@ -641,16 +641,14 @@ defmodule LangChain.ChatModels.TelemetryTest do
   describe "chain token usage aggregation across turns" do
     setup :verify_on_exit!
 
-    test "sums usage across all assistant messages, even when flagged cumulative (streaming)" do
+    test "sums usage across all assistant messages of a run" do
       test_pid = self()
 
-      # Two LLM turns, each reporting usage flagged `cumulative: true` — exactly what
-      # a streaming provider (e.g. Google AI) produces once its deltas are assembled
-      # into a message. The cumulative flag is a *delta-merge* signal for a single
-      # message; it must NOT cause an earlier turn to be discarded when the chain
-      # aggregates per-turn totals across the run.
-      turn1_usage = TokenUsage.new!(%{input: 100, output: 20, cumulative: true})
-      turn2_usage = TokenUsage.new!(%{input: 130, output: 15, cumulative: true})
+      # Two LLM turns, each carrying the usage its own message settled on. A
+      # chain aggregates per-turn totals across the run, so the earlier turn
+      # must survive rather than being superseded by the later one.
+      turn1_usage = TokenUsage.new!(%{input: 100, output: 20})
+      turn2_usage = TokenUsage.new!(%{input: 130, output: 15})
 
       ChatOpenAI
       |> expect(:call, fn _model, _messages, _tools ->
@@ -683,8 +681,7 @@ defmodule LangChain.ChatModels.TelemetryTest do
         |> LLMChain.add_message(Message.new_user!("please call do_thing"))
         |> LLMChain.run(mode: :while_needs_response)
 
-      # 100 + 130 input and 20 + 15 output: the first turn is NOT lost despite both
-      # turns being flagged cumulative. (Before the fix this reported {130, 15}.)
+      # 100 + 130 input and 20 + 15 output: the first turn is not lost.
       assert_received {:chain_stop, stop_metadata}
       assert %TokenUsage{input: 230, output: 35} = stop_metadata.token_usage
 

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -1068,12 +1068,12 @@ defmodule LangChain.MessageDeltaTest do
                metadata: %{
                  usage: %LangChain.TokenUsage{
                    input: 55,
-                   output: 84,
+                   output: 80,
                    raw: %{
                      "cache_creation_input_tokens" => 0,
                      "cache_read_input_tokens" => 0,
                      "input_tokens" => 55,
-                     "output_tokens" => 84
+                     "output_tokens" => 80
                    }
                  }
                }
@@ -1366,7 +1366,7 @@ defmodule LangChain.MessageDeltaTest do
              }
     end
 
-    test "accumulates token usage across batches" do
+    test "combines token usage across batches" do
       accumulated = nil
 
       batch_1 = [
@@ -1381,20 +1381,21 @@ defmodule LangChain.MessageDeltaTest do
 
       accumulated = MessageDelta.merge_deltas(accumulated, batch_1)
 
+      # A later batch reports the message's counts again, further along.
       batch_2 = [
         %MessageDelta{
           content: " world",
           role: :assistant,
           metadata: %{
-            usage: %LangChain.TokenUsage{input: 5, output: 10}
+            usage: %LangChain.TokenUsage{input: 10, output: 12}
           }
         }
       ]
 
       result = MessageDelta.merge_deltas(accumulated, batch_2)
 
-      assert result.metadata.usage.input == 15
-      assert result.metadata.usage.output == 15
+      assert result.metadata.usage.input == 10
+      assert result.metadata.usage.output == 12
     end
 
     test "handles empty batch list" do
@@ -1497,7 +1498,7 @@ defmodule LangChain.MessageDeltaTest do
       assert merged.metadata[:stop_details] == %{"type" => "refusal"}
     end
 
-    test "usage is still summed rather than replaced by the incoming delta's value" do
+    test "usage is combined rather than replaced wholesale by the incoming delta" do
       primary =
         MessageDelta.new!(%{
           role: :assistant,
@@ -1514,8 +1515,10 @@ defmodule LangChain.MessageDeltaTest do
 
       merged = MessageDelta.merge_delta(primary, incoming)
 
+      # The incoming reading advances the output count and says nothing about
+      # the input one, which stands at what the earlier reading established.
       assert merged.metadata[:usage].input == 10
-      assert merged.metadata[:usage].output == 12
+      assert merged.metadata[:usage].output == 7
       assert merged.metadata[:stop_details] == %{"type" => "refusal"}
     end
 
@@ -1533,20 +1536,17 @@ defmodule LangChain.MessageDeltaTest do
   end
 
   describe "to_message/1" do
-    test "settles the cumulative flag on the assembled message's usage" do
-      # `:cumulative` relates one delta to the other deltas of the same message.
-      # Once assembled there are no other deltas, and a message that kept the
-      # flag would make a total across messages collapse to just this one.
+    test "carries the merged usage onto the assembled message" do
       delta = %MessageDelta{
         merged_content: [ContentPart.text!("Hi")],
         role: :assistant,
         status: :complete,
-        metadata: %{usage: TokenUsage.new!(%{input: 25, output: 15, cumulative: true})}
+        metadata: %{usage: TokenUsage.new!(%{input: 25, output: 15})}
       }
 
       {:ok, %Message{} = msg} = MessageDelta.to_message(delta)
 
-      assert %TokenUsage{input: 25, output: 15, cumulative: false} = TokenUsage.get(msg)
+      assert %TokenUsage{input: 25, output: 15} = TokenUsage.get(msg)
     end
 
     test "transform a merged and complete MessageDelta to a Message" do

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -1533,6 +1533,22 @@ defmodule LangChain.MessageDeltaTest do
   end
 
   describe "to_message/1" do
+    test "settles the cumulative flag on the assembled message's usage" do
+      # `:cumulative` relates one delta to the other deltas of the same message.
+      # Once assembled there are no other deltas, and a message that kept the
+      # flag would make a total across messages collapse to just this one.
+      delta = %MessageDelta{
+        merged_content: [ContentPart.text!("Hi")],
+        role: :assistant,
+        status: :complete,
+        metadata: %{usage: TokenUsage.new!(%{input: 25, output: 15, cumulative: true})}
+      }
+
+      {:ok, %Message{} = msg} = MessageDelta.to_message(delta)
+
+      assert %TokenUsage{input: 25, output: 15, cumulative: false} = TokenUsage.get(msg)
+    end
+
     test "transform a merged and complete MessageDelta to a Message" do
       # :assistant content type
       delta = %LangChain.MessageDelta{

--- a/test/token_usage_test.exs
+++ b/test/token_usage_test.exs
@@ -40,6 +40,14 @@ defmodule LangChain.TokenUsageTest do
       usage = TokenUsage.new!(%{input: 1, output: 10})
       assert 11 == TokenUsage.total(usage)
     end
+
+    test "treats an unreported count as contributing nothing" do
+      # Anthropic's closing `message_delta` event carries only `output_tokens`,
+      # so a usage built from it alone has no input count to add.
+      assert 93 == TokenUsage.total(TokenUsage.new!(%{output: 93}))
+      assert 25 == TokenUsage.total(TokenUsage.new!(%{input: 25}))
+      assert 0 == TokenUsage.total(TokenUsage.new!(%{}))
+    end
   end
 
   describe "add/2" do
@@ -137,6 +145,46 @@ defmodule LangChain.TokenUsageTest do
       assert combined.raw["prompt_tokens_details"]["cached_tokens"] == 96
       assert combined.raw["prompt_tokens_details"]["audio_tokens"] == 0
       assert combined.raw["completion_tokens_details"]["reasoning_tokens"] == 5
+    end
+
+    test "takes the later value for a struct rather than merging it key-by-key" do
+      # Structs are maps, so recursing into one would build a malformed struct
+      # out of two rather than a sum. Whatever a provider parked in `:raw`
+      # arrives intact.
+      usage1 = TokenUsage.new!(%{raw: %{"at" => ~D[2024-01-01], "count" => 1}})
+      usage2 = TokenUsage.new!(%{raw: %{"at" => ~D[2024-06-01], "count" => 2}})
+
+      combined = TokenUsage.add(usage1, usage2)
+
+      assert combined.raw["at"] == ~D[2024-06-01]
+      assert combined.raw["count"] == 3
+
+      cumulative =
+        TokenUsage.add(usage1, TokenUsage.new!(%{raw: usage2.raw, cumulative: true}))
+
+      assert cumulative.raw["at"] == ~D[2024-06-01]
+      assert cumulative.raw["count"] == 2
+    end
+
+    test "takes a list-valued detail from the later usage whole" do
+      # Gemini reports the per-modality breakdown as a list of objects rather
+      # than a keyed map, which offers nothing to accumulate against.
+      details = fn n -> [%{"modality" => "TEXT", "tokenCount" => n}] end
+
+      usage1 =
+        TokenUsage.new!(%{
+          raw: %{"promptTokenCount" => 10, "promptTokensDetails" => details.(10)}
+        })
+
+      usage2 =
+        TokenUsage.new!(%{
+          raw: %{"promptTokenCount" => 20, "promptTokensDetails" => details.(20)}
+        })
+
+      combined = TokenUsage.add(usage1, usage2)
+
+      assert combined.raw["promptTokenCount"] == 30
+      assert combined.raw["promptTokensDetails"] == details.(20)
     end
 
     test "keeps nested keys that only one side reports" do

--- a/test/token_usage_test.exs
+++ b/test/token_usage_test.exs
@@ -51,61 +51,28 @@ defmodule LangChain.TokenUsageTest do
   end
 
   describe "add/2" do
-    test "combines two token usages" do
-      usage1 = TokenUsage.new!(%{input: 10, output: 20, raw: %{"total_tokens" => 30}})
-      usage2 = TokenUsage.new!(%{input: 5, output: 15, raw: %{"total_tokens" => 20}})
+    test "keeps the larger reading of each count" do
+      # Two readings of one message: the second reports a further-along picture
+      # of the same counters, not a second message's worth of tokens.
+      opening = TokenUsage.new!(%{input: 10, output: 1, raw: %{"total_tokens" => 11}})
+      closing = TokenUsage.new!(%{input: 10, output: 20, raw: %{"total_tokens" => 30}})
 
-      combined = TokenUsage.add(usage1, usage2)
+      combined = TokenUsage.add(opening, closing)
 
-      assert combined.input == 15
-      assert combined.output == 35
-      assert combined.raw["total_tokens"] == 50
+      assert combined.input == 10
+      assert combined.output == 20
+      assert combined.raw["total_tokens"] == 30
     end
 
-    test "handles nil values gracefully" do
-      usage1 = TokenUsage.new!(%{input: nil, output: 20, raw: %{"total_tokens" => 30}})
-      usage2 = TokenUsage.new!(%{input: 5, output: 15, raw: %{"total_tokens" => 20}})
+    test "handles nil counts on either side" do
+      opening = TokenUsage.new!(%{input: nil, output: 20, raw: %{"total_tokens" => 30}})
+      closing = TokenUsage.new!(%{input: 5, output: 15, raw: %{"total_tokens" => 20}})
 
-      combined = TokenUsage.add(usage1, usage2)
+      combined = TokenUsage.add(opening, closing)
 
       assert combined.input == 5
-      assert combined.output == 35
-      assert combined.raw["total_tokens"] == 50
-    end
-
-    test "merges raw values correctly" do
-      usage1 =
-        TokenUsage.new!(%{
-          input: 55,
-          output: 4,
-          raw: %{
-            "cache_creation_input_tokens" => 0,
-            "cache_read_input_tokens" => 0,
-            "input_tokens" => 55,
-            "output_tokens" => 4
-          }
-        })
-
-      usage2 =
-        TokenUsage.new!(%{
-          input: 30,
-          output: 2,
-          raw: %{
-            "cache_creation_input_tokens" => 10,
-            "cache_read_input_tokens" => 5,
-            "input_tokens" => 30,
-            "output_tokens" => 2
-          }
-        })
-
-      combined = TokenUsage.add(usage1, usage2)
-
-      assert combined.input == 85
-      assert combined.output == 6
-      assert combined.raw["cache_creation_input_tokens"] == 10
-      assert combined.raw["cache_read_input_tokens"] == 5
-      assert combined.raw["input_tokens"] == 85
-      assert combined.raw["output_tokens"] == 6
+      assert combined.output == 20
+      assert combined.raw["total_tokens"] == 30
     end
 
     test "handles nil arguments" do
@@ -116,8 +83,77 @@ defmodule LangChain.TokenUsageTest do
       assert TokenUsage.add(nil, usage) == usage
     end
 
-    test "sums nested raw detail maps per-key at every depth" do
-      usage1 =
+    test "carries forward a class the later reading does not report" do
+      # Anthropic's closing `message_delta` can carry only `output_tokens`.
+      opening =
+        TokenUsage.new!(%{
+          input: 25,
+          output: 1,
+          raw: %{"input_tokens" => 25, "cache_read_input_tokens" => 128}
+        })
+
+      closing = TokenUsage.new!(%{output: 15, raw: %{"output_tokens" => 15}})
+
+      combined = TokenUsage.add(opening, closing)
+
+      assert combined.input == 25
+      assert combined.output == 15
+      assert combined.raw["cache_read_input_tokens"] == 128
+      assert combined.raw["output_tokens"] == 15
+    end
+
+    test "a reading that reports zero does not erase an earlier count" do
+      # Some adapters normalize an unreported class to zero rather than omitting
+      # it. A count never decreases while a message generates, so the earlier
+      # reading stands.
+      opening =
+        TokenUsage.new!(%{
+          input: 25,
+          output: 1,
+          raw: %{"input_tokens" => 25, "cache_creation_input_tokens" => 4096}
+        })
+
+      closing =
+        TokenUsage.new!(%{
+          input: 0,
+          output: 15,
+          raw: %{"input_tokens" => 0, "cache_creation_input_tokens" => 0, "output_tokens" => 15}
+        })
+
+      combined = TokenUsage.add(opening, closing)
+
+      assert combined.input == 25
+      assert combined.output == 15
+      assert combined.raw["input_tokens"] == 25
+      assert combined.raw["cache_creation_input_tokens"] == 4096
+      assert combined.raw["output_tokens"] == 15
+    end
+
+    test "no count exceeds the largest single reading that reports it" do
+      readings = [
+        TokenUsage.new!(%{
+          input: 10,
+          output: 1,
+          raw: %{"input_tokens" => 10, "cache_creation_input_tokens" => 31_350}
+        }),
+        TokenUsage.new!(%{
+          input: 10,
+          output: 93,
+          raw: %{"input_tokens" => 10, "cache_creation_input_tokens" => 31_350}
+        })
+      ]
+
+      combined = Enum.reduce(readings, nil, &TokenUsage.add(&2, &1))
+
+      for key <- ["input_tokens", "cache_creation_input_tokens"] do
+        largest = readings |> Enum.map(& &1.raw[key]) |> Enum.max()
+
+        assert combined.raw[key] == largest
+      end
+    end
+
+    test "advances nested raw detail maps per-key at every depth" do
+      opening =
         TokenUsage.new!(%{
           input: 100,
           output: 10,
@@ -128,47 +164,49 @@ defmodule LangChain.TokenUsageTest do
           }
         })
 
-      usage2 =
+      closing =
         TokenUsage.new!(%{
-          input: 50,
-          output: 5,
+          input: 100,
+          output: 15,
           raw: %{
-            "prompt_tokens" => 50,
-            "prompt_tokens_details" => %{"cached_tokens" => 32, "audio_tokens" => 0},
-            "completion_tokens_details" => %{"reasoning_tokens" => 1}
+            "prompt_tokens" => 100,
+            "prompt_tokens_details" => %{"cached_tokens" => 64, "audio_tokens" => 0},
+            "completion_tokens_details" => %{"reasoning_tokens" => 9}
           }
         })
 
+      combined = TokenUsage.add(opening, closing)
+
+      assert combined.raw["prompt_tokens"] == 100
+      assert combined.raw["prompt_tokens_details"]["cached_tokens"] == 64
+      assert combined.raw["prompt_tokens_details"]["audio_tokens"] == 0
+      assert combined.raw["completion_tokens_details"]["reasoning_tokens"] == 9
+    end
+
+    test "keeps nested keys that only one side reports" do
+      usage1 = TokenUsage.new!(%{raw: %{"details" => %{"a" => 1}}})
+      usage2 = TokenUsage.new!(%{raw: %{"details" => %{"b" => 2}}})
+
       combined = TokenUsage.add(usage1, usage2)
 
-      assert combined.raw["prompt_tokens"] == 150
-      assert combined.raw["prompt_tokens_details"]["cached_tokens"] == 96
-      assert combined.raw["prompt_tokens_details"]["audio_tokens"] == 0
-      assert combined.raw["completion_tokens_details"]["reasoning_tokens"] == 5
+      assert combined.raw["details"] == %{"a" => 1, "b" => 2}
     end
 
     test "takes the later value for a struct rather than merging it key-by-key" do
       # Structs are maps, so recursing into one would build a malformed struct
-      # out of two rather than a sum. Whatever a provider parked in `:raw`
-      # arrives intact.
+      # out of two. Whatever a provider parked in `:raw` arrives intact.
       usage1 = TokenUsage.new!(%{raw: %{"at" => ~D[2024-01-01], "count" => 1}})
       usage2 = TokenUsage.new!(%{raw: %{"at" => ~D[2024-06-01], "count" => 2}})
 
       combined = TokenUsage.add(usage1, usage2)
 
       assert combined.raw["at"] == ~D[2024-06-01]
-      assert combined.raw["count"] == 3
-
-      cumulative =
-        TokenUsage.add(usage1, TokenUsage.new!(%{raw: usage2.raw, cumulative: true}))
-
-      assert cumulative.raw["at"] == ~D[2024-06-01]
-      assert cumulative.raw["count"] == 2
+      assert combined.raw["count"] == 2
     end
 
     test "takes a list-valued detail from the later usage whole" do
       # Gemini reports the per-modality breakdown as a list of objects rather
-      # than a keyed map, which offers nothing to accumulate against.
+      # than a keyed map, which offers nothing to advance against.
       details = fn n -> [%{"modality" => "TEXT", "tokenCount" => n}] end
 
       usage1 =
@@ -183,124 +221,92 @@ defmodule LangChain.TokenUsageTest do
 
       combined = TokenUsage.add(usage1, usage2)
 
-      assert combined.raw["promptTokenCount"] == 30
+      assert combined.raw["promptTokenCount"] == 20
       assert combined.raw["promptTokensDetails"] == details.(20)
     end
 
-    test "keeps nested keys that only one side reports" do
-      usage1 = TokenUsage.new!(%{raw: %{"details" => %{"a" => 1}}})
-      usage2 = TokenUsage.new!(%{raw: %{"details" => %{"b" => 2}}})
+    test "a raw value derived within one reading does not survive the merge" do
+      # An adapter that computes `total_tokens` as this reading's input + output
+      # describes only that reading. Keeping the larger of two such values is
+      # not the total of the merged counts, which is what `total/1` reports.
+      opening = TokenUsage.new!(%{input: 25, output: 1, raw: %{"total_tokens" => 26}})
+      closing = TokenUsage.new!(%{input: 0, output: 15, raw: %{"total_tokens" => 15}})
 
-      combined = TokenUsage.add(usage1, usage2)
+      combined = TokenUsage.add(opening, closing)
 
-      assert combined.raw["details"] == %{"a" => 1, "b" => 2}
-    end
-
-    test "a cumulative usage supersedes the accumulator instead of adding to it" do
-      running = TokenUsage.new!(%{input: 2679, output: 3, raw: %{"input_tokens" => 2679}})
-
-      total =
-        TokenUsage.new!(%{
-          input: 10_682,
-          output: 510,
-          raw: %{"input_tokens" => 10_682},
-          cumulative: true
-        })
-
-      combined = TokenUsage.add(running, total)
-
-      assert combined.input == 10_682
-      assert combined.output == 510
-      assert combined.raw["input_tokens"] == 10_682
-      assert combined.cumulative
-    end
-
-    test "a cumulative usage carries forward the fields it does not report" do
-      running =
-        TokenUsage.new!(%{
-          input: 25,
-          output: 1,
-          raw: %{"input_tokens" => 25, "cache_read_input_tokens" => 128}
-        })
-
-      total = TokenUsage.new!(%{output: 15, raw: %{"output_tokens" => 15}, cumulative: true})
-
-      combined = TokenUsage.add(running, total)
-
-      assert combined.input == 25
-      assert combined.output == 15
-      assert combined.raw["cache_read_input_tokens"] == 128
-      assert combined.raw["output_tokens"] == 15
-    end
-
-    test "a cumulative reading that reports zero does not erase an earlier count" do
-      # Some adapters normalize an unreported class to zero rather than omitting
-      # it. A running total never decreases, so the earlier count stands.
-      running =
-        TokenUsage.new!(%{
-          input: 25,
-          output: 1,
-          raw: %{"input_tokens" => 25, "cache_creation_input_tokens" => 4096}
-        })
-
-      total =
-        TokenUsage.new!(%{
-          input: 0,
-          output: 15,
-          raw: %{"input_tokens" => 0, "cache_creation_input_tokens" => 0, "output_tokens" => 15},
-          cumulative: true
-        })
-
-      combined = TokenUsage.add(running, total)
-
-      assert combined.input == 25
-      assert combined.output == 15
-      assert combined.raw["input_tokens"] == 25
-      assert combined.raw["cache_creation_input_tokens"] == 4096
-      assert combined.raw["output_tokens"] == 15
-    end
-
-    test "a cumulative reading advances nested counts without summing them" do
-      running = TokenUsage.new!(%{raw: %{"details" => %{"cached_tokens" => 64}}})
-
-      total =
-        TokenUsage.new!(%{raw: %{"details" => %{"cached_tokens" => 96}}, cumulative: true})
-
-      combined = TokenUsage.add(running, total)
-
-      assert combined.raw["details"]["cached_tokens"] == 96
-    end
-  end
-
-  describe "clear_cumulative/1" do
-    test "clears the flag and passes other values through" do
-      usage = TokenUsage.new!(%{input: 10, output: 20, cumulative: true})
-
-      assert %TokenUsage{cumulative: false, input: 10, output: 20} =
-               TokenUsage.clear_cumulative(usage)
-
-      assert TokenUsage.clear_cumulative(nil) == nil
+      assert TokenUsage.total(combined) == 40
+      assert combined.raw["total_tokens"] == 26
     end
   end
 
   describe "add_total/2" do
-    test "sums per-message totals even when they are marked cumulative" do
-      first = TokenUsage.new!(%{input: 100, output: 20, cumulative: true})
-      second = TokenUsage.new!(%{input: 150, output: 35, cumulative: true})
+    test "sums the counts of two messages" do
+      first = TokenUsage.new!(%{input: 100, output: 20})
+      second = TokenUsage.new!(%{input: 150, output: 35})
 
       total = TokenUsage.add_total(first, second)
 
       assert total.input == 250
       assert total.output == 55
-      refute total.cumulative
     end
 
     test "handles nil on either side" do
-      usage = TokenUsage.new!(%{input: 10, output: 20, cumulative: true})
+      usage = TokenUsage.new!(%{input: 10, output: 20})
 
       assert TokenUsage.add_total(nil, nil) == nil
-      assert %TokenUsage{input: 10, cumulative: false} = TokenUsage.add_total(nil, usage)
-      assert %TokenUsage{input: 10, cumulative: false} = TokenUsage.add_total(usage, nil)
+      assert %TokenUsage{input: 10} = TokenUsage.add_total(nil, usage)
+      assert %TokenUsage{input: 10} = TokenUsage.add_total(usage, nil)
+    end
+
+    test "treats an unreported count as contributing nothing" do
+      first = TokenUsage.new!(%{input: nil, output: 20})
+      second = TokenUsage.new!(%{input: 5, output: 15})
+
+      total = TokenUsage.add_total(first, second)
+
+      assert total.input == 5
+      assert total.output == 35
+    end
+
+    test "sums raw values, including nested detail maps, at every depth" do
+      first =
+        TokenUsage.new!(%{
+          input: 100,
+          output: 10,
+          raw: %{
+            "prompt_tokens" => 100,
+            "prompt_tokens_details" => %{"cached_tokens" => 64, "audio_tokens" => 0},
+            "completion_tokens_details" => %{"reasoning_tokens" => 4}
+          }
+        })
+
+      second =
+        TokenUsage.new!(%{
+          input: 50,
+          output: 5,
+          raw: %{
+            "prompt_tokens" => 50,
+            "prompt_tokens_details" => %{"cached_tokens" => 32, "audio_tokens" => 0},
+            "completion_tokens_details" => %{"reasoning_tokens" => 1}
+          }
+        })
+
+      total = TokenUsage.add_total(first, second)
+
+      assert total.raw["prompt_tokens"] == 150
+      assert total.raw["prompt_tokens_details"]["cached_tokens"] == 96
+      assert total.raw["prompt_tokens_details"]["audio_tokens"] == 0
+      assert total.raw["completion_tokens_details"]["reasoning_tokens"] == 5
+    end
+
+    test "takes the later value for a struct rather than merging it key-by-key" do
+      first = TokenUsage.new!(%{raw: %{"at" => ~D[2024-01-01], "count" => 1}})
+      second = TokenUsage.new!(%{raw: %{"at" => ~D[2024-06-01], "count" => 2}})
+
+      total = TokenUsage.add_total(first, second)
+
+      assert total.raw["at"] == ~D[2024-06-01]
+      assert total.raw["count"] == 3
     end
   end
 

--- a/test/token_usage_test.exs
+++ b/test/token_usage_test.exs
@@ -107,6 +107,153 @@ defmodule LangChain.TokenUsageTest do
       assert TokenUsage.add(usage, nil) == usage
       assert TokenUsage.add(nil, usage) == usage
     end
+
+    test "sums nested raw detail maps per-key at every depth" do
+      usage1 =
+        TokenUsage.new!(%{
+          input: 100,
+          output: 10,
+          raw: %{
+            "prompt_tokens" => 100,
+            "prompt_tokens_details" => %{"cached_tokens" => 64, "audio_tokens" => 0},
+            "completion_tokens_details" => %{"reasoning_tokens" => 4}
+          }
+        })
+
+      usage2 =
+        TokenUsage.new!(%{
+          input: 50,
+          output: 5,
+          raw: %{
+            "prompt_tokens" => 50,
+            "prompt_tokens_details" => %{"cached_tokens" => 32, "audio_tokens" => 0},
+            "completion_tokens_details" => %{"reasoning_tokens" => 1}
+          }
+        })
+
+      combined = TokenUsage.add(usage1, usage2)
+
+      assert combined.raw["prompt_tokens"] == 150
+      assert combined.raw["prompt_tokens_details"]["cached_tokens"] == 96
+      assert combined.raw["prompt_tokens_details"]["audio_tokens"] == 0
+      assert combined.raw["completion_tokens_details"]["reasoning_tokens"] == 5
+    end
+
+    test "keeps nested keys that only one side reports" do
+      usage1 = TokenUsage.new!(%{raw: %{"details" => %{"a" => 1}}})
+      usage2 = TokenUsage.new!(%{raw: %{"details" => %{"b" => 2}}})
+
+      combined = TokenUsage.add(usage1, usage2)
+
+      assert combined.raw["details"] == %{"a" => 1, "b" => 2}
+    end
+
+    test "a cumulative usage supersedes the accumulator instead of adding to it" do
+      running = TokenUsage.new!(%{input: 2679, output: 3, raw: %{"input_tokens" => 2679}})
+
+      total =
+        TokenUsage.new!(%{
+          input: 10_682,
+          output: 510,
+          raw: %{"input_tokens" => 10_682},
+          cumulative: true
+        })
+
+      combined = TokenUsage.add(running, total)
+
+      assert combined.input == 10_682
+      assert combined.output == 510
+      assert combined.raw["input_tokens"] == 10_682
+      assert combined.cumulative
+    end
+
+    test "a cumulative usage carries forward the fields it does not report" do
+      running =
+        TokenUsage.new!(%{
+          input: 25,
+          output: 1,
+          raw: %{"input_tokens" => 25, "cache_read_input_tokens" => 128}
+        })
+
+      total = TokenUsage.new!(%{output: 15, raw: %{"output_tokens" => 15}, cumulative: true})
+
+      combined = TokenUsage.add(running, total)
+
+      assert combined.input == 25
+      assert combined.output == 15
+      assert combined.raw["cache_read_input_tokens"] == 128
+      assert combined.raw["output_tokens"] == 15
+    end
+
+    test "a cumulative reading that reports zero does not erase an earlier count" do
+      # Some adapters normalize an unreported class to zero rather than omitting
+      # it. A running total never decreases, so the earlier count stands.
+      running =
+        TokenUsage.new!(%{
+          input: 25,
+          output: 1,
+          raw: %{"input_tokens" => 25, "cache_creation_input_tokens" => 4096}
+        })
+
+      total =
+        TokenUsage.new!(%{
+          input: 0,
+          output: 15,
+          raw: %{"input_tokens" => 0, "cache_creation_input_tokens" => 0, "output_tokens" => 15},
+          cumulative: true
+        })
+
+      combined = TokenUsage.add(running, total)
+
+      assert combined.input == 25
+      assert combined.output == 15
+      assert combined.raw["input_tokens"] == 25
+      assert combined.raw["cache_creation_input_tokens"] == 4096
+      assert combined.raw["output_tokens"] == 15
+    end
+
+    test "a cumulative reading advances nested counts without summing them" do
+      running = TokenUsage.new!(%{raw: %{"details" => %{"cached_tokens" => 64}}})
+
+      total =
+        TokenUsage.new!(%{raw: %{"details" => %{"cached_tokens" => 96}}, cumulative: true})
+
+      combined = TokenUsage.add(running, total)
+
+      assert combined.raw["details"]["cached_tokens"] == 96
+    end
+  end
+
+  describe "clear_cumulative/1" do
+    test "clears the flag and passes other values through" do
+      usage = TokenUsage.new!(%{input: 10, output: 20, cumulative: true})
+
+      assert %TokenUsage{cumulative: false, input: 10, output: 20} =
+               TokenUsage.clear_cumulative(usage)
+
+      assert TokenUsage.clear_cumulative(nil) == nil
+    end
+  end
+
+  describe "add_total/2" do
+    test "sums per-message totals even when they are marked cumulative" do
+      first = TokenUsage.new!(%{input: 100, output: 20, cumulative: true})
+      second = TokenUsage.new!(%{input: 150, output: 35, cumulative: true})
+
+      total = TokenUsage.add_total(first, second)
+
+      assert total.input == 250
+      assert total.output == 55
+      refute total.cumulative
+    end
+
+    test "handles nil on either side" do
+      usage = TokenUsage.new!(%{input: 10, output: 20, cumulative: true})
+
+      assert TokenUsage.add_total(nil, nil) == nil
+      assert %TokenUsage{input: 10, cumulative: false} = TokenUsage.add_total(nil, usage)
+      assert %TokenUsage{input: 10, cumulative: false} = TokenUsage.add_total(usage, nil)
+    end
   end
 
   describe "get/1" do

--- a/test/trajectory_test.exs
+++ b/test/trajectory_test.exs
@@ -154,6 +154,65 @@ defmodule LangChain.TrajectoryTest do
       assert trajectory.token_usage.output == 35
     end
 
+    test "sums per-message totals when the usage is marked cumulative" do
+      # Streaming providers mark a delta's usage cumulative to say it already
+      # includes the earlier deltas *of the same message*. Across messages the
+      # totals still add up.
+      usage1 = TokenUsage.new!(%{input: 100, output: 20, cumulative: true})
+      usage2 = TokenUsage.new!(%{input: 150, output: 35, cumulative: true})
+
+      messages = [
+        user_msg("Hello"),
+        assistant_msg("Hi", usage: usage1),
+        user_msg("More"),
+        assistant_msg("Sure", usage: usage2)
+      ]
+
+      trajectory = Trajectory.from_chain(chain_with_messages(messages))
+
+      assert trajectory.token_usage.input == 250
+      assert trajectory.token_usage.output == 55
+    end
+
+    test "sums nested raw usage details across messages" do
+      # OpenAI-shaped providers report cached and reasoning tokens nested under
+      # detail maps rather than as top-level counts.
+      usage1 =
+        TokenUsage.new!(%{
+          input: 100,
+          output: 20,
+          raw: %{
+            "prompt_tokens" => 100,
+            "prompt_tokens_details" => %{"cached_tokens" => 64},
+            "completion_tokens_details" => %{"reasoning_tokens" => 8}
+          }
+        })
+
+      usage2 =
+        TokenUsage.new!(%{
+          input: 150,
+          output: 35,
+          raw: %{
+            "prompt_tokens" => 150,
+            "prompt_tokens_details" => %{"cached_tokens" => 96},
+            "completion_tokens_details" => %{"reasoning_tokens" => 12}
+          }
+        })
+
+      messages = [
+        user_msg("Hello"),
+        assistant_msg("Hi", usage: usage1),
+        user_msg("More"),
+        assistant_msg("Sure", usage: usage2)
+      ]
+
+      trajectory = Trajectory.from_chain(chain_with_messages(messages))
+
+      assert trajectory.token_usage.raw["prompt_tokens"] == 250
+      assert trajectory.token_usage.raw["prompt_tokens_details"]["cached_tokens"] == 160
+      assert trajectory.token_usage.raw["completion_tokens_details"]["reasoning_tokens"] == 20
+    end
+
     test "returns nil token usage when no messages have usage" do
       messages = [
         user_msg("Hello"),

--- a/test/trajectory_test.exs
+++ b/test/trajectory_test.exs
@@ -154,12 +154,12 @@ defmodule LangChain.TrajectoryTest do
       assert trajectory.token_usage.output == 35
     end
 
-    test "sums per-message totals when the usage is marked cumulative" do
-      # Streaming providers mark a delta's usage cumulative to say it already
-      # includes the earlier deltas *of the same message*. Across messages the
-      # totals still add up.
-      usage1 = TokenUsage.new!(%{input: 100, output: 20, cumulative: true})
-      usage2 = TokenUsage.new!(%{input: 150, output: 35, cumulative: true})
+    test "sums per-message totals rather than keeping the largest message" do
+      # `TokenUsage.add/2` combines several readings of one message by keeping
+      # the larger count. Aggregating a trajectory is the other question, and
+      # answering it with `add/2` would report only the biggest turn.
+      usage1 = TokenUsage.new!(%{input: 100, output: 20})
+      usage2 = TokenUsage.new!(%{input: 150, output: 35})
 
       messages = [
         user_msg("Hello"),


### PR DESCRIPTION
## The problem

`%LangChain.TokenUsage{}` carried a `:cumulative` boolean meaning "this reading is a running total for the message so far, not an increment". `TokenUsage.add/2` honored it, but only `ChatGoogleAI` ever set it. Every other provider that reports usage more than once per stream had those readings summed:

| Provider | What was recorded |
| --- | --- |
| `ChatAnthropic` | `message_start` opens the message and `message_delta` closes it with the message total. Both were summed, so input, cache-creation and cache-read were each recorded at exactly **2x** truth. |
| `ChatVertexAI` | Decodes the same Gemini shape as `ChatGoogleAI`, where every chunk repeats the running totals, but never marked them. Usage multiplied by the chunk count. |
| `ChatReqLLM` | Reproduced the Anthropic bug through the dependency. |
| `ChatAwsMantle` | Returned `:skip` for the usage-only terminal chunk, so a streamed turn recorded nothing at all. |
| `ChatPerplexity` | The streaming decode never read `usage`. No callback, no message metadata, `token_usage: nil` on the span. |
| `ChatModel.token_usage_from_result/1` | Read usage only off delta metadata, ignoring the bare `%TokenUsage{}` that OpenAI-shaped providers return, so streamed `ChatOpenAI` calls reported `token_usage: nil` to telemetry and OTEL. |

## The fix: delete the flag, split the function

Marking readings provider-by-provider is a bug generator. It is one line, easy to forget, and forgetting it fails silently at a plausible-looking number. Five providers had already got it wrong.

The distinction the flag was carrying is better carried by the call site, because the caller always knows which question it is asking:

```elixir
TokenUsage.add(a, b)        # several readings of ONE message  -> keep the larger count per field
TokenUsage.add_total(a, b)  # final usage of DIFFERENT messages -> sum them
```

Keeping the larger count is correct for every provider convention on the wire. A token count is a counter, so it never decreases while a message generates. Providers differ only in how completely each reading repeats the picture: some report every class every time (Gemini), some report only what changed (Anthropic's closing event), some normalize an unreported class to zero (`req_llm`). Under all three, a fuller reading advances the total and a partial one cannot erase a class it never meant to describe.

Every remaining `add/2` call site combines readings of one message, and every cross-message site now calls `add_total/2`. The flag had no work left to do, so it is gone.

**The payoff:** `chat_anthropic.ex`, `chat_google_ai.ex`, `chat_vertex_ai.ex` and `chat_req_llm.ex` now differ from `main` **only by comments** (21 added lines, 4 removed, all documentation). The Anthropic double-count, the Vertex per-chunk summing and the ReqLLM inheritance of the Anthropic bug are all fixed by one semantic change in one function. A bug fixed in one place cannot be forgotten in a sixth provider.

### Core

* [`TokenUsage.add/2`](https://github.com/brainlid/langchain/blob/me-fix-token-usage-accumulation/lib/token_usage.ex#L148) keeps the larger count per field, recursing into nested `raw` detail maps at every depth.
* [`TokenUsage.add_total/2`](https://github.com/brainlid/langchain/blob/me-fix-token-usage-accumulation/lib/token_usage.ex#L182) sums, likewise at every depth. `LLMChain` and `Trajectory` aggregation now use it.
* [`TokenUsage.total/1`](https://github.com/brainlid/langchain/blob/me-fix-token-usage-accumulation/lib/token_usage.ex#L92) treats an unreported count as contributing nothing instead of raising `ArithmeticError`. Anthropic's closing event carries only `output_tokens`, so `nil` input is a real shape.

### Providers

* [`ChatAwsMantle`](https://github.com/brainlid/langchain/blob/me-fix-token-usage-accumulation/lib/chat_models/chat_aws_mantle.ex#L685) returns the `%TokenUsage{}` from its usage-only terminal chunk instead of `:skip`.
* [`ChatPerplexity`](https://github.com/brainlid/langchain/blob/me-fix-token-usage-accumulation/lib/chat_models/chat_perplexity.ex#L922) reads `usage` off the chunk that closes the stream, fires `:on_llm_token_usage`, and sets it on the deltas so it reaches the assembled message.
* [`ChatModel.token_usage_from_result/1`](https://github.com/brainlid/langchain/blob/me-fix-token-usage-accumulation/lib/chat_models/chat_model.ex#L165) reads both carriers a stream uses: delta metadata and a bare `%TokenUsage{}` in the same list.

That last change also fixes a case nobody was looking for. vLLM and OpenRouter honour `stream_options: {include_usage: true, continuous_usage_stats: true}` by putting a running total on **every** content chunk and repeating it on the terminal chunk, and `ChatOpenAI` drives every OpenAI-compatible endpoint. Under the old summing rule an 11-token prompt was recorded as 22. Reading both carriers without changing the rule would have made it 33. Under snapshot semantics it is 11.

### Types

[`ChatModel.call_response/0`](https://github.com/brainlid/langchain/blob/me-fix-token-usage-accumulation/lib/chat_models/chat_model.ex#L26) now declares what a streamed call actually returns: a new [`stream_item/0`](https://github.com/brainlid/langchain/blob/me-fix-token-usage-accumulation/lib/chat_models/chat_model.ex#L17) covering deltas, bare `%TokenUsage{}` and in-list error tuples, plus the list-of-lists nesting that `Utils.handle_stream_fn/3` produces and that both `LLMChain.do_run/1` and `token_usage_from_result/1` already flatten for. `ChatAwsMantle.do_process_response/2` gained the `@spec` it was missing.

## Breaking change: `:cumulative` is removed from `%TokenUsage{}`

The field is gone from the struct and from `@create_fields`, and `TokenUsage.clear_cumulative/1` is deleted.

**Compilation catches almost all of it.** Anything that touches the field through the struct is a hard compile error, not a runtime surprise:

```elixir
%TokenUsage{input: 10, cumulative: true}     # ** (KeyError) key :cumulative not found
%TokenUsage{usage | cumulative: false}       # ** (KeyError) key :cumulative not found
def handle(%TokenUsage{cumulative: true}),   # ** (KeyError) key :cumulative not found
usage.cumulative                             # type warning, then KeyError at runtime
TokenUsage.clear_cumulative(usage)           # warning: undefined function
```

`mix compile --warnings-as-errors` surfaces every one of these. It is still worth calling out, because two things do **not** fail loudly.

**1. Changeset params are silently ignored.** `Ecto.Changeset.cast/3` drops params that are not in the permitted list, so this neither errors nor takes effect:

```elixir
TokenUsage.new!(%{input: 10, output: 5, cumulative: true})   # builds fine, flag ignored
```

Grep for `cumulative` rather than relying on the compiler alone.

**2. `add/2` across messages changed meaning.** This is the one behavioral change with no compile-time signal. Code that summed per-message or per-turn totals with `add/2` now gets the largest single message instead of the sum.

### Migration

| If you were... | Do this |
| --- | --- |
| Setting `cumulative: true` in a custom chat model | Delete it. `add/2` treats every reading of a message as a snapshot, so the marking is no longer needed by anyone. |
| Reading the flag to choose between replace and add | Delete the branch and call `add/2`. It already does the right thing for both conventions. |
| Calling `TokenUsage.clear_cumulative/1` | Delete the call. There is no flag left to clear. |
| Summing usage across messages or turns with `add/2` | Switch to `add_total/2`. **This is the one that compilation will not catch.** |
| Combining several readings of one streamed message with `add/2` | No change. This is what `add/2` is now for. |
| Passing `cumulative:` to `new/1` or `new!/1` | Remove it. It is ignored rather than rejected. |

No changelog entry in this PR. It will be written after merge, per the usual flow.

## New coverage

A cross-provider table, [`test/chat_models/streamed_token_usage_test.exs`](https://github.com/brainlid/langchain/blob/me-fix-token-usage-accumulation/test/chat_models/streamed_token_usage_test.exs#L174), asserts the invariant this PR is actually about: **a streamed turn reports its usage, once, whatever carrier the provider chose.**

It drives the real `call/3` for all ten streaming providers (OpenAI, OpenAI Responses, Anthropic, Mistral, Perplexity, DeepSeek, Orq, AWS Mantle, Google AI, Vertex AI) through Req's `:into` collector with real SSE bytes, then asserts each one reports the same usage to `token_usage_from_result/1`, which is what the `[:langchain, :llm, :call, :stop]` span reads.

This is the test that finds the Perplexity class of bug. Per-provider tests cannot: a provider whose streaming decode drops usage entirely looks perfectly healthy from inside its own test file. Reverting the Perplexity fix fails exactly that row.

## Known limitation, now documented

Keeping the larger count is sound for a primitive counter. It is not sound for a `raw` key holding a value *derived* from other counts within a single reading, such as the `total_tokens` `req_llm` computes as that snapshot's input plus output. Such a value only means anything alongside the reading it came from. `add/2` and `ChatReqLLM.translate_usage/1` both say so, and a test pins it, so it is a known limitation rather than a silent trap. `TokenUsage.total/1` is the accessor to read a combined total from.

Dropping the key at the source was the obvious alternative and it is wrong: for Google via `req_llm`, `total_tokens` comes from `totalTokenCount`, a genuine provider-reported running total that merges correctly. Deleting it would destroy good data to fix bad data.

## Verification

* `mix precommit` green: **2305 tests pass** (41 doctests), 145 excluded live-API tests.
* `mix format --check-formatted`, `mix compile --warnings-as-errors` and `mix dialyzer` all clean. Dialyzer reports the same two unnecessary ignore-file skips it reports on `main`.
* **Negative check:** reverting `add/2` to the old summing behavior fails **31 tests** spanning `TokenUsage`, `MessageDelta`, `LLMChain`, `ChatAnthropic`, `ChatVertexAI`, `ChatReqLLM` and the new cross-provider table.
* Four existing expectations changed, all because the old number was wrong. In the captured Anthropic thinking stream the assembled message now reports 80 output tokens rather than 84, because the closing `message_delta` is the message total and not an increment.

## Out of scope, but noticed

Two pre-existing gaps of the same shape as the Perplexity bug, untouched here:

* `ChatBumblebee` fires `:on_llm_token_usage` but never attaches usage to the message, so it never reaches telemetry.
* `ChatOllamaAI` ignores Ollama's `prompt_eval_count` and `eval_count` entirely.
