### PR TITLE
Report the token usage xAI sends on a streamed turn

### DIFF
--- a/lib/chat_models/chat_grok.ex
+++ b/lib/chat_models/chat_grok.ex
@@ -774,6 +774,17 @@ defmodule LangChain.ChatModels.ChatGrok do
     }
   end
 
+  # xAI closes a stream with a usage-only chunk (empty `choices`, populated
+  # `usage`) when `stream_options.include_usage` is set. Returning the
+  # `%TokenUsage{}` hands it to `LangChain.Chains.LLMChain.merge_delta/2`, which
+  # folds it into the final delta, matching how `ChatOpenAI` reports the same
+  # chunk. An empty delta instead reports no tokens for the whole streamed turn,
+  # while the request is asking xAI to count them.
+  defp choice_delta_to_message(%{"choices" => [], "usage" => usage} = data, _metadata)
+       when is_map(usage) do
+    get_token_usage(data)
+  end
+
   defp choice_delta_to_message(%{"choices" => []}, metadata) do
     %MessageDelta{
       role: :assistant,

--- a/test/chat_models/chat_grok_test.exs
+++ b/test/chat_models/chat_grok_test.exs
@@ -3,6 +3,7 @@ defmodule LangChain.ChatModels.ChatGrokTest do
   use Mimic
 
   doctest LangChain.ChatModels.ChatGrok
+  alias LangChain.Chains.LLMChain
   alias LangChain.ChatModels.ChatGrok
   alias LangChain.Function
   alias LangChain.FunctionParam
@@ -10,6 +11,7 @@ defmodule LangChain.ChatModels.ChatGrokTest do
   alias LangChain.Message.ContentPart
   alias LangChain.Message.ToolCall
   alias LangChain.Message.ToolResult
+  alias LangChain.MessageDelta
   alias LangChain.TokenUsage
 
   @test_model "grok-4"
@@ -259,11 +261,18 @@ defmodule LangChain.ChatModels.ChatGrokTest do
           stream_options: %{include_usage: true}
         })
 
-      {:ok, deltas} = ChatGrok.call(grok, "Count from 1 to 3")
+      {:ok, [_ | _] = items} = ChatGrok.call(grok, "Count from 1 to 3")
 
-      assert is_list(deltas)
-      assert length(deltas) > 0
-      assert Enum.all?(deltas, fn delta -> match?(%LangChain.MessageDelta{}, delta) end)
+      # `include_usage` closes the stream with a usage-only chunk, which comes
+      # back as a `%TokenUsage{}` among the deltas.
+      {usage, deltas} = Enum.split_with(items, &match?(%TokenUsage{}, &1))
+
+      assert [%MessageDelta{} | _] = deltas
+      assert Enum.all?(deltas, &match?(%MessageDelta{}, &1))
+
+      assert [%TokenUsage{input: input, output: output}] = usage
+      assert input > 0
+      assert output > 0
     end
 
     @tag live_call: true, live_grok: true
@@ -502,6 +511,73 @@ defmodule LangChain.ChatModels.ChatGrokTest do
       assert %TokenUsage{input: 11, output: 22} = stop_metadata.token_usage
 
       :telemetry.detach("test-grok-token-usage-stop")
+    end
+
+    test "streamed call reports the usage-only terminal chunk" do
+      grok =
+        ChatGrok.new!(%{
+          model: "grok-4",
+          api_key: "test-xai-key",
+          stream: true,
+          stream_options: %{include_usage: true}
+        })
+
+      # xAI closes an `include_usage` stream with a chunk that has no choices and
+      # carries the usage for the whole turn.
+      body =
+        Enum.join(
+          [
+            ~s|data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}|,
+            ~s|data: {"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":22,"total_tokens":33}}|,
+            "data: [DONE]"
+          ],
+          "\n"
+        )
+
+      expect(Req, :post, fn _opts ->
+        {:ok, %Req.Response{status: 200, body: body}}
+      end)
+
+      assert {:ok, items} = ChatGrok.call(grok, [Message.new_user!("Hi")], [])
+
+      # The usage rides back as a `%TokenUsage{}` among the deltas, the shape
+      # `LLMChain.merge_delta/2` folds into the final delta.
+      assert [%MessageDelta{}, %TokenUsage{input: 11, output: 22} = usage] = items
+      assert usage.raw["total_tokens"] == 33
+    end
+
+    test "a streamed turn's usage reaches the merged delta" do
+      grok =
+        ChatGrok.new!(%{
+          model: "grok-4",
+          api_key: "test-xai-key",
+          stream: true,
+          stream_options: %{include_usage: true}
+        })
+
+      body =
+        Enum.join(
+          [
+            ~s|data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"Hel"}}]}|,
+            ~s|data: {"choices":[{"index":0,"delta":{"content":"lo!"}}]}|,
+            ~s|data: {"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":22,"total_tokens":33}}|,
+            "data: [DONE]"
+          ],
+          "\n"
+        )
+
+      expect(Req, :post, fn _opts ->
+        {:ok, %Req.Response{status: 200, body: body}}
+      end)
+
+      assert {:ok, items} = ChatGrok.call(grok, [Message.new_user!("Hi")], [])
+
+      chain =
+        Enum.reduce(items, LLMChain.new!(%{llm: grok}), &LLMChain.merge_delta(&2, &1))
+
+      assert %MessageDelta{} = chain.delta
+      assert %TokenUsage{input: 11, output: 22} = usage = TokenUsage.get(chain.delta)
+      assert usage.raw["total_tokens"] == 33
     end
   end
 end


### PR DESCRIPTION
## Problem

`ChatGrok` asks xAI to count tokens on a streamed turn and then throws the answer away.

When `stream_options.include_usage` is set, xAI closes the stream with a usage-only chunk: empty `choices`, populated `usage`. `choice_delta_to_message/2` matched that chunk on its empty `choices` and answered with an empty `%MessageDelta{}` carrying the request metadata, so the counts never reached the delta, the assembled turn, or the `[:langchain, :llm, :call, :stop]` telemetry event. A streamed Grok call reported no tokens at all. The non-streaming path has always reported usage correctly, which is what made the gap easy to miss.

## Solution

Report the `%TokenUsage{}` for that chunk, matching how `ChatOpenAI` handles the identical shape. `LangChain.Chains.LLMChain.merge_delta/2` already has a `%TokenUsage{}` clause that folds it into the final delta, so nothing downstream needed changing.

## Changes

- `lib/chat_models/chat_grok.ex` - The usage-only terminal chunk reports usage instead of an empty delta

## Behavior changes for library consumers

A streamed `ChatGrok` response includes a `%TokenUsage{}` among the returned items where it previously included an empty `%MessageDelta{}`. This is the shape `ChatOpenAI` has always returned for the same chunk, and `LLMChain` already handles it. Code that assumes every item in a streamed Grok response is a `%MessageDelta{}` needs to account for it.

## Testing

Full suite green: 2215 tests, 40 doctests, 145 excluded (live API).

- The usage-only terminal chunk comes back as a `%TokenUsage{}` alongside the delta, with `raw` intact
- A streamed turn's usage reaches the merged delta through `LLMChain.merge_delta/2`

Both drive the real `call/3` with only the HTTP layer mocked, so the wiring is what is under test rather than a hand-fed stub. The live streaming test previously asserted every returned item was a `%MessageDelta{}`; it now separates the usage from the deltas and asserts both.

Reverting the fix fails 2 tests.

## Notes

Streamed Grok usage also needs `ChatModel.token_usage_from_result/1` to read a bare `%TokenUsage{}` out of the response list before it reaches the LLM-call telemetry span and OTEL. That reader is fixed in #625, which covers the same gap for `ChatOpenAI` and `ChatAwsMantle`. This PR is independent of that one and can merge in either order; once both are in, streamed Grok usage reaches telemetry as well as the assembled turn.

Streaming has a second, deeper defect that this PR does not address: `choice_delta_to_message/2` never reads `finish_reason`, so every delta stays `:incomplete`, `MessageDelta.to_message/1` always fails, and a streamed run through `LLMChain` returns `{:ok, chain}` with the assistant's reply stranded in `chain.delta` and never added to `chain.messages`. `:on_llm_new_delta` never fires either, since `handle_stream_response/3` does not call `LangChain.Utils.fire_streamed_callback/2`. Both date to the original Grok commit (#338) and are tracked separately.
