### PR TITLE
Make ChatGrok streaming stream, complete, and report usage

### DIFF
--- a/lib/chat_models/chat_grok.ex
+++ b/lib/chat_models/chat_grok.ex
@@ -78,9 +78,11 @@ defmodule LangChain.ChatModels.ChatGrok do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  require Logger
   alias __MODULE__
   alias LangChain.Config
   alias LangChain.ChatModels.ChatModel
+  alias LangChain.ChatModels.ChatOpenAI
   alias LangChain.Message
   alias LangChain.Message.ContentPart
   alias LangChain.Message.ToolCall
@@ -585,20 +587,45 @@ defmodule LangChain.ChatModels.ChatGrok do
       IO.inspect(api_payload, pretty: true, limit: :infinity)
     end
 
-    Req.post(
+    req_opts = [
       url: grok.endpoint,
       json: api_payload,
       headers: headers,
       receive_timeout: grok.receive_timeout,
       retry: false,
       max_retries: 0
-    )
+    ]
+
+    # A streamed request collects chunks as they arrive through the shared
+    # `Utils.handle_stream_fn/3`, which decodes each SSE chunk, converts it, and
+    # fires `:on_llm_new_delta` for what that chunk carried. Buffering the whole
+    # body and splitting it afterwards yields the same final list while the
+    # caller sees nothing until the model has finished, which is the opposite of
+    # what asking for a stream is for. xAI speaks the OpenAI SSE dialect, so it
+    # shares `ChatOpenAI.decode_stream/1` the way ChatAwsMantle and ChatGoogleAI
+    # already do.
+    req_opts =
+      if grok.stream do
+        Keyword.put(
+          req_opts,
+          :into,
+          Utils.handle_stream_fn(
+            grok,
+            &ChatOpenAI.decode_stream/1,
+            &choice_delta_to_message(&1, metadata)
+          )
+        )
+      else
+        req_opts
+      end
+
+    Req.post(req_opts)
     |> case do
       {:ok, %Req.Response{status: 200} = response} ->
         Callbacks.fire(grok.callbacks, :on_llm_response_headers, [response.headers])
 
         case grok.stream do
-          true -> handle_stream_response(response, grok, metadata)
+          true -> {:ok, response.body}
           false -> handle_response(response, grok, metadata)
         end
 
@@ -649,13 +676,21 @@ defmodule LangChain.ChatModels.ChatGrok do
   defp handle_response(%Req.Response{body: data}, grok, metadata) do
     case data do
       %{"choices" => choices} = response_data ->
-        grok
-        |> maybe_execute_callback(:on_llm_token_usage, [response_data])
+        token_usage = get_token_usage(response_data)
 
-        # Extract usage as a `%TokenUsage{}` struct (not the raw API map) so it
-        # rides on the message metadata in the shape `ChatModel.token_usage_from_result/1`
-        # reads — otherwise the LLM-call telemetry span reports `token_usage: nil`.
-        updated_metadata = Map.put(metadata, :usage, get_token_usage(response_data))
+        # Model-tier callbacks are fired with just the event argument, and every
+        # other chat model hands this one a `%TokenUsage{}`. Firing the model
+        # alongside the raw API map instead raises `BadArityError` in any handler
+        # written to the documented shape, which `Callbacks.fire/3` turns into an
+        # error tuple for the whole call.
+        if token_usage do
+          Callbacks.fire(grok.callbacks, :on_llm_token_usage, [token_usage])
+        end
+
+        # Usage rides on the message metadata as a `%TokenUsage{}`, the shape
+        # `ChatModel.token_usage_from_result/1` reads, so the LLM-call telemetry
+        # span reports it.
+        updated_metadata = Map.put(metadata, :usage, token_usage)
         messages = Enum.map(choices, &(&1 |> choice_to_message(updated_metadata)))
 
         # Track non-streaming response completion
@@ -681,20 +716,6 @@ defmodule LangChain.ChatModels.ChatGrok do
            original: other
          )}
     end
-  end
-
-  defp handle_stream_response(%Req.Response{body: body}, _grok, metadata) when is_binary(body) do
-    body
-    |> String.split("\n")
-    |> Enum.filter(&String.starts_with?(&1, "data: "))
-    |> Enum.map(&String.slice(&1, 6..-1//1))
-    |> Enum.filter(&(&1 != "[DONE]"))
-    |> Enum.map(&Jason.decode!/1)
-    |> Enum.map(&choice_delta_to_message(&1, metadata))
-    |> then(&{:ok, &1})
-  rescue
-    error ->
-      {:error, LangChainError.exception(type: :stream_parse_error, message: inspect(error))}
   end
 
   defp handle_error_response(%Req.Response{status: status, body: body, headers: headers}) do
@@ -752,12 +773,13 @@ defmodule LangChain.ChatModels.ChatGrok do
 
   defp get_token_usage(_response_body), do: nil
 
-  defp choice_to_message(%{"message" => message_data}, metadata) do
+  defp choice_to_message(%{"message" => message_data} = choice, metadata) do
     usage = metadata[:usage]
 
     %Message{
       role: :assistant,
       content: message_data["content"],
+      status: finish_reason_to_status(choice["finish_reason"]),
       tool_calls: parse_tool_calls(message_data["tool_calls"]),
       metadata: %{usage: usage}
     }
@@ -766,9 +788,15 @@ defmodule LangChain.ChatModels.ChatGrok do
   defp choice_delta_to_message(%{"choices" => [choice | _]}, metadata) do
     delta = choice["delta"]
 
+    # The status is what makes a merged delta convertible. Leaving every delta
+    # `:incomplete` means `MessageDelta.to_message/1` always fails, so an
+    # `LLMChain` run finishes with the assistant's reply stranded in the delta
+    # and never added to the conversation.
     %MessageDelta{
       role: :assistant,
       content: delta["content"] || "",
+      status: finish_reason_to_status(choice["finish_reason"]),
+      index: choice["index"],
       tool_calls: parse_tool_calls(delta["tool_calls"]),
       metadata: metadata
     }
@@ -785,14 +813,7 @@ defmodule LangChain.ChatModels.ChatGrok do
     get_token_usage(data)
   end
 
-  defp choice_delta_to_message(%{"choices" => []}, metadata) do
-    %MessageDelta{
-      role: :assistant,
-      content: "",
-      tool_calls: [],
-      metadata: metadata
-    }
-  end
+  defp choice_delta_to_message(%{"choices" => []}, _metadata), do: :skip
 
   defp choice_delta_to_message(data, metadata) do
     # Fallback for unexpected streaming data format
@@ -802,6 +823,20 @@ defmodule LangChain.ChatModels.ChatGrok do
       tool_calls: [],
       metadata: Map.put(metadata, :raw_data, data)
     }
+  end
+
+  # xAI reports the same finish reasons as OpenAI. `nil` means the message is
+  # still being generated, which is every chunk until the last one.
+  defp finish_reason_to_status(nil), do: :incomplete
+  defp finish_reason_to_status("stop"), do: :complete
+  defp finish_reason_to_status("tool_calls"), do: :complete
+  defp finish_reason_to_status("content_filter"), do: :content_filtered
+  defp finish_reason_to_status("length"), do: :length
+  defp finish_reason_to_status("max_tokens"), do: :length
+
+  defp finish_reason_to_status(other) do
+    Logger.warning("Unsupported finish_reason in Grok message. Reason: #{inspect(other)}")
+    nil
   end
 
   defp parse_tool_calls(nil), do: []
@@ -814,10 +849,6 @@ defmodule LangChain.ChatModels.ChatGrok do
         arguments: tool_call["function"]["arguments"]
       }
     end)
-  end
-
-  defp maybe_execute_callback(grok, callback_name, args) do
-    Callbacks.fire(grok.callbacks, callback_name, [grok | args])
   end
 
   @doc """

--- a/test/chat_models/chat_grok_test.exs
+++ b/test/chat_models/chat_grok_test.exs
@@ -513,71 +513,170 @@ defmodule LangChain.ChatModels.ChatGrokTest do
       :telemetry.detach("test-grok-token-usage-stop")
     end
 
-    test "streamed call reports the usage-only terminal chunk" do
+    test "fires :on_llm_token_usage with a %TokenUsage{} at the model-tier arity" do
+      test_pid = self()
+
+      # Model-tier handlers receive just the event argument. Firing the model
+      # alongside a raw API map raises BadArityError inside `Callbacks.fire/3`,
+      # which fails the whole call rather than only the handler.
       grok =
         ChatGrok.new!(%{
           model: "grok-4",
           api_key: "test-xai-key",
-          stream: true,
-          stream_options: %{include_usage: true}
+          callbacks: [%{on_llm_token_usage: fn usage -> send(test_pid, {:usage, usage}) end}]
         })
 
-      # xAI closes an `include_usage` stream with a chunk that has no choices and
-      # carries the usage for the whole turn.
-      body =
-        Enum.join(
-          [
-            ~s|data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}|,
-            ~s|data: {"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":22,"total_tokens":33}}|,
-            "data: [DONE]"
-          ],
-          "\n"
-        )
+      response_body = %{
+        "choices" => [
+          %{
+            "message" => %{"role" => "assistant", "content" => "Hi"},
+            "finish_reason" => "stop",
+            "index" => 0
+          }
+        ],
+        "usage" => %{"prompt_tokens" => 11, "completion_tokens" => 22, "total_tokens" => 33}
+      }
 
       expect(Req, :post, fn _opts ->
-        {:ok, %Req.Response{status: 200, body: body}}
+        {:ok, %Req.Response{status: 200, body: response_body}}
       end)
 
-      assert {:ok, items} = ChatGrok.call(grok, [Message.new_user!("Hi")], [])
+      assert {:ok, [%Message{}]} = ChatGrok.call(grok, [Message.new_user!("Hi")], [])
+
+      assert_received {:usage, %TokenUsage{input: 11, output: 22}}
+    end
+
+    test "carries the finish reason onto a non-streamed message" do
+      grok = ChatGrok.new!(%{model: "grok-4", api_key: "test-xai-key"})
+
+      response_body = %{
+        "choices" => [
+          %{
+            "message" => %{"role" => "assistant", "content" => "Hel"},
+            "finish_reason" => "length",
+            "index" => 0
+          }
+        ]
+      }
+
+      expect(Req, :post, fn _opts ->
+        {:ok, %Req.Response{status: 200, body: response_body}}
+      end)
+
+      assert {:ok, [%Message{status: :length}]} =
+               ChatGrok.call(grok, [Message.new_user!("Hi")], [])
+    end
+
+    # A streamed request hands `Req` an `:into` collector, so a mocked post has
+    # to drive that collector the way a real response would rather than handing
+    # back a buffered body.
+    defp expect_streamed_post(chunks) do
+      expect(Req, :post, fn opts ->
+        collector = Keyword.fetch!(opts, :into)
+        start = {Req.Request.new(), %Req.Response{status: 200, headers: %{}, body: ""}}
+
+        {_req, response} =
+          Enum.reduce(chunks, start, fn chunk, acc ->
+            case collector.({:data, chunk}, acc) do
+              {:cont, next} -> next
+              {:halt, next} -> next
+            end
+          end)
+
+        {:ok, response}
+      end)
+    end
+
+    defp streaming_grok(attrs \\ %{}) do
+      ChatGrok.new!(
+        Map.merge(
+          %{
+            model: "grok-4",
+            api_key: "test-xai-key",
+            stream: true,
+            stream_options: %{include_usage: true}
+          },
+          attrs
+        )
+      )
+    end
+
+    @content_chunk ~s|data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"Hel"},"finish_reason":null}]}\n\n|
+    @final_chunk ~s|data: {"choices":[{"index":0,"delta":{"content":"lo!"},"finish_reason":"stop"}]}\n\n|
+    @usage_chunk ~s|data: {"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":22,"total_tokens":33}}\n\n|
+
+    test "streamed call reports the usage-only terminal chunk" do
+      expect_streamed_post([@content_chunk, @final_chunk, @usage_chunk])
+
+      assert {:ok, items} = ChatGrok.call(streaming_grok(), [Message.new_user!("Hi")], [])
 
       # The usage rides back as a `%TokenUsage{}` among the deltas, the shape
       # `LLMChain.merge_delta/2` folds into the final delta.
-      assert [%MessageDelta{}, %TokenUsage{input: 11, output: 22} = usage] = items
+      assert [%TokenUsage{input: 11, output: 22} = usage] =
+               items |> List.flatten() |> Enum.filter(&match?(%TokenUsage{}, &1))
+
       assert usage.raw["total_tokens"] == 33
     end
 
-    test "a streamed turn's usage reaches the merged delta" do
-      grok =
-        ChatGrok.new!(%{
-          model: "grok-4",
-          api_key: "test-xai-key",
-          stream: true,
-          stream_options: %{include_usage: true}
-        })
+    test "a streamed turn assembles into a complete Message" do
+      # The finish reason is what makes the merged delta convertible. Without it
+      # every delta stays `:incomplete`, `to_message/1` fails, and an LLMChain
+      # run ends with the reply stranded in the delta.
+      expect_streamed_post([@content_chunk, @final_chunk, @usage_chunk])
 
-      body =
-        Enum.join(
-          [
-            ~s|data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"Hel"}}]}|,
-            ~s|data: {"choices":[{"index":0,"delta":{"content":"lo!"}}]}|,
-            ~s|data: {"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":22,"total_tokens":33}}|,
-            "data: [DONE]"
-          ],
-          "\n"
-        )
-
-      expect(Req, :post, fn _opts ->
-        {:ok, %Req.Response{status: 200, body: body}}
-      end)
-
-      assert {:ok, items} = ChatGrok.call(grok, [Message.new_user!("Hi")], [])
+      assert {:ok, items} = ChatGrok.call(streaming_grok(), [Message.new_user!("Hi")], [])
 
       chain =
-        Enum.reduce(items, LLMChain.new!(%{llm: grok}), &LLMChain.merge_delta(&2, &1))
+        items
+        |> List.flatten()
+        |> Enum.reduce(LLMChain.new!(%{llm: streaming_grok()}), &LLMChain.merge_delta(&2, &1))
 
-      assert %MessageDelta{} = chain.delta
-      assert %TokenUsage{input: 11, output: 22} = usage = TokenUsage.get(chain.delta)
-      assert usage.raw["total_tokens"] == 33
+      assert {:ok, %Message{status: :complete} = message} = MessageDelta.to_message(chain.delta)
+      assert ContentPart.parts_to_string(message.content) == "Hello!"
+      assert %TokenUsage{input: 11, output: 22} = TokenUsage.get(message)
+    end
+
+    test "a streamed run through LLMChain adds the assistant message" do
+      expect_streamed_post([@content_chunk, @final_chunk, @usage_chunk])
+
+      assert {:ok, chain} =
+               %{llm: streaming_grok()}
+               |> LLMChain.new!()
+               |> LLMChain.add_message(Message.new_user!("Hi"))
+               |> LLMChain.run()
+
+      assert %Message{role: :assistant, status: :complete} = chain.last_message
+      assert ContentPart.parts_to_string(chain.last_message.content) == "Hello!"
+    end
+
+    test "streaming fires :on_llm_new_delta as chunks arrive" do
+      test_pid = self()
+
+      grok =
+        streaming_grok(%{
+          callbacks: [%{on_llm_new_delta: fn deltas -> send(test_pid, {:delta, deltas}) end}]
+        })
+
+      expect_streamed_post([@content_chunk, @final_chunk, @usage_chunk])
+
+      assert {:ok, _items} = ChatGrok.call(grok, [Message.new_user!("Hi")], [])
+
+      # One callback per arriving chunk, not a single batch after the fact.
+      assert_received {:delta, [%MessageDelta{content: "Hel"}]}
+      assert_received {:delta, [%MessageDelta{content: "lo!", status: :complete}]}
+      assert_received {:delta, [%TokenUsage{input: 11, output: 22}]}
+    end
+
+    test "a truncated stream reports the length status" do
+      truncated =
+        ~s|data: {"choices":[{"index":0,"delta":{"content":"Hel"},"finish_reason":"length"}]}\n\n|
+
+      expect_streamed_post([@content_chunk, truncated])
+
+      assert {:ok, items} = ChatGrok.call(streaming_grok(), [Message.new_user!("Hi")], [])
+
+      merged = items |> List.flatten() |> MessageDelta.merge_deltas()
+      assert %MessageDelta{status: :length} = merged
     end
   end
 end


### PR DESCRIPTION
## Problem

Streaming with `ChatGrok` returns success and delivers nothing. Three separate defects, all present since the model was added in #338.

**The turn never completes.** `choice_delta_to_message/2` never read `finish_reason`, so every delta stayed `:incomplete`. `MessageDelta.to_message/1` therefore always answered `{:error, "Cannot convert incomplete message"}`. Through an `LLMChain`:

```
LLMChain.run/1       -> {:ok, chain}          # reports success
chain.messages       -> [user: "Hi"]          # assistant reply never added
chain.last_message   -> the user's own message
chain.delta          -> "Hello!" stranded as :incomplete
```

The reply is silently discarded and the caller is told the run succeeded.

**Nothing streams.** `Req.post` was called without an `:into` collector, so the whole response was buffered and only then split on `data:` lines. `:on_llm_new_delta` never fired, and a caller asking for a stream saw nothing until the model had finished. The `[:langchain, :llm, :stream, :first_token]` telemetry never fired either.

**A correct usage handler breaks the call.** `:on_llm_token_usage` fired as `[grok, response_data]`: two arguments, the second a raw API map. Model-tier handlers receive just the event argument, and every other chat model passes a `%TokenUsage{}`. A handler written to the documented shape raised `BadArityError` inside `Callbacks.fire/3`, which converts it to an error tuple, so the entire `call/3` failed:

```
{:error, %LangChainError{message: "Callback handler for :on_llm_token_usage raised
 an exception: (BadArityError) ... with arity 1 called with 2 arguments"}}
```

## Solution

**Read the finish reason.** `finish_reason_to_status/1` maps xAI's reasons the same way `ChatOpenAI` does, and both the streamed delta and the non-streamed message carry the result. A truncated or filtered turn now reports `:length` or `:content_filtered` rather than passing as complete. Streamed deltas also carry the choice `index`.

**Stream the request.** The streaming path hands `Req` the shared `Utils.handle_stream_fn/3` collector, which decodes each chunk as it arrives, converts it, and fires `:on_llm_new_delta` for what that chunk carried. xAI speaks the OpenAI SSE dialect, so it shares `ChatOpenAI.decode_stream/1` the way `ChatAwsMantle` and `ChatGoogleAI` already do. A chunk carrying neither choices nor usage is now `:skip`, which the collector filters, rather than an empty delta that merges into nothing.

**Fire the usage callback the way the contract describes.** One argument, a `%TokenUsage{}`.

## Changes

- `lib/chat_models/chat_grok.ex` - Status from `finish_reason` on deltas and messages; streamed requests use the shared stream collector; `:on_llm_token_usage` fires with a `%TokenUsage{}` at the model-tier arity; the buffered stream parser and `maybe_execute_callback/3` are gone

## Behavior changes for library consumers

- A streamed `ChatGrok` turn now assembles into a `%Message{}` and reaches `chain.messages`. Code that worked around the reply never arriving can drop the workaround.
- `:on_llm_new_delta` fires during a streamed Grok call. Handlers registered on the model or through a chain now receive deltas they previously never saw.
- `:on_llm_token_usage` is called with one argument, a `%TokenUsage{}`, rather than two arguments ending in the raw API map. A handler written for the old shape needs updating; a handler written to the documented shape stops failing the call.
- A non-streamed response with `finish_reason` of `length` or `content_filter` now reports `:length` or `:content_filtered` instead of `:complete`.
- A streamed chunk with neither choices nor usage is skipped rather than returned as an empty `%MessageDelta{}`.

## Testing

Full suite green: 2220 tests, 40 doctests, 145 excluded (live API).

New coverage in `test/chat_models/chat_grok_test.exs`, all driving the real `call/3` with only the HTTP layer mocked, so the wiring is what is under test:

- A streamed turn assembles into a `%Message{status: :complete}` with the full text and its usage
- A streamed run through `LLMChain` puts the assistant message on the chain
- `:on_llm_new_delta` fires once per arriving chunk rather than in one batch afterwards
- A truncated stream reports `:length`
- A non-streamed response carries its finish reason
- `:on_llm_token_usage` receives a `%TokenUsage{}` as its only argument
- The usage-only terminal chunk still reports usage

The streaming tests drive the `:into` collector the way a real response would, so they fail outright if the request stops streaming.

Negative checks, reverting each fix and running the whole suite:

| Reverted | Failing tests |
|---|---|
| `finish_reason` on streamed deltas | 4 |
| `finish_reason` on messages | 1 |
| `:on_llm_token_usage` shape | 1 |
| The stream collector | 5 |
