### PR TITLE
Cover the WebSocket scheme derived from the Responses endpoint

### DIFF
--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -2295,6 +2295,43 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       verify!()
     end
 
+    test "connect_websocket! derives the WebSocket scheme from the endpoint" do
+      LangChain.WebSocket
+      |> expect(:start_link, fn opts ->
+        assert opts[:url] == "wss://proxy.internal.example/v1/responses"
+        {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+      end)
+      |> expect(:start_link, fn opts ->
+        assert opts[:url] == "ws://localhost:8080/v1/responses"
+        {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+      end)
+
+      # An https endpoint always upgrades to the TLS-backed wss scheme.
+      secure =
+        ChatOpenAIResponses.new!(%{
+          model: @test_model,
+          endpoint: "https://proxy.internal.example/v1/responses"
+        })
+        |> ChatOpenAIResponses.connect_websocket!()
+
+      # A plaintext endpoint stays plaintext. Rewriting it to wss would make
+      # Mint open a TLS connection to a server that speaks none, so the
+      # connection fails instead of becoming secure.
+      plain =
+        ChatOpenAIResponses.new!(%{
+          model: @test_model,
+          endpoint: "http://localhost:8080/v1/responses"
+        })
+        |> ChatOpenAIResponses.connect_websocket!()
+
+      on_exit(fn ->
+        Process.exit(secure.websocket, :kill)
+        Process.exit(plain.websocket, :kill)
+      end)
+
+      verify!()
+    end
+
     test "disconnect_websocket! clears websocket and is safe on nil" do
       model = ChatOpenAIResponses.new!(%{model: @test_model})
       assert %{websocket: nil} = ChatOpenAIResponses.disconnect_websocket!(model)


### PR DESCRIPTION
Adds a regression test that pins the scheme `ChatOpenAIResponses.connect_websocket/1` derives from the configured endpoint:

- `https://` endpoint connects over `wss://`
- `http://` endpoint connects over `ws://`

`LangChain.WebSocket` turns that scheme into the transport it opens: `wss` connects with `Mint.HTTP.connect(:https, ...)` and `ws` with `:http`. The scheme is therefore what decides whether the connection is TLS-backed, and nothing but an endpoint the caller explicitly set to `http://` produces a plaintext one. The default endpoint is `https://api.openai.com/v1/responses`.

Rewriting the plaintext case to `wss://` would not secure anything. It would make Mint negotiate TLS against a server that speaks none, so connecting to a local proxy or a test server fails outright rather than becoming encrypted. The test states both halves of the mapping so a later refactor cannot quietly drop the TLS-backed one.

Context: https://github.com/brainlid/langchain/issues/628