### PR TITLE
Carry OpenAI reasoning items across a tool loop

### DIFF
--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -111,6 +111,33 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
   same usage information for each choice but it is duplicated and only one
   response is meaningful.
 
+  ## Reasoning Continuity
+
+  Reasoning models such as `gpt-5` and the o-series return a `reasoning` output
+  item alongside their text and tool calls. Handing that item back on the next
+  request lets the model resume the reasoning it already did instead of
+  re-deriving it, which matters most inside a tool loop where every tool result
+  is another round trip.
+
+  The item is only replayable when it carries its `encrypted_content`, and the
+  API only returns that when the request asks for it:
+
+      ChatOpenAIResponses.new!(%{
+        model: "gpt-5",
+        include: ["reasoning.encrypted_content"],
+        reasoning: %{effort: :high}
+      })
+
+  With that set, reasoning items are captured off the response and sent back as
+  their own `input` items on subsequent requests. Nothing else is required. A
+  reasoning item that arrived without `encrypted_content` is omitted rather than
+  sent as a stub, so leaving `:include` alone keeps the previous behavior.
+
+  This is the stateless path, and it works whether or not responses are stored.
+  `:previous_response_id` covers the stored case instead, and is unavailable to
+  a Zero Data Retention organization, which the API treats as stateless by
+  definition.
+
   ## Native Tools (Web Search)
 
   Open AI's Responses API also supports built-in tools. Among those, we support Web Search currently.
@@ -809,8 +836,9 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     Enum.map(tool_results, &for_api(model, &1))
   end
 
-  # Native tool calls (such as web_search_call) need to get plucked
-  # out of the content parts and become their own input items.
+  # Reasoning items and native tool calls (such as web_search_call) are their own
+  # entries in the API's `output` array, so they get plucked out of the content
+  # parts and go back as their own input items.
   def for_api(
         %ChatOpenAIResponses{} = model,
         %Message{role: :assistant, content: content} = msg
@@ -834,7 +862,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
           ]
       end
 
-    native_tool_calls_for_api(model, content) ++
+    stand_alone_items_for_api(model, content) ++
       assistant_message ++
       Enum.map(msg.tool_calls || [], &for_api(model, &1))
   end
@@ -889,6 +917,74 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
   end
 
   def native_tool_call_for_api(_, _), do: nil
+
+  @doc """
+  Convert the content parts of an assistant message into the stand-alone items
+  the API expects in `input`, preserving their original order.
+
+  Some content parts do not belong to the assistant message item at all. A
+  reasoning item and a native tool call are each their own entry in the
+  `output` array the API returned, and each must go back as its own entry in
+  `input`. Order matters: the API expects a reasoning item to precede the
+  message or function call it produced.
+  """
+  def stand_alone_items_for_api(%ChatOpenAIResponses{} = model, content_parts)
+      when is_list(content_parts) do
+    Enum.flat_map(content_parts, fn part ->
+      case reasoning_item_for_api(part) do
+        nil ->
+          case native_tool_call_for_api(model, part) do
+            nil -> []
+            item -> [item]
+          end
+
+        item ->
+          [item]
+      end
+    end)
+  end
+
+  @doc """
+  Convert a content part holding a reasoning item back into the reasoning entry
+  the API accepts in `input`. Returns `nil` for any other content part.
+
+  A reasoning item is only accepted back when it carries its
+  `encrypted_content`, which the API returns when the request asked for it with
+  `include: ["reasoning.encrypted_content"]`. Without that payload there is
+  nothing to hand back, so the item is omitted rather than sent as a stub.
+
+  Both shapes a reasoning item arrives as are recognized: the `:unsupported`
+  part built from a non-streamed response, and the `:thinking` part the
+  streaming events build.
+  """
+  def reasoning_item_for_api(%ContentPart{type: type, options: options})
+      when type in [:unsupported, :thinking] and is_list(options) do
+    with "reasoning" <- Keyword.get(options, :type),
+         id when is_binary(id) <- Keyword.get(options, :id),
+         encrypted when is_binary(encrypted) <- Keyword.get(options, :encrypted_content) do
+      %{
+        "type" => "reasoning",
+        "id" => id,
+        "summary" => Keyword.get(options, :summary) || [],
+        "encrypted_content" => encrypted
+      }
+    else
+      _ -> nil
+    end
+  end
+
+  def reasoning_item_for_api(%ContentPart{}), do: nil
+
+  # The API only returns `encrypted_content` when the request asked for it with
+  # `include: ["reasoning.encrypted_content"]`. Leave the key out entirely when
+  # it is absent so a reasoning item without a payload is recognizably
+  # unreplayable.
+  defp maybe_put_encrypted_content(options, encrypted_content)
+       when is_binary(encrypted_content) do
+    Keyword.put(options, :encrypted_content, encrypted_content)
+  end
+
+  defp maybe_put_encrypted_content(options, _encrypted_content), do: options
 
   @doc """
   Convert a list of ContentParts to the expected map of data for the OpenAI API.
@@ -1651,13 +1747,23 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     end
   end
 
+  # The completed reasoning item carries the `id` and, when the request included
+  # `reasoning.encrypted_content`, the encrypted payload. Both ride along in the
+  # thinking part's options so the item can be replayed on the next request.
+  # The part stays `:thinking` because that is the type the earlier
+  # `response.output_item.added` event opened at this index, and content parts
+  # only merge with a part of their own type.
   def do_process_response(_model, %{
         "type" => "response.output_item.done",
         "output_index" => output_index,
-        "item" => %{"type" => "reasoning"}
+        "item" => %{"type" => "reasoning"} = item
       }) do
+    options =
+      [id: item["id"], summary: item["summary"] || [], type: "reasoning"]
+      |> maybe_put_encrypted_content(item["encrypted_content"])
+
     data = %{
-      content: ContentPart.new!(%{type: :thinking, content: ""}),
+      content: ContentPart.new!(%{type: :thinking, content: "", options: options}),
       status: :complete,
       role: :assistant,
       index: output_index
@@ -2001,23 +2107,25 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     end
   end
 
-  # Handle reasoning output from gpt-5 and o-series models
-  # We can either ignore it or store it as metadata
-  defp content_item_to_content_part_or_tool_call(%{
-         "type" => "reasoning",
-         "id" => reasoning_id,
-         "summary" => summary
-       }) do
-    # Store reasoning as an unsupported content part for now
-    # This preserves the information without breaking the flow
-    case ContentPart.new(%{
-           type: :unsupported,
-           options: %{
-             id: reasoning_id,
-             summary: summary,
-             type: "reasoning"
-           }
-         }) do
+  # Reasoning output from gpt-5 and o-series models. The item has no display
+  # value, but it carries the `encrypted_content` the API needs handed back to
+  # keep reasoning continuous across a tool loop, so it is kept as an
+  # `:unsupported` part and replayed by `reasoning_item_for_api/1`.
+  #
+  # `encrypted_content` is only present when the request asked for it with
+  # `include: ["reasoning.encrypted_content"]`.
+  defp content_item_to_content_part_or_tool_call(
+         %{
+           "type" => "reasoning",
+           "id" => reasoning_id,
+           "summary" => summary
+         } = item
+       ) do
+    options =
+      [id: reasoning_id, summary: summary, type: "reasoning"]
+      |> maybe_put_encrypted_content(item["encrypted_content"])
+
+    case ContentPart.new(%{type: :unsupported, options: options}) do
       {:ok, %ContentPart{} = part} ->
         part
 

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -731,6 +731,272 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
     end
   end
 
+  describe "reasoning item continuity" do
+    setup do
+      %{model: ChatOpenAIResponses.new!(%{"model" => @test_model})}
+    end
+
+    test "captures encrypted_content from a non-streamed reasoning item", %{model: model} do
+      response = %{
+        "status" => "completed",
+        "output" => [
+          %{
+            "type" => "reasoning",
+            "id" => "rs_abc123",
+            "summary" => [],
+            "encrypted_content" => "gAAAAAB-encrypted-payload"
+          },
+          %{
+            "type" => "message",
+            "content" => [%{"type" => "output_text", "text" => "Let me check."}]
+          }
+        ]
+      }
+
+      assert %LangChain.Message{} =
+               message = ChatOpenAIResponses.do_process_response(model, response)
+
+      assert [%ContentPart{type: :unsupported} = reasoning, %ContentPart{type: :text}] =
+               message.content
+
+      assert reasoning.options[:id] == "rs_abc123"
+      assert reasoning.options[:type] == "reasoning"
+      assert reasoning.options[:encrypted_content] == "gAAAAAB-encrypted-payload"
+    end
+
+    test "omits encrypted_content when the API did not return it", %{model: model} do
+      response = %{
+        "status" => "completed",
+        "output" => [
+          %{"type" => "reasoning", "id" => "rs_abc123", "summary" => []}
+        ]
+      }
+
+      assert %LangChain.Message{} =
+               message = ChatOpenAIResponses.do_process_response(model, response)
+
+      assert [%ContentPart{type: :unsupported} = reasoning] = message.content
+      assert reasoning.options[:id] == "rs_abc123"
+      refute Keyword.has_key?(reasoning.options, :encrypted_content)
+    end
+
+    test "captures the reasoning id and encrypted_content from a streamed item", %{model: model} do
+      response = %{
+        "type" => "response.output_item.done",
+        "output_index" => 0,
+        "item" => %{
+          "type" => "reasoning",
+          "id" => "rs_stream1",
+          "summary" => [],
+          "encrypted_content" => "gAAAAAB-streamed-payload"
+        }
+      }
+
+      assert %LangChain.MessageDelta{} =
+               delta = ChatOpenAIResponses.do_process_response(model, response)
+
+      assert %ContentPart{type: :thinking} = delta.content
+      assert delta.content.options[:id] == "rs_stream1"
+      assert delta.content.options[:type] == "reasoning"
+      assert delta.content.options[:encrypted_content] == "gAAAAAB-streamed-payload"
+    end
+
+    test "replays an unsupported reasoning part as its own input item", %{model: model} do
+      reasoning =
+        ContentPart.new!(%{
+          type: :unsupported,
+          options: [
+            id: "rs_abc123",
+            summary: [],
+            type: "reasoning",
+            encrypted_content: "gAAAAAB-encrypted-payload"
+          ]
+        })
+
+      message =
+        Message.new_assistant!(%{content: [reasoning, ContentPart.text!("Let me check.")]})
+
+      assert [
+               %{
+                 "type" => "reasoning",
+                 "id" => "rs_abc123",
+                 "summary" => [],
+                 "encrypted_content" => "gAAAAAB-encrypted-payload"
+               },
+               %{"type" => "message", "role" => "assistant"}
+             ] = ChatOpenAIResponses.for_api(model, message)
+    end
+
+    test "replays a thinking part that carries reasoning options", %{model: model} do
+      reasoning =
+        ContentPart.new!(%{
+          type: :thinking,
+          content: "",
+          options: [
+            id: "rs_stream1",
+            type: "reasoning",
+            encrypted_content: "gAAAAAB-streamed-payload"
+          ]
+        })
+
+      message = Message.new_assistant!(%{content: [reasoning, ContentPart.text!("Answer")]})
+
+      assert [
+               %{
+                 "type" => "reasoning",
+                 "id" => "rs_stream1",
+                 "encrypted_content" => "gAAAAAB-streamed-payload"
+               },
+               %{"type" => "message", "role" => "assistant"}
+             ] = ChatOpenAIResponses.for_api(model, message)
+    end
+
+    test "omits a reasoning part that has no encrypted_content", %{model: model} do
+      reasoning =
+        ContentPart.new!(%{
+          type: :unsupported,
+          options: [id: "rs_abc123", summary: [], type: "reasoning"]
+        })
+
+      message =
+        Message.new_assistant!(%{content: [reasoning, ContentPart.text!("Let me check.")]})
+
+      assert [%{"type" => "message", "role" => "assistant"}] =
+               ChatOpenAIResponses.for_api(model, message)
+    end
+
+    test "omits a plain thinking part that carries no reasoning item", %{model: model} do
+      message = Message.new_assistant!([ContentPart.new!(%{type: :thinking, content: "hmm"})])
+
+      assert [] = ChatOpenAIResponses.for_api(model, message)
+    end
+
+    test "replays reasoning ahead of the tool calls it produced", %{model: model} do
+      reasoning =
+        ContentPart.new!(%{
+          type: :unsupported,
+          options: [
+            id: "rs_abc123",
+            summary: [],
+            type: "reasoning",
+            encrypted_content: "gAAAAAB-encrypted-payload"
+          ]
+        })
+
+      tool_call =
+        ToolCall.new!(%{call_id: "call_abc", name: "calculator", arguments: %{expression: "1+1"}})
+
+      message =
+        Message.new_assistant!(%{content: [reasoning], tool_calls: [tool_call]})
+
+      assert [
+               %{"type" => "reasoning", "id" => "rs_abc123"},
+               %{"type" => "function_call", "call_id" => "call_abc"}
+             ] = ChatOpenAIResponses.for_api(model, message)
+    end
+
+    test "keeps the original ordering of reasoning and native tool calls", %{model: model} do
+      reasoning_one =
+        ContentPart.new!(%{
+          type: :unsupported,
+          options: [id: "rs_one", summary: [], type: "reasoning", encrypted_content: "first"]
+        })
+
+      search =
+        ContentPart.new!(%{
+          type: :unsupported,
+          options: %{id: "ws_one", type: "web_search_call", status: "completed"}
+        })
+
+      reasoning_two =
+        ContentPart.new!(%{
+          type: :unsupported,
+          options: [id: "rs_two", summary: [], type: "reasoning", encrypted_content: "second"]
+        })
+
+      message =
+        Message.new_assistant!(%{content: [reasoning_one, search, reasoning_two]})
+
+      assert [
+               %{"type" => "reasoning", "id" => "rs_one"},
+               %{type: "web_search_call", id: "ws_one"},
+               %{"type" => "reasoning", "id" => "rs_two"}
+             ] = ChatOpenAIResponses.for_api(model, message)
+    end
+
+    test "carries a streamed reasoning item through merge and back to the API", %{model: model} do
+      events = [
+        %{
+          "type" => "response.output_item.added",
+          "output_index" => 0,
+          "item" => %{"type" => "reasoning", "id" => "rs_stream1"}
+        },
+        %{
+          "type" => "response.output_item.done",
+          "output_index" => 0,
+          "item" => %{
+            "type" => "reasoning",
+            "id" => "rs_stream1",
+            "summary" => [],
+            "encrypted_content" => "gAAAAAB-streamed-payload"
+          }
+        }
+      ]
+
+      assert %LangChain.MessageDelta{} =
+               merged =
+               events
+               |> Enum.map(&ChatOpenAIResponses.do_process_response(model, &1))
+               |> LangChain.MessageDelta.merge_deltas()
+
+      assert {:ok, %LangChain.Message{} = message} =
+               LangChain.MessageDelta.to_message(%LangChain.MessageDelta{
+                 merged
+                 | status: :complete
+               })
+
+      assert [
+               %{
+                 "type" => "reasoning",
+                 "id" => "rs_stream1",
+                 "encrypted_content" => "gAAAAAB-streamed-payload"
+               }
+             ] = ChatOpenAIResponses.for_api(model, message)
+    end
+
+    test "round trips a reasoning item through a tool loop", %{model: model} do
+      response = %{
+        "status" => "completed",
+        "output" => [
+          %{
+            "type" => "reasoning",
+            "id" => "rs_loop",
+            "summary" => [],
+            "encrypted_content" => "gAAAAAB-loop"
+          },
+          %{
+            "type" => "function_call",
+            "call_id" => "call_loop",
+            "name" => "get_weather",
+            "arguments" => ~s({"city":"NYC"})
+          }
+        ]
+      }
+
+      assert %LangChain.Message{} =
+               message = ChatOpenAIResponses.do_process_response(model, response)
+
+      assert [
+               %{
+                 "type" => "reasoning",
+                 "id" => "rs_loop",
+                 "encrypted_content" => "gAAAAAB-loop"
+               },
+               %{"type" => "function_call", "call_id" => "call_loop"}
+             ] = ChatOpenAIResponses.for_api(model, message)
+    end
+  end
+
   describe "for_api/3 verbosity" do
     test "includes verbosity when set" do
       openai =


### PR DESCRIPTION
## Problem

The Responses API returns a `reasoning` output item next to the assistant's text and tool calls. `ChatOpenAIResponses` parsed it into a `%ContentPart{type: :unsupported}` and then had no outbound clause that could emit it, and `reasoning.encrypted_content` was never captured in the first place. The model re-derived its reasoning on every request, which inside a tool loop is every round trip.

`ContentPart` documents `:unsupported` as a part that "can be provided back to the LLM to maintain reasoning continuity". `ChatAnthropic` fulfils that contract by replaying `thinking` with its `signature`; `ChatGoogleAI` replays `thought_signature`. This adapter produced the part the contract describes and had no way to send it.

Reported in #618 with a thorough writeup. I verified every claim against `main` before changing anything.

## What the investigation added

The issue covers the non-streaming path. The streaming path is worse: `response.output_item.done` discarded the reasoning `id` too, emitting an empty `:thinking` part. Since agent tool loops usually stream, fixing only the non-streaming path would have left the reported symptom in place for most callers.

That constrained the design. `ContentPart.update_options/2` merges options only when both sides are keyword lists, and `append_content/2` refuses to merge parts of different types. So the streamed reasoning item cannot become an `:unsupported` part at its output index (it would be dropped with a warning), and its options cannot be a map (they would be silently discarded during the delta merge).

## Changes

**Capture** `encrypted_content` on both paths:
- Non-streaming keeps the `:unsupported` part and adds the payload.
- Streaming keeps the `:thinking` part the `output_item.added` event opened at that index, and carries `id`, `summary`, and `encrypted_content` in its options.

**Replay** reasoning items as their own `input` entries. `stand_alone_items_for_api/2` maps assistant content parts to the entries that do not belong inside the message item, preserving order, so a reasoning item precedes the message or function call it produced. `reasoning_item_for_api/1` recognizes both shapes.

**Omit** any reasoning item without `encrypted_content` rather than sending a stub, so nothing changes for callers who never set `include: ["reasoning.encrypted_content"]`.

Reasoning option keys move from a map to a keyword list. That is what `ContentPart` documents, what `merge_part/2` can merge, and it gives the outbound path one shape to read. No test asserted the map shape, and nothing consumed these options before this change, since nothing sent them back.

## Notes for review

- **`:include` is not set automatically.** Without `include: ["reasoning.encrypted_content"]` the API returns no payload and this code stays inert. Auto-adding it for every model risks a 400 on non-reasoning models, so it is documented in the moduledoc instead. Happy to add a narrower auto-enable (only when `:reasoning` options are configured) if you want it.
- **`native_tool_calls_for_api/2` is no longer called internally.** It is public, so I left it rather than make a breaking removal. Say the word and I will drop it.
- **`ContentPart.options` is virtual and excluded from `Jason.Encoder`.** In-memory tool loops are unaffected, but an application persisting messages between processes will lose the payload. Out of scope here; worth knowing.

## Tests

Eleven tests in a new `reasoning item continuity` block. Nine fail on `main`; the other two are regression guards for the omit-without-payload behavior.

Coverage includes capture on both paths, replay of both part shapes, omission without a payload, omission of a plain `:thinking` part, ordering ahead of function calls, ordering preserved when reasoning interleaves with `web_search_call`, a non-streamed parse-then-serialize round trip, and a streamed round trip that merges the deltas into a `Message` and serializes it back.

`mix precommit` is clean: 2316 passed, 0 failures.

Closes #618
