### PR TITLE
Give ContentPart options one shape

### DIFF
--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -172,13 +172,12 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
       Message.new_assistant!([
         ContentPart.new!(%{
           type: :unsupported,
-            options: %{
-              id: "ws_123456789", # ID as provided from Open AI
-              status: "completed",
-              type: "web_search_call"
-            }
-          }
-        ),
+          options: [
+            id: "ws_123456789", # ID as provided from Open AI
+            status: "completed",
+            type: "web_search_call"
+          ]
+        }),
         ContentPart.text!("The Astros won today 5-4...")
       ])
 
@@ -911,9 +910,18 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
           nil | %{id: any(), status: any(), type: <<_::120>>}
   def native_tool_call_for_api(%ChatOpenAIResponses{} = _model, %ContentPart{
         type: :unsupported,
-        options: %{type: "web_search_call"} = opts
-      }) do
-    %{id: opts.id, type: "web_search_call", status: opts.status}
+        options: options
+      })
+      when is_list(options) do
+    if Keyword.get(options, :type) == "web_search_call" do
+      %{
+        id: Keyword.get(options, :id),
+        type: "web_search_call",
+        status: Keyword.get(options, :status)
+      }
+    else
+      nil
+    end
   end
 
   def native_tool_call_for_api(_, _), do: nil
@@ -2092,12 +2100,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
        }) do
     case ContentPart.new(%{
            type: :unsupported,
-           options: %{
-             id: web_search_call_id,
-             status: "completed",
-             type: "web_search_call"
-           },
-           call_id: web_search_call_id
+           options: [id: web_search_call_id, status: "completed", type: "web_search_call"]
          }) do
       {:ok, %ContentPart{} = call} ->
         call
@@ -2146,12 +2149,12 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     # This preserves the information without breaking the flow
     case ContentPart.new(%{
            type: :unsupported,
-           options: %{
+           options: [
              id: part["id"],
              type: "file_search_call",
              queries: part["queries"],
              results: part["results"]
-           }
+           ]
          }) do
       {:ok, %ContentPart{} = part} ->
         part

--- a/lib/message/content_part.ex
+++ b/lib/message/content_part.ex
@@ -32,6 +32,12 @@ defmodule LangChain.Message.ContentPart do
     the options may contain LLM specific data that is recommended to be
     preserved like a `signature` or `redacted_thinking` data used by the LLM.
 
+    A map of options is accepted and converted to a keyword list, so a part
+    holds the same shape whichever way it was built and keeps it across a
+    serialization round trip. The keys must be atoms; a map with a string key
+    is rejected rather than converted, because turning caller-supplied strings
+    into atoms would let untrusted input grow the atom table.
+
   ## Image mime types
 
   The `:media` option is used to specify the mime type of the image. Various
@@ -84,8 +90,33 @@ defmodule LangChain.Message.ContentPart do
     %ContentPart{}
     |> cast(attrs, @create_fields)
     |> Utils.assign_string_value(:content, attrs)
+    |> normalize_options()
     |> common_validations()
     |> apply_action(:insert)
+  end
+
+  # Options are a keyword list. A map of options is accepted and converted so
+  # that every part reaching a chat model has one shape to read, and so a part
+  # keeps that shape across a serialization round trip.
+  #
+  # Keys must already be atoms. Converting caller-supplied strings to atoms
+  # would let untrusted input grow the atom table, so a map with any non-atom
+  # key is left alone and reported as invalid.
+  defp normalize_options(changeset) do
+    case get_field(changeset, :options) do
+      options when is_map(options) and map_size(options) > 0 ->
+        if Enum.all?(options, fn {k, _v} -> is_atom(k) end) do
+          put_change(changeset, :options, Enum.map(options, fn {k, v} -> {k, v} end))
+        else
+          add_error(changeset, :options, "keys must be atoms")
+        end
+
+      options when is_map(options) ->
+        put_change(changeset, :options, [])
+
+      _other ->
+        changeset
+    end
   end
 
   @doc """

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -731,6 +731,64 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
     end
   end
 
+  describe "native tool call option shape" do
+    setup do
+      %{model: ChatOpenAIResponses.new!(%{"model" => @test_model})}
+    end
+
+    # A stored conversation comes back with its ContentPart options as a keyword
+    # list. A native tool call has to serialize the same either way, or it goes
+    # missing from the history of a conversation that outlived its process.
+    test "serializes a web_search_call the same before and after a round trip", %{model: model} do
+      %ContentPart{} =
+        part =
+        ContentPart.new!(%{
+          type: :unsupported,
+          options: [id: "ws_1", status: "completed", type: "web_search_call"]
+        })
+
+      restored =
+        %ContentPart{
+          part
+          | options:
+              part.options
+              |> Map.new(fn {k, v} -> {to_string(k), v} end)
+              |> Enum.map(fn {k, v} -> {String.to_existing_atom(k), v} end)
+              |> Keyword.new()
+        }
+
+      assert %{id: "ws_1", type: "web_search_call", status: "completed"} =
+               ChatOpenAIResponses.native_tool_call_for_api(model, part)
+
+      assert ChatOpenAIResponses.native_tool_call_for_api(model, part) ==
+               ChatOpenAIResponses.native_tool_call_for_api(model, restored)
+    end
+
+    test "parses a web_search_call into keyword options", %{model: model} do
+      response = %{
+        "status" => "completed",
+        "output" => [
+          %{"type" => "web_search_call", "id" => "ws_1", "status" => "completed"}
+        ]
+      }
+
+      assert %LangChain.Message{} =
+               message = ChatOpenAIResponses.do_process_response(model, response)
+
+      assert [%ContentPart{type: :unsupported} = part] = message.content
+      assert is_list(part.options)
+      assert part.options[:type] == "web_search_call"
+
+      assert [%{id: "ws_1", type: "web_search_call", status: "completed"}] =
+               ChatOpenAIResponses.for_api(model, message)
+    end
+
+    test "ignores an unsupported part that is not a native tool call", %{model: model} do
+      part = ContentPart.new!(%{type: :unsupported, options: [type: "something_else"]})
+      assert nil == ChatOpenAIResponses.native_tool_call_for_api(model, part)
+    end
+  end
+
   describe "reasoning item continuity" do
     setup do
       %{model: ChatOpenAIResponses.new!(%{"model" => @test_model})}
@@ -905,7 +963,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       search =
         ContentPart.new!(%{
           type: :unsupported,
-          options: %{id: "ws_one", type: "web_search_call", status: "completed"}
+          options: [id: "ws_one", type: "web_search_call", status: "completed"]
         })
 
       reasoning_two =
@@ -1368,7 +1426,9 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       assert result.status == :complete
       [content_part] = result.content
       assert content_part.type == :unsupported
-      assert %{results: [_, _], queries: [_], type: "file_search_call"} = content_part.options
+      assert [_, _] = content_part.options[:results]
+      assert [_] = content_part.options[:queries]
+      assert content_part.options[:type] == "file_search_call"
     end
 
     test "handles error responses", %{model: model} do

--- a/test/message/content_part_test.exs
+++ b/test/message/content_part_test.exs
@@ -28,6 +28,57 @@ defmodule LangChain.Message.ContentPartTest do
     end
   end
 
+  describe "new/1 options" do
+    test "keeps a keyword list of options as-is" do
+      {:ok, %ContentPart{} = part} =
+        ContentPart.new(%{type: :thinking, content: "hmm", options: [signature: "sig"]})
+
+      assert part.options == [signature: "sig"]
+    end
+
+    test "converts a map of options into a keyword list" do
+      {:ok, %ContentPart{} = part} =
+        ContentPart.new(%{
+          type: :unsupported,
+          options: %{id: "ws_1", status: "completed", type: "web_search_call"}
+        })
+
+      assert is_list(part.options)
+      assert part.options[:id] == "ws_1"
+      assert part.options[:status] == "completed"
+      assert part.options[:type] == "web_search_call"
+    end
+
+    test "converts an empty map of options into an empty list" do
+      {:ok, %ContentPart{} = part} = ContentPart.new(%{type: :text, content: "hi", options: %{}})
+      assert part.options == []
+    end
+
+    test "rejects a map of options with non-atom keys" do
+      # Converting caller-supplied strings to atoms would let untrusted input
+      # grow the atom table.
+      assert {:error, changeset} =
+               ContentPart.new(%{type: :unsupported, options: %{"id" => "ws_1"}})
+
+      refute changeset.valid?
+      assert {"keys must be atoms", _} = changeset.errors[:options]
+    end
+
+    test "options survive the writers and readers that expect a keyword list" do
+      part =
+        ContentPart.new!(%{
+          type: :unsupported,
+          options: %{id: "ws_1", type: "web_search_call"}
+        })
+
+      assert [%ContentPart{} = updated] =
+               ContentPart.set_option_on_last_part([part], :cache_control, true)
+
+      assert updated.options[:cache_control] == true
+      assert updated.options[:id] == "ws_1"
+    end
+  end
+
   describe "new!/1" do
     test "accepts valid settings" do
       %ContentPart{} = part = ContentPart.new!(%{type: :text, content: "Hello!"})


### PR DESCRIPTION
Follows #630, now merged. Rebased onto `main`, so this is a single commit containing only the options change.

## Problem

`ContentPart` documents `:options` as a keyword list, and every provider reads it as one. `ChatOpenAIResponses` built the options of its `web_search_call` and `file_search_call` parts as a map instead, and pattern matched on that map to serialize them back:

```elixir
options: %{type: "web_search_call"} = opts   # producer and consumer both assume a map
```

A map does not survive persistence. An application storing a conversation gets its options back as a keyword list, because that is what a JSON round trip produces. The map pattern then fails to match, the clause falls through to `def native_tool_call_for_api(_, _), do: nil`, and the native tool call is **dropped from the replayed history with no error**.

The same part crashes `ContentPart.set_option_on_last_part/3`, which calls `Keyword.put/3` on it. I confirmed that against the unfixed code: it raises `FunctionClauseError`.

The shape was therefore doing two different things depending on whether the process had restarted, which is why neither failure showed up in the suite. Tests do not cross that boundary.

## Why this is fixed in `ContentPart` rather than at the call sites

The three call sites in the Responses adapter were the only map-shaped options in the library. Everything else already uses keyword lists, and some of it depends on that in ways that raise rather than degrade: `ChatVertexAI` reads options with `Keyword.fetch!(part.options, :media)`.

So `:options` is a shape contract the whole library already relies on, held by an `:any` field that nothing checks. Fixing the three call sites would leave the next provider free to reintroduce the same bug.

`ContentPart.new/1` now normalizes options to a keyword list, and the Responses adapter reads them with `Keyword`.

## Compatibility

Less breaking than the shape change suggests:

- **Callers passing a map keep working.** Normalization happens in the constructor, so the `web_search_call` example in the `ChatOpenAIResponses` moduledoc still builds a valid part. There is a test for this.
- **Already-persisted conversations start working with no migration.** Rows were serialized from atom-keyed maps, so they come back as keyword lists, which is exactly what the new read path expects.

What breaks is code that *reads* `part.options` expecting a map, such as `part.options.id` or a `%{type: ...}` pattern. That is the intended change.

## Atom keys only

Keys must already be atoms. A map with any non-atom key is rejected with a changeset error rather than converted, because `String.to_atom/1` on caller-supplied input is an atom-table exhaustion vector, which is what `sobelow` flags in `mix precommit`. Nothing in the library produces string-keyed options, and `Sagents.Persistence.StateSerializer` already converts to atoms before constructing, so this costs nothing in practice.

## Tests

Eight new tests.

`ContentPart`: a keyword list passes through untouched, an atom-keyed map is converted, an empty map becomes `[]`, a string-keyed map is rejected, and a part built from a map now works with `set_option_on_last_part/3`.

`ChatOpenAIResponses`: a `web_search_call` serializes identically before and after a persistence-style round trip, a parsed `web_search_call` carries keyword options and serializes back, and an unsupported part that is not a native tool call is ignored.

`mix precommit` is clean: 2324 passed, sobelow reports no vulnerabilities.

## Note, not included here

There is no outbound clause for `file_search_call` at all, so one can be parsed but never replayed. Separate gap, happy to file it.
