### PR TITLE
Let a callback review each tool call before it runs

### DIFF
--- a/lib/callbacks.ex
+++ b/lib/callbacks.ex
@@ -47,4 +47,60 @@ defmodule LangChain.Callbacks do
       end
     end)
   end
+
+  @doc """
+  Fold a decision-returning callback across the attached handler maps.
+
+  Where `fire/3` discards what a handler returns, this collects it. A handler
+  map that does not define `callback_name` is skipped without consulting the
+  reducer.
+
+  `reducer` receives two arguments: a zero-risk `invoke` function that applies
+  the handler to a list of arguments, and the current accumulator. It returns
+  `{:cont, acc}` to consult the next handler or `{:halt, acc}` to stop. Passing
+  `invoke` rather than the raw handler lets the reducer choose the arguments
+  per handler (so a handler can see what an earlier one changed) while the
+  exception wrapping stays here, identical to `fire/3`.
+
+  ## Example
+
+      Callbacks.reduce(callbacks, :on_thing_reviewed, :allowed, fn invoke, acc ->
+        case invoke.([subject]) do
+          :ok -> {:cont, acc}
+          {:denied, _reason} = denial -> {:halt, denial}
+        end
+      end)
+
+  """
+  @spec reduce([map()], atom(), acc, (([any()] -> any()), acc -> {:cont, acc} | {:halt, acc})) ::
+          acc
+        when acc: term()
+  def reduce(callbacks, callback_name, acc, reducer)
+      when is_list(callbacks) and is_function(reducer, 2) do
+    Enum.reduce_while(callbacks, acc, fn handlers_map, acc ->
+      case Map.get(handlers_map, callback_name) do
+        nil ->
+          {:cont, acc}
+
+        callback_fn when is_function(callback_fn) ->
+          reducer.(invoker(callback_name, callback_fn), acc)
+
+        other ->
+          raise LangChainError,
+                "Unexpected callback handler. Callback #{inspect(callback_name)} was assigned #{inspect(other)}"
+      end
+    end)
+  end
+
+  defp invoker(callback_name, callback_fn) do
+    fn arguments ->
+      try do
+        apply(callback_fn, arguments)
+      rescue
+        err ->
+          raise LangChainError,
+                "Callback handler for #{inspect(callback_name)} raised an exception: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"
+      end
+    end
+  end
 end

--- a/lib/callbacks.ex
+++ b/lib/callbacks.ex
@@ -22,29 +22,12 @@ defmodule LangChain.Callbacks do
   end
 
   def fire(callbacks, callback_name, arguments) when is_list(callbacks) do
-    # A model may contain multiple callback handler maps. Cycle through them to
-    # execute the named callback with the arguments if assigned.
-    Enum.each(callbacks, fn handlers_map ->
-      # find if the callback is in the handler map
-      case Map.get(handlers_map, callback_name) do
-        nil ->
-          # no handler attached
-          :ok
-
-        callback_fn when is_function(callback_fn) ->
-          try do
-            # execute the function
-            apply(callback_fn, arguments)
-          rescue
-            err ->
-              raise LangChainError,
-                    "Callback handler for #{inspect(callback_name)} raised an exception: #{LangChainError.format_exception(err, __STACKTRACE__, :short)}"
-          end
-
-        other ->
-          raise LangChainError,
-                "Unexpected callback handler. Callback #{inspect(callback_name)} was assigned #{inspect(other)}"
-      end
+    # A model may contain multiple callback handler maps. Every handler gets the
+    # same arguments and whatever it returns is discarded, which is `reduce/4`
+    # with nothing to accumulate.
+    reduce(callbacks, callback_name, :ok, fn invoke, acc ->
+      invoke.(arguments)
+      {:cont, acc}
     end)
   end
 
@@ -55,12 +38,15 @@ defmodule LangChain.Callbacks do
   map that does not define `callback_name` is skipped without consulting the
   reducer.
 
-  `reducer` receives two arguments: a zero-risk `invoke` function that applies
-  the handler to a list of arguments, and the current accumulator. It returns
-  `{:cont, acc}` to consult the next handler or `{:halt, acc}` to stop. Passing
-  `invoke` rather than the raw handler lets the reducer choose the arguments
-  per handler (so a handler can see what an earlier one changed) while the
-  exception wrapping stays here, identical to `fire/3`.
+  `reducer` receives two arguments: an `invoke` function that applies the handler
+  to a list of arguments, and the current accumulator. It returns `{:cont, acc}`
+  to consult the next handler or `{:halt, acc}` to stop. Passing `invoke` rather
+  than the raw handler lets the reducer choose the arguments per handler, so a
+  handler can be shown what an earlier one changed, while the exception wrapping
+  stays here.
+
+  This is the primitive the module is built on. `fire/3` is this function with
+  the same arguments given to every handler and nothing accumulated.
 
   ## Example
 

--- a/lib/chains/chain_callbacks.ex
+++ b/lib/chains/chain_callbacks.ex
@@ -166,9 +166,9 @@ defmodule LangChain.Chains.ChainCallbacks do
   `:on_tool_pre_execution` instead.
 
   It fires only for a call that is going to run. An `:on_tool_call_review`
-  handler settles its call before this point, so a denied or escalated call is
-  reported to `:on_tool_execution_failed` or `:on_tool_interrupted` without ever
-  being announced as started. A UI tracking tool state must reach those from
+  handler settles its call before this point, so a call it denied, or held to ask
+  the user about, is reported to `:on_tool_execution_failed` or
+  `:on_tool_interrupted` without ever being announced as started. A UI tracking tool state must reach those from
   `:on_tool_call_identified` as well as from here.
 
   The ToolCall carries whatever arguments review left it with, which is what the
@@ -235,7 +235,7 @@ defmodule LangChain.Chains.ChainCallbacks do
   call itself.
 
   - `:human_decision` is `nil` while the model's call is being run directly. It
-    is `:approve` or `:edit` once a person has decided on this call through
+    is `:approve` or `:edit` once the user has decided on this call through
     `LLMChain.execute_tool_calls_with_decisions/3`, which is the only thing that
     gives it any other value.
   - `:custom_context` is the context the tool will be given: the context passed
@@ -252,83 +252,116 @@ defmodule LangChain.Chains.ChainCallbacks do
   Match on the keys a handler cares about rather than the whole map. It gains
   keys as the chain learns more about a call.
 
-  ## Escalating to a person
+  ## Return values
 
-  Review runs again for the same call once a person has decided on it, so a
-  handler that escalates has to recognize the answer coming back.
-  `:human_decision` is what it reads. A handler that ignores it raises the same
-  escalation a second time and the call never runs.
+  - `:ok` - express no opinion; the call proceeds to the next handler
+  - `{:update_arguments, map}` - rewrite the arguments and keep going. Later
+    handlers review the rewritten call, and the tool runs with it.
+  - `{:deny, reason}` - refuse the call. The tool never runs and `reason` is
+    returned to the model as the tool result.
+  - `{:interrupt, message, interrupt_data}` - refuse the call for now and
+    interrupt, producing a `ToolResult` with `is_interrupt: true`. Use this to
+    put the call in front of the user before it runs.
 
-  Take a refund the handler will not clear on its own:
+  Handlers are consulted in the order their maps were added to the chain. The
+  first `{:deny, _}` or `{:interrupt, _, _}` settles the call and the remaining
+  handlers are skipped.
+
+  An exception raised by a handler aborts the whole batch of tool calls before
+  any of them runs, including calls an earlier handler already cleared. A
+  handler that cannot reach the system it consults should decide the call, by
+  denying it, rather than raise.
+
+  ## Asking the user to confirm
+
+  A handler decides from the arguments the model chose and what the chain knows
+  about the user, so the same tool can run without comment in one case and be
+  worth stopping on in another. `{:interrupt, _, _}` puts that call in front of
+  the user before it runs.
+
+  Review runs again for the call once the user answers, so a handler has to
+  recognize their answer coming back. `:human_decision` is what it reads. A
+  handler that ignores it asks the same question a second time and the call
+  never runs.
+
+  Take a file deletion, on a chain whose `custom_context` carries the project
+  the user is working in:
 
       on_tool_call_review: fn _chain, call, _func, review ->
         cond do
+          # The user already answered for this call. Their answer stands.
           review.human_decision ->
-            # A person has already answered for this call. Their decision stands.
             :ok
 
-          call.arguments["amount_cents"] > 50_000 ->
-            {:interrupt, "A manager has to approve a refund this size.",
-             %{limit_cents: 50_000}}
+          call.name == "delete_file" and
+              not inside?(call.arguments["path"], review.custom_context.workspace_root) ->
+            {:interrupt, "That file is outside your project. Delete it anyway?",
+             %{path: call.arguments["path"]}}
 
           true ->
             :ok
         end
       end
 
+  A delete inside the project runs without comment. A delete outside it stops
+  and asks. Withholding the tool cannot draw that line, because which case a
+  call falls into depends on the path the model chose.
+
   ### First pass, on the model's call
 
-  The handler is given `%{human_decision: nil, custom_context: %{tenant_id: "acme"}}`.
-  No one has decided anything yet, the amount is over the ceiling, and the
-  handler interrupts. The tool never runs, and the call is answered by a stand-in
-  result:
+  The handler is given
+  `%{human_decision: nil, custom_context: %{workspace_root: "/home/sam/project"}}`.
+  The user has not been asked anything yet, the path is outside the project, and
+  the handler interrupts. The tool never runs, and the call is answered by a
+  stand-in result:
 
       %ToolResult{
         tool_call_id: "call_abc123",
-        name: "issue_refund",
-        display_text: "Issuing the refund",
-        content: [%ContentPart{type: :text, content: "A manager has to approve a refund this size."}],
+        name: "delete_file",
+        display_text: "Deleting the file",
+        content: [%ContentPart{type: :text, content: "That file is outside your project. Delete it anyway?"}],
         is_error: false,
         is_interrupt: true,
-        interrupt_data: %{limit_cents: 50_000}
+        interrupt_data: %{path: "/home/sam/notes.md"}
       }
 
   The message becomes `content`, as a list of ContentParts rather than the string
   the handler returned. `interrupt_data` is carried through untouched and is
-  never shown to the model. It is for the code deciding what to ask a person.
+  never shown to the model. It is for the code that builds the question, which
+  needs the path here to show the user what they are agreeing to.
 
   `:on_tool_interrupted` fires with that result, and `LLMChain.run/2` returns:
 
-      {:interrupt, chain, %{limit_cents: 50_000, tool_call_id: "call_abc123"}}
+      {:interrupt, chain, %{path: "/home/sam/notes.md", tool_call_id: "call_abc123"}}
 
   The chain adds `:tool_call_id` to whatever the handler returned, so a handler
   does not need to put the call id in `interrupt_data` itself. That id is what
-  ties the question back to the call it came from.
+  ties the answer back to the call it came from.
 
-  ### Second pass, once the person has answered
+  ### Second pass, once the user has answered
 
   The host resumes through `LLMChain.execute_tool_calls_with_decisions/3` with
-  the decision it collected. Review runs again on the same call, and this time
-  the handler is given:
+  the answer it collected. Review runs again on the same call, and this time the
+  handler is given:
 
-      %{human_decision: :approve, custom_context: %{tenant_id: "acme"}}
+      %{human_decision: :approve, custom_context: %{workspace_root: "/home/sam/project"}}
 
   The first branch matches, the handler returns `:ok`, and the tool runs. The
   call is answered the way any other cleared call is:
 
       %ToolResult{
         tool_call_id: "call_abc123",
-        name: "issue_refund",
-        display_text: "Issuing the refund",
-        content: [%ContentPart{type: :text, content: "refunded"}],
+        name: "delete_file",
+        display_text: "Deleting the file",
+        content: [%ContentPart{type: :text, content: "deleted"}],
         is_error: false,
         is_interrupt: false,
         interrupt_data: nil
       }
 
-  An `:edit` decision reaches the handler the same way, with
-  `human_decision: :edit` and the call already carrying the arguments the person
-  supplied. A `:reject` decision does not reach review at all, because the call
+  An `:edit` answer reaches the handler the same way, with
+  `human_decision: :edit` and the call already carrying the arguments the user
+  supplied. A `:reject` answer does not reach review at all, because the call
   does not run.
 
   An interrupt raised on the model's call leaves the chain holding a ToolResult

--- a/lib/chains/chain_callbacks.ex
+++ b/lib/chains/chain_callbacks.ex
@@ -231,56 +231,110 @@ defmodule LangChain.Chains.ChainCallbacks do
 
   ## The review context
 
-  - `:human_decision` - `nil` when the model's call is being run directly, or
-    `:approve` / `:edit` when a person has already decided on this call through
-    `LLMChain.execute_tool_calls_with_decisions/3`.
-  - `:custom_context` - the context the tool will be given, which is the
-    context passed to `LLMChain.execute_tool_calls/2` when one is supplied and
-    `chain.custom_context` otherwise. A handler scoped to a tenant should read
-    this rather than `chain.custom_context`, which is not always the context the
-    call will run under.
+  The fourth argument describes the circumstances of the call rather than the
+  call itself.
 
-  Match the map loosely. It gains keys as the chain learns more about a call.
+  - `:human_decision` is `nil` while the model's call is being run directly. It
+    is `:approve` or `:edit` once a person has decided on this call through
+    `LLMChain.execute_tool_calls_with_decisions/3`, which is the only thing that
+    gives it any other value.
+  - `:custom_context` is the context the tool will be given: the context passed
+    to `LLMChain.execute_tool_calls/2` when one is supplied, and
+    `chain.custom_context` otherwise. A handler scoped to a tenant reads this
+    rather than `chain.custom_context`, which is not always the context the call
+    will run under.
 
-  ## Return values
+  On a chain whose `custom_context` is `%{tenant_id: "acme"}`, a handler running
+  against the model's own call is given:
 
-  - `:ok` - express no opinion; the call proceeds to the next handler
-  - `{:update_arguments, map}` - rewrite the arguments and keep going. Later
-    handlers review the rewritten call, and the tool runs with it.
-  - `{:deny, reason}` - refuse the call. The tool never runs and `reason` is
-    returned to the model as the tool result.
-  - `{:interrupt, message, interrupt_data}` - refuse the call for now and
-    interrupt, producing a `ToolResult` with `is_interrupt: true`. Use this to
-    escalate a decision the handler cannot make on its own.
+      %{human_decision: nil, custom_context: %{tenant_id: "acme"}}
 
-  Handlers are consulted in the order their maps were added to the chain. The
-  first `{:deny, _}` or `{:interrupt, _, _}` settles the call and the remaining
-  handlers are skipped.
-
-  An exception raised by a handler aborts the whole batch of tool calls before
-  any of them runs, including calls an earlier handler already cleared. A
-  handler that cannot reach the system it consults should decide the call, by
-  denying it, rather than raise.
+  Match on the keys a handler cares about rather than the whole map. It gains
+  keys as the chain learns more about a call.
 
   ## Escalating to a person
 
-  A handler that returns `{:interrupt, _, _}` is consulted again for the same
-  call when the person's decision comes back, because review applies to the
-  human-decision path too. Read `:human_decision` and stand aside once it is
-  set, or the escalation is raised again and the call never progresses:
+  Review runs again for the same call once a person has decided on it, so a
+  handler that escalates has to recognize the answer coming back.
+  `:human_decision` is what it reads. A handler that ignores it raises the same
+  escalation a second time and the call never runs.
+
+  Take a refund the handler will not clear on its own:
 
       on_tool_call_review: fn _chain, call, _func, review ->
         cond do
-          review.human_decision -> :ok
-          Policy.needs_sign_off?(call) -> {:interrupt, "Needs a manager", %{call_id: call.call_id}}
-          true -> :ok
+          review.human_decision ->
+            # A person has already answered for this call. Their decision stands.
+            :ok
+
+          call.arguments["amount_cents"] > 50_000 ->
+            {:interrupt, "A manager has to approve a refund this size.",
+             %{limit_cents: 50_000}}
+
+          true ->
+            :ok
         end
       end
 
-  Resuming from an interrupt raised here works the same way as resuming from one
-  a tool returned: the chain already holds a `ToolResult` answering the call, so
-  a resumed run replaces it with `LangChain.Message.replace_tool_result/3`
-  rather than adding a second result for the same call.
+  ### First pass, on the model's call
+
+  The handler is given `%{human_decision: nil, custom_context: %{tenant_id: "acme"}}`.
+  No one has decided anything yet, the amount is over the ceiling, and the
+  handler interrupts. The tool never runs, and the call is answered by a stand-in
+  result:
+
+      %ToolResult{
+        tool_call_id: "call_abc123",
+        name: "issue_refund",
+        display_text: "Issuing the refund",
+        content: [%ContentPart{type: :text, content: "A manager has to approve a refund this size."}],
+        is_error: false,
+        is_interrupt: true,
+        interrupt_data: %{limit_cents: 50_000}
+      }
+
+  The message becomes `content`, as a list of ContentParts rather than the string
+  the handler returned. `interrupt_data` is carried through untouched and is
+  never shown to the model. It is for the code deciding what to ask a person.
+
+  `:on_tool_interrupted` fires with that result, and `LLMChain.run/2` returns:
+
+      {:interrupt, chain, %{limit_cents: 50_000, tool_call_id: "call_abc123"}}
+
+  The chain adds `:tool_call_id` to whatever the handler returned, so a handler
+  does not need to put the call id in `interrupt_data` itself. That id is what
+  ties the question back to the call it came from.
+
+  ### Second pass, once the person has answered
+
+  The host resumes through `LLMChain.execute_tool_calls_with_decisions/3` with
+  the decision it collected. Review runs again on the same call, and this time
+  the handler is given:
+
+      %{human_decision: :approve, custom_context: %{tenant_id: "acme"}}
+
+  The first branch matches, the handler returns `:ok`, and the tool runs. The
+  call is answered the way any other cleared call is:
+
+      %ToolResult{
+        tool_call_id: "call_abc123",
+        name: "issue_refund",
+        display_text: "Issuing the refund",
+        content: [%ContentPart{type: :text, content: "refunded"}],
+        is_error: false,
+        is_interrupt: false,
+        interrupt_data: nil
+      }
+
+  An `:edit` decision reaches the handler the same way, with
+  `human_decision: :edit` and the call already carrying the arguments the person
+  supplied. A `:reject` decision does not reach review at all, because the call
+  does not run.
+
+  An interrupt raised on the model's call leaves the chain holding a ToolResult
+  that already answers it, so a resumed run replaces that result with
+  `LangChain.Message.replace_tool_result/3` rather than adding a second one for
+  the same call.
 
   ## Rewritten arguments and the transcript
 

--- a/lib/chains/chain_callbacks.ex
+++ b/lib/chains/chain_callbacks.ex
@@ -369,6 +369,49 @@ defmodule LangChain.Chains.ChainCallbacks do
   `LangChain.Message.replace_tool_result/3` rather than adding a second one for
   the same call.
 
+  ### Remembering an answer for later calls
+
+  `:human_decision` answers for one call. It says the user agreed to the call in
+  front of them, not that they agreed to a kind of call, and it is gone by the
+  next one. A user who says "stop asking me about this" is describing a rule,
+  and a rule has to be recorded somewhere the handler can read on the calls that
+  follow.
+
+  `custom_context` is the natural place for one that lasts as long as the
+  conversation, since review is handed it already. The host records what the
+  user agreed to and builds the next chain with it:
+
+      on_tool_call_review: fn _chain, call, _func, review ->
+        cond do
+          # This call was answered directly.
+          review.human_decision ->
+            :ok
+
+          # This kind of call was answered earlier and that answer still stands.
+          call.name in review.custom_context.always_allow ->
+            :ok
+
+          call.name == "delete_file" and
+              not inside?(call.arguments["path"], review.custom_context.workspace_root) ->
+            {:interrupt, "That file is outside your project. Delete it anyway?",
+             %{path: call.arguments["path"]}}
+
+          true ->
+            :ok
+        end
+      end
+
+  A rule meant to outlive the conversation belongs in a store keyed to the user
+  rather than on the chain, but the handler reads it the same way.
+
+  `:human_decision` is checked first so the answer to the call being resumed is
+  honored whatever the standing rules say.
+
+  What this cannot do is spare a call's siblings. Every call in a batch is
+  reviewed before any interrupt reaches anyone, so a model asking to delete three
+  files at once has all three held together and the user is asked about all
+  three. A rule recorded from their answer applies from the next batch on.
+
   ## Rewritten arguments and the transcript
 
   `{:update_arguments, map}` changes what the tool receives and what

--- a/lib/chains/chain_callbacks.ex
+++ b/lib/chains/chain_callbacks.ex
@@ -199,6 +199,62 @@ defmodule LangChain.Chains.ChainCallbacks do
   @type chain_tool_pre_execution :: (LLMChain.t(), ToolCall.t(), Function.t() -> any())
 
   @typedoc """
+  Executed before a tool call is announced or run, to decide whether it may
+  proceed.
+
+  This is the one tool callback whose return value is used. It fires in the
+  parent chain process ahead of `:on_tool_execution_started`, before any async
+  `Task` is spawned, so a call that is turned away is never announced as
+  running and never reaches the tool function.
+
+  It fires on every path that executes a tool, including
+  `LLMChain.execute_tool_calls_with_decisions/3`. A human approving a call in a
+  Human-in-the-Loop workflow does not exempt it from review.
+
+  - First argument: LLMChain.t()
+  - Second argument: ToolCall struct under review
+  - Third argument: Function struct for the tool
+
+  ## Return values
+
+  - `:ok` - express no opinion; the call proceeds to the next handler
+  - `{:update_arguments, map}` - rewrite the arguments and keep going. Later
+    handlers review the rewritten call, and the tool runs with it.
+  - `{:deny, reason}` - refuse the call. The tool never runs and `reason` is
+    returned to the model as the tool result.
+  - `{:interrupt, message, interrupt_data}` - refuse the call for now and
+    interrupt, producing a `ToolResult` with `is_interrupt: true`. Use this to
+    escalate a decision the handler cannot make on its own.
+
+  Handlers are consulted in the order their maps were added to the chain. The
+  first `{:deny, _}` or `{:interrupt, _, _}` settles the call and the remaining
+  handlers are skipped.
+
+  A denied call is reported with `is_error: false`. It is a decision about the
+  call, not a fault in it, so it leaves the chain's failure counter alone and
+  cannot exhaust `max_retry_count`. A policy that turns down many calls in a
+  row will not abort the run.
+
+  ## Example
+
+      callback_handler = %{
+        on_tool_call_review: fn _chain, tool_call, _func ->
+          case Policy.check(tool_call.name, tool_call.arguments) do
+            :allowed -> :ok
+            {:refused, why} -> {:deny, why}
+          end
+        end
+      }
+
+  """
+  @type chain_tool_call_review ::
+          (LLMChain.t(), ToolCall.t(), Function.t() ->
+             :ok
+             | {:update_arguments, map()}
+             | {:deny, String.t()}
+             | {:interrupt, String.t(), map()})
+
+  @typedoc """
   Executed when a single tool execution completes successfully.
 
   Fires after individual tool execution, before results are aggregated.
@@ -370,6 +426,7 @@ defmodule LangChain.Chains.ChainCallbacks do
           optional(:on_tool_call_identified) => chain_tool_call_identified(),
           optional(:on_tool_execution_started) => chain_tool_execution_started(),
           optional(:on_tool_pre_execution) => chain_tool_pre_execution(),
+          optional(:on_tool_call_review) => chain_tool_call_review(),
           optional(:on_tool_execution_completed) => chain_tool_execution_completed(),
           optional(:on_tool_execution_failed) => chain_tool_execution_failed(),
           optional(:on_tool_execution_exception) => chain_tool_execution_exception(),

--- a/lib/chains/chain_callbacks.ex
+++ b/lib/chains/chain_callbacks.ex
@@ -165,6 +165,15 @@ defmodule LangChain.Chains.ChainCallbacks do
   (e.g. propagating tenancy/OTel/Sentry context across the async boundary), use
   `:on_tool_pre_execution` instead.
 
+  It fires only for a call that is going to run. An `:on_tool_call_review`
+  handler settles its call before this point, so a denied or escalated call is
+  reported to `:on_tool_execution_failed` or `:on_tool_interrupted` without ever
+  being announced as started. A UI tracking tool state must reach those from
+  `:on_tool_call_identified` as well as from here.
+
+  The ToolCall carries whatever arguments review left it with, which is what the
+  tool is actually given.
+
   - First argument: LLMChain.t()
   - Second argument: ToolCall struct being executed
   - Third argument: Function struct for the tool (includes display_text)
@@ -211,9 +220,27 @@ defmodule LangChain.Chains.ChainCallbacks do
   `LLMChain.execute_tool_calls_with_decisions/3`. A human approving a call in a
   Human-in-the-Loop workflow does not exempt it from review.
 
+  It does not fire for a call naming a tool the chain does not have. There is no
+  `Function` to hand a handler, so there is nothing to allow or deny. A handler
+  auditing what the model attempts sees only calls that resolve to a real tool.
+
   - First argument: LLMChain.t()
   - Second argument: ToolCall struct under review
   - Third argument: Function struct for the tool
+  - Fourth argument: a review context map describing the circumstances
+
+  ## The review context
+
+  - `:human_decision` - `nil` when the model's call is being run directly, or
+    `:approve` / `:edit` when a person has already decided on this call through
+    `LLMChain.execute_tool_calls_with_decisions/3`.
+  - `:custom_context` - the context the tool will be given, which is the
+    context passed to `LLMChain.execute_tool_calls/2` when one is supplied and
+    `chain.custom_context` otherwise. A handler scoped to a tenant should read
+    this rather than `chain.custom_context`, which is not always the context the
+    call will run under.
+
+  Match the map loosely. It gains keys as the chain learns more about a call.
 
   ## Return values
 
@@ -230,15 +257,56 @@ defmodule LangChain.Chains.ChainCallbacks do
   first `{:deny, _}` or `{:interrupt, _, _}` settles the call and the remaining
   handlers are skipped.
 
+  An exception raised by a handler aborts the whole batch of tool calls before
+  any of them runs, including calls an earlier handler already cleared. A
+  handler that cannot reach the system it consults should decide the call, by
+  denying it, rather than raise.
+
+  ## Escalating to a person
+
+  A handler that returns `{:interrupt, _, _}` is consulted again for the same
+  call when the person's decision comes back, because review applies to the
+  human-decision path too. Read `:human_decision` and stand aside once it is
+  set, or the escalation is raised again and the call never progresses:
+
+      on_tool_call_review: fn _chain, call, _func, review ->
+        cond do
+          review.human_decision -> :ok
+          Policy.needs_sign_off?(call) -> {:interrupt, "Needs a manager", %{call_id: call.call_id}}
+          true -> :ok
+        end
+      end
+
+  Resuming from an interrupt raised here works the same way as resuming from one
+  a tool returned: the chain already holds a `ToolResult` answering the call, so
+  a resumed run replaces it with `LangChain.Message.replace_tool_result/3`
+  rather than adding a second result for the same call.
+
+  ## Rewritten arguments and the transcript
+
+  `{:update_arguments, map}` changes what the tool receives and what
+  `:on_tool_execution_started` reports. It does not change the assistant message
+  already recorded in `chain.messages`, which keeps the arguments the model
+  produced, and it does not change what `:on_tool_call_identified` reported
+  during streaming. A UI or audit trail that reads arguments off the assistant
+  message shows what was asked for, not what ran.
+
+  ## Denials and the failure counter
+
   A denied call is reported with `is_error: false`. It is a decision about the
   call, not a fault in it, so it leaves the chain's failure counter alone and
-  cannot exhaust `max_retry_count`. A policy that turns down many calls in a
-  row will not abort the run.
+  cannot exhaust `max_retry_count`. A policy that turns down many calls in a row
+  will not abort the run.
+
+  That counter is also the only bound on a tool-calling loop, so a model that
+  keeps reaching for a tool that keeps being denied is not stopped by it. Write
+  the `reason` so the model can act on it, naming what to do instead of
+  retrying, since the reason is the whole of what the model learns.
 
   ## Example
 
       callback_handler = %{
-        on_tool_call_review: fn _chain, tool_call, _func ->
+        on_tool_call_review: fn _chain, tool_call, _func, _review ->
           case Policy.check(tool_call.name, tool_call.arguments) do
             :allowed -> :ok
             {:refused, why} -> {:deny, why}
@@ -248,7 +316,7 @@ defmodule LangChain.Chains.ChainCallbacks do
 
   """
   @type chain_tool_call_review ::
-          (LLMChain.t(), ToolCall.t(), Function.t() ->
+          (LLMChain.t(), ToolCall.t(), Function.t(), map() ->
              :ok
              | {:update_arguments, map()}
              | {:deny, String.t()}
@@ -272,7 +340,13 @@ defmodule LangChain.Chains.ChainCallbacks do
   Executed when a single tool execution fails.
 
   Fires when tool execution raises an exception, returns an error result, names a
-  tool that doesn't exist, or is rejected during human review.
+  tool that doesn't exist, is rejected during human review, or is denied by an
+  `:on_tool_call_review` handler.
+
+  A denial and a human rejection both report a `ToolResult` with
+  `is_error: false`, because each is a decision about the call rather than a
+  fault in it. A handler that counts failures should read the `ToolResult` rather
+  than assume every call it hears about here errored.
 
   - First argument: LLMChain.t()
   - Second argument: ToolCall that failed

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1480,18 +1480,25 @@ defmodule LangChain.Chains.LLMChain do
           end
         end)
 
+      # Let :on_tool_call_review handlers settle each call first. A call they
+      # turn away is never announced as started and never reaches a Task, so a
+      # refusal leaves no trace of a tool that appeared to run.
+      {async_calls, async_reviewed} = partition_reviewed_calls(chain, grouped[:async])
+      {sync_calls, sync_reviewed} = partition_reviewed_calls(chain, grouped[:sync])
+      reviewed_results = async_reviewed ++ sync_reviewed
+
       # Fire execution started callbacks for ALL valid tools BEFORE execution
       # This is the ONLY place :on_tool_execution_started fires (not during streaming detection)
       # The :on_tool_call_identified callback already fired earlier during streaming
       # Augment each ToolCall with display_text from Function before firing callback
-      Enum.each(grouped[:async] ++ grouped[:sync], fn {call, func} ->
+      Enum.each(async_calls ++ sync_calls, fn {call, func} ->
         Callbacks.fire(chain.callbacks, :on_tool_execution_started, [chain, call, func])
       end)
 
       # execute all the async calls. This keeps the responses in order too.
       # Return tuple with call and func for callback firing
       async_results =
-        grouped[:async]
+        async_calls
         |> Enum.map(fn {call, func} ->
           # Capture the current OpenTelemetry context in THIS (parent) process. It
           # lives in the process dictionary and is NOT inherited by a spawned Task,
@@ -1523,7 +1530,7 @@ defmodule LangChain.Chains.LLMChain do
 
       # Execute sync tools with immediate callbacks
       sync_tool_results =
-        Enum.map(grouped[:sync], fn {call, func} ->
+        Enum.map(sync_calls, fn {call, func} ->
           Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [chain, call, func])
           result = execute_tool_call(call, func, verbose: verbose, context: use_context)
 
@@ -1547,7 +1554,8 @@ defmodule LangChain.Chains.LLMChain do
           })
         end)
 
-      combined_results = async_tool_results ++ sync_tool_results ++ invalid_calls
+      combined_results =
+        async_tool_results ++ sync_tool_results ++ reviewed_results ++ invalid_calls
 
       # Fire interrupt callback if any tools interrupted
       interrupted_results = Enum.filter(combined_results, & &1.is_interrupt)
@@ -1629,85 +1637,13 @@ defmodule LangChain.Chains.LLMChain do
       |> Enum.map(fn {tool_call, decision} ->
         case decision.type do
           :approve ->
-            # Execute with original arguments
-            case chain._tool_map[tool_call.name] do
-              %Function{} = func ->
-                Callbacks.fire(chain.callbacks, :on_tool_execution_started, [
-                  chain,
-                  tool_call,
-                  func
-                ])
-
-                Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [
-                  chain,
-                  tool_call,
-                  func
-                ])
-
-                result =
-                  execute_tool_call(tool_call, func, verbose: verbose, context: use_context)
-
-                fire_tool_execution_callbacks(chain, tool_call, result)
-
-              nil ->
-                error_msg = "Tool '#{tool_call.name}' not found"
-
-                Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [
-                  chain,
-                  tool_call,
-                  error_msg
-                ])
-
-                ToolResult.new!(%{
-                  tool_call_id: tool_call.call_id,
-                  name: tool_call.name,
-                  content: error_msg,
-                  is_error: true
-                })
-            end
+            dispatch_decided_call(chain, tool_call, use_context, verbose)
 
           :edit ->
             # Execute with edited arguments
             edited_args = Map.get(decision, :arguments, %{})
-
-            case chain._tool_map[tool_call.name] do
-              %Function{} = func ->
-                edited_call = %{tool_call | arguments: edited_args}
-
-                # Fire started callback before execution
-                Callbacks.fire(chain.callbacks, :on_tool_execution_started, [
-                  chain,
-                  edited_call,
-                  func
-                ])
-
-                Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [
-                  chain,
-                  edited_call,
-                  func
-                ])
-
-                result =
-                  execute_tool_call(edited_call, func, verbose: verbose, context: use_context)
-
-                fire_tool_execution_callbacks(chain, edited_call, result)
-
-              nil ->
-                error_msg = "Tool '#{tool_call.name}' not found"
-
-                Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [
-                  chain,
-                  tool_call,
-                  error_msg
-                ])
-
-                ToolResult.new!(%{
-                  tool_call_id: tool_call.call_id,
-                  name: tool_call.name,
-                  content: error_msg,
-                  is_error: true
-                })
-            end
+            edited_call = %{tool_call | arguments: edited_args}
+            dispatch_decided_call(chain, edited_call, use_context, verbose)
 
           :reject ->
             # Create rejection result without executing
@@ -1827,6 +1763,130 @@ defmodule LangChain.Chains.LLMChain do
     end
 
     result
+  end
+
+  # Split reviewed `{call, func}` pairs into the ones cleared to run and the
+  # ToolResults standing in for the ones that were not. A cleared call carries
+  # whatever arguments review left it with.
+  defp partition_reviewed_calls(%LLMChain{} = chain, pairs) do
+    {allowed, results} =
+      Enum.reduce(pairs, {[], []}, fn {call, func}, {allowed, results} ->
+        case review_tool_call(chain, call, func) do
+          {:execute, reviewed_call} ->
+            {[{reviewed_call, func} | allowed], results}
+
+          settled ->
+            {allowed, [reviewed_tool_result(chain, settled, func) | results]}
+        end
+      end)
+
+    {Enum.reverse(allowed), Enum.reverse(results)}
+  end
+
+  # Consult every :on_tool_call_review handler in turn. Argument rewrites thread
+  # forward so a later handler reviews what an earlier one produced; the first
+  # handler to deny or interrupt settles the call and the rest are skipped.
+  defp review_tool_call(%LLMChain{} = chain, %ToolCall{} = call, %Function{} = func) do
+    Callbacks.reduce(
+      chain.callbacks,
+      :on_tool_call_review,
+      {:execute, call},
+      &apply_review_decision(&1, &2, chain, func)
+    )
+  end
+
+  defp apply_review_decision(invoke, {:execute, %ToolCall{} = current} = acc, chain, func) do
+    case invoke.([chain, current, func]) do
+      :ok ->
+        {:cont, acc}
+
+      {:update_arguments, arguments} when is_map(arguments) ->
+        {:cont, {:execute, %ToolCall{current | arguments: arguments}}}
+
+      {:deny, reason} when is_binary(reason) ->
+        {:halt, {:deny, reason, current}}
+
+      {:interrupt, message, interrupt_data} when is_binary(message) ->
+        {:halt, {:interrupt, message, interrupt_data, current}}
+
+      other ->
+        raise LangChainError,
+              "Unexpected :on_tool_call_review result for tool #{inspect(func.name)}. " <>
+                "Expected :ok, {:update_arguments, map}, {:deny, reason}, or " <>
+                "{:interrupt, message, data}. Got: #{inspect(other)}"
+    end
+  end
+
+  # A refusal is a decision about the call, not a fault in it, so it reports
+  # `is_error: false` and leaves the chain's failure counter untouched. A policy
+  # that turns down many calls in a row must not exhaust `max_retry_count`.
+  defp reviewed_tool_result(
+         %LLMChain{} = chain,
+         {:deny, reason, %ToolCall{} = call},
+         %Function{} = func
+       ) do
+    Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [chain, call, reason])
+
+    ToolResult.new!(%{
+      tool_call_id: call.call_id,
+      name: func.name,
+      content: reason,
+      display_text: func.display_text,
+      is_error: false
+    })
+  end
+
+  defp reviewed_tool_result(
+         %LLMChain{},
+         {:interrupt, message, interrupt_data, %ToolCall{} = call},
+         %Function{} = func
+       ) do
+    ToolResult.new!(%{
+      tool_call_id: call.call_id,
+      name: func.name,
+      content: message,
+      display_text: func.display_text,
+      is_interrupt: true,
+      interrupt_data: interrupt_data
+    })
+  end
+
+  # Resolve and run one call that a human decision cleared. Review still
+  # applies: an approval says a person agreed, not that policy did.
+  defp dispatch_decided_call(%LLMChain{} = chain, %ToolCall{} = call, use_context, verbose) do
+    case chain._tool_map[call.name] do
+      %Function{} = func ->
+        case review_tool_call(chain, call, func) do
+          {:execute, reviewed_call} ->
+            Callbacks.fire(chain.callbacks, :on_tool_execution_started, [
+              chain,
+              reviewed_call,
+              func
+            ])
+
+            Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [chain, reviewed_call, func])
+
+            result =
+              execute_tool_call(reviewed_call, func, verbose: verbose, context: use_context)
+
+            fire_tool_execution_callbacks(chain, reviewed_call, result)
+
+          settled ->
+            reviewed_tool_result(chain, settled, func)
+        end
+
+      nil ->
+        error_msg = "Tool '#{call.name}' not found"
+
+        Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [chain, call, error_msg])
+
+        ToolResult.new!(%{
+          tool_call_id: call.call_id,
+          name: call.name,
+          content: error_msg,
+          is_error: true
+        })
+    end
   end
 
   @doc """

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1464,98 +1464,92 @@ defmodule LangChain.Chains.LLMChain do
       use_context = context || chain.custom_context
       verbose = chain.verbose
 
-      # Get all the tools to call. Accumulate them into a map.
-      grouped =
-        Enum.reduce(message.tool_calls, %{async: [], sync: [], invalid: []}, fn call, acc ->
+      # What review handlers are told about the circumstances of the call. On
+      # this path no human has weighed in on it.
+      review_context = %{human_decision: nil, custom_context: use_context}
+
+      # Resolve every tool call to a disposition, keeping the order the model
+      # asked for them in. Review settles a call here, so one it turns away is
+      # never announced as started and never reaches a Task: a refusal leaves
+      # no trace of a tool that appeared to run.
+      dispositions =
+        Enum.map(message.tool_calls, fn call ->
           case chain._tool_map[call.name] do
-            %Function{async: true} = func ->
-              Map.put(acc, :async, acc.async ++ [{call, func}])
+            %Function{} = func ->
+              case review_tool_call(chain, call, func, review_context) do
+                {:execute, reviewed_call} -> {:execute, reviewed_call, func}
+                settled -> {:settled, reviewed_tool_result(chain, settled, func)}
+              end
 
-            %Function{async: false} = func ->
-              Map.put(acc, :sync, acc.sync ++ [{call, func}])
-
-            # invalid tool call
             nil ->
-              Map.put(acc, :invalid, acc.invalid ++ [{call, nil}])
+              {:settled, tool_not_found_result(chain, call)}
           end
         end)
 
-      # Let :on_tool_call_review handlers settle each call first. A call they
-      # turn away is never announced as started and never reaches a Task, so a
-      # refusal leaves no trace of a tool that appeared to run.
-      {async_calls, async_reviewed} = partition_reviewed_calls(chain, grouped[:async])
-      {sync_calls, sync_reviewed} = partition_reviewed_calls(chain, grouped[:sync])
-      reviewed_results = async_reviewed ++ sync_reviewed
+      # Announce every call that is going to run, before any of them does. This
+      # is the ONLY place :on_tool_execution_started fires; :on_tool_call_identified
+      # already fired during streaming. A call review settled is not announced.
+      Enum.each(dispositions, fn
+        {:execute, call, func} ->
+          Callbacks.fire(chain.callbacks, :on_tool_execution_started, [chain, call, func])
 
-      # Fire execution started callbacks for ALL valid tools BEFORE execution
-      # This is the ONLY place :on_tool_execution_started fires (not during streaming detection)
-      # The :on_tool_call_identified callback already fired earlier during streaming
-      # Augment each ToolCall with display_text from Function before firing callback
-      Enum.each(async_calls ++ sync_calls, fn {call, func} ->
-        Callbacks.fire(chain.callbacks, :on_tool_execution_started, [chain, call, func])
+        {:settled, _result} ->
+          :ok
       end)
 
-      # execute all the async calls. This keeps the responses in order too.
-      # Return tuple with call and func for callback firing
-      async_results =
-        async_calls
-        |> Enum.map(fn {call, func} ->
-          # Capture the current OpenTelemetry context in THIS (parent) process. It
-          # lives in the process dictionary and is NOT inherited by a spawned Task,
-          # so without this the async tool's span would orphan into its own root
-          # trace instead of nesting under the chain span. Re-attached inside the
-          # Task below. No-op (returns nil) when OTel isn't loaded or set up.
-          otel_ctx = capture_otel_context()
+      # Start a Task for each async call, leaving it in the slot its call
+      # occupies. Everything downstream stays in call order as a result.
+      spawned =
+        Enum.map(dispositions, fn
+          {:execute, call, %Function{async: true} = func} ->
+            # Capture the current OpenTelemetry context in THIS (parent) process. It
+            # lives in the process dictionary and is NOT inherited by a spawned Task,
+            # so without this the async tool's span would orphan into its own root
+            # trace instead of nesting under the chain span. Re-attached inside the
+            # Task below. No-op (returns nil) when OTel isn't loaded or set up.
+            otel_ctx = capture_otel_context()
 
-          Task.async(fn ->
-            # Re-attach the parent OTel context before anything telemetry-bearing
-            # runs, so the tool-call span (opened inside execute_tool_call) and any
-            # callback work parent correctly.
-            attach_otel_context(otel_ctx)
+            task =
+              Task.async(fn ->
+                # Re-attach the parent OTel context before anything telemetry-bearing
+                # runs, so the tool-call span (opened inside execute_tool_call) and any
+                # callback work parent correctly.
+                attach_otel_context(otel_ctx)
 
-            # Fires inside the spawned Task so handlers (e.g. tenancy/OTel
-            # propagation) can re-apply per-process state before the tool runs.
-            Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [chain, call, func])
-            result = execute_tool_call(call, func, verbose: verbose, context: use_context)
-            {call, func, result}
-          end)
+                # Fires inside the spawned Task so handlers (e.g. tenancy/OTel
+                # propagation) can re-apply per-process state before the tool runs.
+                Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [chain, call, func])
+                execute_tool_call(call, func, verbose: verbose, context: use_context)
+              end)
+
+            {:await, call, task}
+
+          disposition ->
+            disposition
         end)
+
+      # One shared deadline covers the whole async batch, and it is awaited
+      # before any sync tool runs.
+      awaited =
+        for({:await, _call, task} <- spawned, do: task)
         |> Task.await_many(chain.async_tool_timeout || default_async_tool_timeout())
 
-      # Fire completed/failed callbacks for async tools and extract results
-      async_tool_results =
-        Enum.map(async_results, fn {call, _func, result} ->
-          fire_tool_execution_callbacks(chain, call, result)
+      # Walk the slots in call order, taking each async result off the awaited
+      # list and running each sync call in place. The empty accumulator match
+      # holds the two lists to the same length.
+      {combined_results, []} =
+        Enum.map_reduce(spawned, awaited, fn
+          {:await, call, _task}, [result | rest] ->
+            {fire_tool_execution_callbacks(chain, call, result), rest}
+
+          {:execute, call, func}, rest ->
+            Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [chain, call, func])
+            result = execute_tool_call(call, func, verbose: verbose, context: use_context)
+            {fire_tool_execution_callbacks(chain, call, result), rest}
+
+          {:settled, result}, rest ->
+            {result, rest}
         end)
-
-      # Execute sync tools with immediate callbacks
-      sync_tool_results =
-        Enum.map(sync_calls, fn {call, func} ->
-          Callbacks.fire(chain.callbacks, :on_tool_pre_execution, [chain, call, func])
-          result = execute_tool_call(call, func, verbose: verbose, context: use_context)
-
-          fire_tool_execution_callbacks(chain, call, result)
-        end)
-
-      # log invalid tool calls (can't augment - no func available)
-      invalid_calls =
-        Enum.map(grouped[:invalid], fn {call, _} ->
-          text = "Tool call made to #{call.name} but tool not found"
-          Logger.warning(text)
-
-          # Fire failed callback for invalid tools
-          Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [chain, call, text])
-
-          ToolResult.new!(%{
-            tool_call_id: call.call_id,
-            name: call.name,
-            content: text,
-            is_error: true
-          })
-        end)
-
-      combined_results =
-        async_tool_results ++ sync_tool_results ++ reviewed_results ++ invalid_calls
 
       # Fire interrupt callback if any tools interrupted
       interrupted_results = Enum.filter(combined_results, & &1.is_interrupt)
@@ -1604,6 +1598,12 @@ defmodule LangChain.Chains.LLMChain do
   - `:edit` - Execute the tool with modified arguments from the decision
   - `:reject` - Create an error result without executing the tool
 
+  An approved or edited call is still put to any `:on_tool_call_review`
+  handlers, which are told the decision the person made. A person agreeing to a
+  call is not the same as policy agreeing to it, and a handler that escalated the
+  call to them reads the decision to recognize the answer coming back. A rejected
+  call is not reviewed, since it does not run.
+
   Returns the updated chain with tool results added and callbacks fired.
 
   ## Parameters
@@ -1637,13 +1637,13 @@ defmodule LangChain.Chains.LLMChain do
       |> Enum.map(fn {tool_call, decision} ->
         case decision.type do
           :approve ->
-            dispatch_decided_call(chain, tool_call, use_context, verbose)
+            dispatch_decided_call(chain, tool_call, use_context, verbose, :approve)
 
           :edit ->
             # Execute with edited arguments
             edited_args = Map.get(decision, :arguments, %{})
             edited_call = %{tool_call | arguments: edited_args}
-            dispatch_decided_call(chain, edited_call, use_context, verbose)
+            dispatch_decided_call(chain, edited_call, use_context, verbose, :edit)
 
           :reject ->
             # Create rejection result without executing
@@ -1765,38 +1765,47 @@ defmodule LangChain.Chains.LLMChain do
     result
   end
 
-  # Split reviewed `{call, func}` pairs into the ones cleared to run and the
-  # ToolResults standing in for the ones that were not. A cleared call carries
-  # whatever arguments review left it with.
-  defp partition_reviewed_calls(%LLMChain{} = chain, pairs) do
-    {allowed, results} =
-      Enum.reduce(pairs, {[], []}, fn {call, func}, {allowed, results} ->
-        case review_tool_call(chain, call, func) do
-          {:execute, reviewed_call} ->
-            {[{reviewed_call, func} | allowed], results}
+  # A call naming a tool the chain does not have. Review never sees it: there is
+  # no Function to hand a handler, so there is nothing to allow or deny.
+  defp tool_not_found_result(%LLMChain{} = chain, %ToolCall{} = call) do
+    text = "Tool call made to #{call.name} but tool not found"
+    Logger.warning(text)
 
-          settled ->
-            {allowed, [reviewed_tool_result(chain, settled, func) | results]}
-        end
-      end)
+    Callbacks.fire(chain.callbacks, :on_tool_execution_failed, [chain, call, text])
 
-    {Enum.reverse(allowed), Enum.reverse(results)}
+    ToolResult.new!(%{
+      tool_call_id: call.call_id,
+      name: call.name,
+      content: text,
+      is_error: true
+    })
   end
 
   # Consult every :on_tool_call_review handler in turn. Argument rewrites thread
   # forward so a later handler reviews what an earlier one produced; the first
   # handler to deny or interrupt settles the call and the rest are skipped.
-  defp review_tool_call(%LLMChain{} = chain, %ToolCall{} = call, %Function{} = func) do
+  defp review_tool_call(
+         %LLMChain{} = chain,
+         %ToolCall{} = call,
+         %Function{} = func,
+         review_context
+       ) do
     Callbacks.reduce(
       chain.callbacks,
       :on_tool_call_review,
       {:execute, call},
-      &apply_review_decision(&1, &2, chain, func)
+      &apply_review_decision(&1, &2, chain, func, review_context)
     )
   end
 
-  defp apply_review_decision(invoke, {:execute, %ToolCall{} = current} = acc, chain, func) do
-    case invoke.([chain, current, func]) do
+  defp apply_review_decision(
+         invoke,
+         {:execute, %ToolCall{} = current} = acc,
+         chain,
+         func,
+         review_context
+       ) do
+    case invoke.([chain, current, func, review_context]) do
       :ok ->
         {:cont, acc}
 
@@ -1812,8 +1821,9 @@ defmodule LangChain.Chains.LLMChain do
       other ->
         raise LangChainError,
               "Unexpected :on_tool_call_review result for tool #{inspect(func.name)}. " <>
-                "Expected :ok, {:update_arguments, map}, {:deny, reason}, or " <>
-                "{:interrupt, message, data}. Got: #{inspect(other)}"
+                "Expected :ok, {:update_arguments, map}, {:deny, reason} with a " <>
+                "string reason, or {:interrupt, message, data} with a string " <>
+                "message. Got: #{inspect(other)}"
     end
   end
 
@@ -1852,11 +1862,21 @@ defmodule LangChain.Chains.LLMChain do
   end
 
   # Resolve and run one call that a human decision cleared. Review still
-  # applies: an approval says a person agreed, not that policy did.
-  defp dispatch_decided_call(%LLMChain{} = chain, %ToolCall{} = call, use_context, verbose) do
+  # applies: an approval says a person agreed, not that policy did. The decision
+  # is passed on so a handler that escalated to a human can recognize the
+  # answer coming back and stand aside rather than escalating the same call again.
+  defp dispatch_decided_call(
+         %LLMChain{} = chain,
+         %ToolCall{} = call,
+         use_context,
+         verbose,
+         human_decision
+       ) do
     case chain._tool_map[call.name] do
       %Function{} = func ->
-        case review_tool_call(chain, call, func) do
+        review_context = %{human_decision: human_decision, custom_context: use_context}
+
+        case review_tool_call(chain, call, func, review_context) do
           {:execute, reviewed_call} ->
             Callbacks.fire(chain.callbacks, :on_tool_execution_started, [
               chain,

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -1599,10 +1599,10 @@ defmodule LangChain.Chains.LLMChain do
   - `:reject` - Create an error result without executing the tool
 
   An approved or edited call is still put to any `:on_tool_call_review`
-  handlers, which are told the decision the person made. A person agreeing to a
-  call is not the same as policy agreeing to it, and a handler that escalated the
-  call to them reads the decision to recognize the answer coming back. A rejected
-  call is not reviewed, since it does not run.
+  handlers, which are told the answer the user gave. A user agreeing to a call is
+  not the same as policy agreeing to it, and a handler that asked the user about
+  the call reads the answer to know not to ask again. A rejected call is not
+  reviewed, since it does not run.
 
   Returns the updated chain with tool results added and callbacks fired.
 

--- a/test/chains/llm_chain_tool_call_review_test.exs
+++ b/test/chains/llm_chain_tool_call_review_test.exs
@@ -535,6 +535,71 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
       assert text(resumed) == "shipped"
     end
 
+    test "a standing answer carried in the context stops the asking" do
+      # The handler asks about a call unless the tool is already on a list the
+      # user has agreed to. The list rides on custom_context, so a host that
+      # records "always allow this" rebuilds the chain with the tool added.
+      handler = %{
+        on_tool_call_review: fn _chain, call, _func, review ->
+          cond do
+            review.human_decision -> :ok
+            call.name in review.custom_context.always_allow -> :ok
+            true -> {:interrupt, "Run #{call.name}?", %{tool: call.name}}
+          end
+        end
+      }
+
+      ask = fn always_allow ->
+        [tool(self())]
+        |> chain_with([handler])
+        |> Map.put(:custom_context, %{always_allow: always_allow})
+        |> with_call()
+        |> LLMChain.execute_tool_calls()
+        |> only_result()
+      end
+
+      first = ask.([])
+      assert first.is_interrupt
+      assert first.interrupt_data == %{tool: "ship_order"}
+      refute_received {:tool_ran, _}
+
+      # The user answers "always allow this one", the host records it, and the
+      # next call of that tool runs without being asked about again.
+      later = ask.(["ship_order"])
+      refute later.is_interrupt
+      assert_received {:tool_ran, _}
+      assert text(later) == "shipped"
+    end
+
+    test "a batch is reviewed before any of it is asked about" do
+      # Every call is settled before the first interrupt reaches anyone, so an
+      # answer to one of them cannot spare its siblings in the same batch.
+      handler = %{
+        on_tool_call_review: fn _chain, call, _func, _review ->
+          {:interrupt, "Run #{call.name}?", %{tool: call.name}}
+        end
+      }
+
+      message =
+        Message.new_assistant!(%{
+          content: "calling",
+          tool_calls: [
+            ToolCall.new!(%{call_id: "call_1", name: "ship_order", arguments: %{}}),
+            ToolCall.new!(%{call_id: "call_2", name: "ship_order", arguments: %{}})
+          ]
+        })
+
+      chain =
+        [tool(self())]
+        |> chain_with([handler])
+        |> LLMChain.add_message(message)
+
+      assert [first, second] = LLMChain.execute_tool_calls(chain).last_message.tool_results
+      assert first.is_interrupt
+      assert second.is_interrupt
+      refute_received {:tool_ran, _}
+    end
+
     test "carries the context the tool will actually run with" do
       test_pid = self()
 

--- a/test/chains/llm_chain_tool_call_review_test.exs
+++ b/test/chains/llm_chain_tool_call_review_test.exs
@@ -1,0 +1,371 @@
+defmodule LangChain.Chains.LLMChainToolCallReviewTest do
+  use ExUnit.Case
+
+  alias LangChain.Chains.LLMChain
+  alias LangChain.{Function, LangChainError, Message}
+  alias LangChain.Message.{ContentPart, ToolCall}
+  alias LangChain.ChatModels.ChatAnthropic
+
+  defp tool(test_pid, opts \\ []) do
+    Function.new!(%{
+      name: Keyword.get(opts, :name, "ship_order"),
+      description: "Ships an order",
+      display_text: "Shipping the order",
+      async: Keyword.get(opts, :async, false),
+      parameters_schema: %{type: "object", properties: %{}},
+      function: fn args, _ctx ->
+        send(test_pid, {:tool_ran, args})
+        {:ok, "shipped"}
+      end
+    })
+  end
+
+  defp chain_with(tools, callbacks) do
+    LLMChain.new!(%{
+      llm: ChatAnthropic.new!(%{model: "claude-sonnet-4-5-20250929"}),
+      tools: List.wrap(tools),
+      callbacks: callbacks
+    })
+  end
+
+  defp with_call(chain, arguments \\ %{"amount" => 5000}, name \\ "ship_order") do
+    LLMChain.add_message(
+      chain,
+      Message.new_assistant!(%{
+        content: "calling",
+        tool_calls: [ToolCall.new!(%{call_id: "call_1", name: name, arguments: arguments})]
+      })
+    )
+  end
+
+  defp only_result(%LLMChain{} = chain) do
+    [result] = chain.last_message.tool_results
+    result
+  end
+
+  defp text(%{content: [%ContentPart{content: text}]}), do: text
+
+  describe "review decisions" do
+    test ":ok lets the call through untouched" do
+      chain =
+        [tool(self())]
+        |> chain_with([%{on_tool_call_review: fn _chain, _call, _func -> :ok end}])
+        |> with_call()
+
+      result = LLMChain.execute_tool_calls(chain) |> only_result()
+
+      assert_received {:tool_ran, %{"amount" => 5000}}
+      assert text(result) == "shipped"
+      refute result.is_error
+    end
+
+    test "a chain with no review handler behaves as before" do
+      chain = [tool(self())] |> chain_with([]) |> with_call()
+
+      result = LLMChain.execute_tool_calls(chain) |> only_result()
+
+      assert_received {:tool_ran, %{"amount" => 5000}}
+      assert text(result) == "shipped"
+    end
+
+    test "{:deny, reason} keeps the tool from running and returns the reason" do
+      handler = %{
+        on_tool_call_review: fn _chain, _call, _func -> {:deny, "over the store limit"} end
+      }
+
+      chain = [tool(self())] |> chain_with([handler]) |> with_call()
+
+      result = LLMChain.execute_tool_calls(chain) |> only_result()
+
+      refute_received {:tool_ran, _}
+      assert text(result) == "over the store limit"
+      assert result.tool_call_id == "call_1"
+      assert result.name == "ship_order"
+      assert result.display_text == "Shipping the order"
+    end
+
+    test "a denial is not an error and leaves the failure counter alone" do
+      handler = %{on_tool_call_review: fn _chain, _call, _func -> {:deny, "no"} end}
+
+      chain =
+        [tool(self())]
+        |> chain_with([handler])
+        |> LLMChain.increment_current_failure_count()
+        |> with_call()
+
+      assert chain.current_failure_count == 1
+
+      updated = LLMChain.execute_tool_calls(chain)
+
+      refute only_result(updated).is_error
+      assert updated.current_failure_count == 0
+    end
+
+    test "{:update_arguments, args} rewrites what the tool receives" do
+      handler = %{
+        on_tool_call_review: fn _chain, call, _func ->
+          {:update_arguments, Map.put(call.arguments, "warehouse", "EU-1")}
+        end
+      }
+
+      chain = [tool(self())] |> chain_with([handler]) |> with_call()
+
+      LLMChain.execute_tool_calls(chain)
+
+      assert_received {:tool_ran, %{"amount" => 5000, "warehouse" => "EU-1"}}
+    end
+
+    test "{:interrupt, message, data} settles the call as an interrupt" do
+      handler = %{
+        on_tool_call_review: fn _chain, _call, _func ->
+          {:interrupt, "needs a manager", %{approver: "manager"}}
+        end
+      }
+
+      chain = [tool(self())] |> chain_with([handler]) |> with_call()
+
+      result = LLMChain.execute_tool_calls(chain) |> only_result()
+
+      refute_received {:tool_ran, _}
+      assert result.is_interrupt
+      assert result.interrupt_data == %{approver: "manager"}
+      assert text(result) == "needs a manager"
+    end
+
+    test "an unrecognized return value raises with the tool named" do
+      handler = %{on_tool_call_review: fn _chain, _call, _func -> :maybe end}
+
+      chain = [tool(self())] |> chain_with([handler]) |> with_call()
+
+      assert_raise LangChainError,
+                   ~r/Unexpected :on_tool_call_review result for tool "ship_order"/,
+                   fn ->
+                     LLMChain.execute_tool_calls(chain)
+                   end
+    end
+  end
+
+  describe "review runs before anything is announced" do
+    test "a denied call never fires on_tool_execution_started" do
+      test_pid = self()
+
+      handlers = [
+        %{
+          on_tool_call_review: fn _chain, _call, _func -> {:deny, "no"} end,
+          on_tool_execution_started: fn _chain, call, _func ->
+            send(test_pid, {:started, call.name})
+          end,
+          on_tool_execution_failed: fn _chain, call, reason ->
+            send(test_pid, {:failed, call.name, reason})
+          end
+        }
+      ]
+
+      chain = [tool(self())] |> chain_with(handlers) |> with_call()
+
+      LLMChain.execute_tool_calls(chain)
+
+      refute_received {:started, _}
+      assert_received {:failed, "ship_order", "no"}
+    end
+
+    test "an async tool is denied without spawning its Task" do
+      handler = %{on_tool_call_review: fn _chain, _call, _func -> {:deny, "no"} end}
+
+      chain =
+        [tool(self(), async: true)]
+        |> chain_with([handler])
+        |> with_call()
+
+      result = LLMChain.execute_tool_calls(chain) |> only_result()
+
+      refute_received {:tool_ran, _}
+      assert text(result) == "no"
+    end
+
+    test "on_tool_execution_started still fires for a call review allows" do
+      test_pid = self()
+
+      handlers = [
+        %{
+          on_tool_call_review: fn _chain, _call, _func -> :ok end,
+          on_tool_execution_started: fn _chain, call, _func ->
+            send(test_pid, {:started, call.name})
+          end
+        }
+      ]
+
+      chain = [tool(self())] |> chain_with(handlers) |> with_call()
+
+      LLMChain.execute_tool_calls(chain)
+
+      assert_received {:started, "ship_order"}
+    end
+  end
+
+  describe "several handlers" do
+    test "argument rewrites thread forward into the next handler" do
+      test_pid = self()
+
+      first = %{
+        on_tool_call_review: fn _chain, call, _func ->
+          {:update_arguments, Map.put(call.arguments, "step", ["first"])}
+        end
+      }
+
+      second = %{
+        on_tool_call_review: fn _chain, call, _func ->
+          send(test_pid, {:second_saw, call.arguments})
+          {:update_arguments, Map.update!(call.arguments, "step", &(&1 ++ ["second"]))}
+        end
+      }
+
+      chain = [tool(self())] |> chain_with([first, second]) |> with_call()
+
+      LLMChain.execute_tool_calls(chain)
+
+      assert_received {:second_saw, %{"step" => ["first"]}}
+      assert_received {:tool_ran, %{"step" => ["first", "second"]}}
+    end
+
+    test "the first denial settles the call and later handlers are skipped" do
+      test_pid = self()
+
+      first = %{on_tool_call_review: fn _chain, _call, _func -> {:deny, "first says no"} end}
+
+      second = %{
+        on_tool_call_review: fn _chain, _call, _func ->
+          send(test_pid, :second_consulted)
+          :ok
+        end
+      }
+
+      chain = [tool(self())] |> chain_with([first, second]) |> with_call()
+
+      result = LLMChain.execute_tool_calls(chain) |> only_result()
+
+      refute_received :second_consulted
+      assert text(result) == "first says no"
+    end
+  end
+
+  describe "a batch of calls" do
+    test "denying one call leaves the others running, one result per call" do
+      test_pid = self()
+
+      keep =
+        Function.new!(%{
+          name: "keep",
+          description: "runs",
+          parameters_schema: %{type: "object", properties: %{}},
+          function: fn _args, _ctx ->
+            send(test_pid, :keep_ran)
+            {:ok, "kept"}
+          end
+        })
+
+      handler = %{
+        on_tool_call_review: fn _chain, call, _func ->
+          if call.name == "ship_order", do: {:deny, "no shipping"}, else: :ok
+        end
+      }
+
+      message =
+        Message.new_assistant!(%{
+          content: "calling",
+          tool_calls: [
+            ToolCall.new!(%{call_id: "call_1", name: "ship_order", arguments: %{}}),
+            ToolCall.new!(%{call_id: "call_2", name: "keep", arguments: %{}})
+          ]
+        })
+
+      chain =
+        [tool(self()), keep]
+        |> chain_with([handler])
+        |> LLMChain.add_message(message)
+
+      results = LLMChain.execute_tool_calls(chain).last_message.tool_results
+
+      assert_received :keep_ran
+      refute_received {:tool_ran, _}
+
+      assert length(results) == 2
+      assert MapSet.new(results, & &1.tool_call_id) == MapSet.new(["call_1", "call_2"])
+
+      denied = Enum.find(results, &(&1.tool_call_id == "call_1"))
+      assert text(denied) == "no shipping"
+    end
+  end
+
+  describe "the human-decision path" do
+    defp decided(chain, decisions) do
+      tool_calls = chain.last_message.tool_calls
+      LLMChain.execute_tool_calls_with_decisions(chain, tool_calls, decisions)
+    end
+
+    test "an approved call is still reviewed and can be denied" do
+      handler = %{
+        on_tool_call_review: fn _chain, _call, _func -> {:deny, "store policy still says no"} end
+      }
+
+      chain = [tool(self())] |> chain_with([handler]) |> with_call()
+
+      result = decided(chain, [%{type: :approve}]) |> only_result()
+
+      refute_received {:tool_ran, _}
+      assert text(result) == "store policy still says no"
+    end
+
+    test "an edited call is reviewed with the edited arguments" do
+      test_pid = self()
+
+      handler = %{
+        on_tool_call_review: fn _chain, call, _func ->
+          send(test_pid, {:reviewed, call.arguments})
+          :ok
+        end
+      }
+
+      chain = [tool(self())] |> chain_with([handler]) |> with_call()
+
+      decided(chain, [%{type: :edit, arguments: %{"amount" => 10}}])
+
+      assert_received {:reviewed, %{"amount" => 10}}
+      assert_received {:tool_ran, %{"amount" => 10}}
+    end
+
+    test "review can rewrite arguments on an approved call" do
+      handler = %{
+        on_tool_call_review: fn _chain, call, _func ->
+          {:update_arguments, Map.put(call.arguments, "warehouse", "EU-1")}
+        end
+      }
+
+      chain = [tool(self())] |> chain_with([handler]) |> with_call()
+
+      decided(chain, [%{type: :approve}])
+
+      assert_received {:tool_ran, %{"amount" => 5000, "warehouse" => "EU-1"}}
+    end
+
+    test "an unknown tool still reports not found" do
+      chain = [tool(self())] |> chain_with([]) |> with_call(%{}, "ship_order")
+
+      unknown = %{(chain.last_message.tool_calls |> hd()) | name: "nope"}
+      updated = LLMChain.execute_tool_calls_with_decisions(chain, [unknown], [%{type: :approve}])
+
+      result = only_result(updated)
+      assert result.is_error
+      assert text(result) =~ "not found"
+    end
+
+    test "a rejected call is unchanged by review" do
+      chain = [tool(self())] |> chain_with([]) |> with_call()
+
+      result = decided(chain, [%{type: :reject}]) |> only_result()
+
+      refute_received {:tool_ran, _}
+      assert text(result) =~ "rejected by a human reviewer"
+    end
+  end
+end

--- a/test/chains/llm_chain_tool_call_review_test.exs
+++ b/test/chains/llm_chain_tool_call_review_test.exs
@@ -49,7 +49,7 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
     test ":ok lets the call through untouched" do
       chain =
         [tool(self())]
-        |> chain_with([%{on_tool_call_review: fn _chain, _call, _func -> :ok end}])
+        |> chain_with([%{on_tool_call_review: fn _chain, _call, _func, _review -> :ok end}])
         |> with_call()
 
       result = LLMChain.execute_tool_calls(chain) |> only_result()
@@ -70,7 +70,9 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
 
     test "{:deny, reason} keeps the tool from running and returns the reason" do
       handler = %{
-        on_tool_call_review: fn _chain, _call, _func -> {:deny, "over the store limit"} end
+        on_tool_call_review: fn _chain, _call, _func, _review ->
+          {:deny, "over the store limit"}
+        end
       }
 
       chain = [tool(self())] |> chain_with([handler]) |> with_call()
@@ -85,7 +87,7 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
     end
 
     test "a denial is not an error and leaves the failure counter alone" do
-      handler = %{on_tool_call_review: fn _chain, _call, _func -> {:deny, "no"} end}
+      handler = %{on_tool_call_review: fn _chain, _call, _func, _review -> {:deny, "no"} end}
 
       chain =
         [tool(self())]
@@ -103,7 +105,7 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
 
     test "{:update_arguments, args} rewrites what the tool receives" do
       handler = %{
-        on_tool_call_review: fn _chain, call, _func ->
+        on_tool_call_review: fn _chain, call, _func, _review ->
           {:update_arguments, Map.put(call.arguments, "warehouse", "EU-1")}
         end
       }
@@ -117,7 +119,7 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
 
     test "{:interrupt, message, data} settles the call as an interrupt" do
       handler = %{
-        on_tool_call_review: fn _chain, _call, _func ->
+        on_tool_call_review: fn _chain, _call, _func, _review ->
           {:interrupt, "needs a manager", %{approver: "manager"}}
         end
       }
@@ -133,7 +135,7 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
     end
 
     test "an unrecognized return value raises with the tool named" do
-      handler = %{on_tool_call_review: fn _chain, _call, _func -> :maybe end}
+      handler = %{on_tool_call_review: fn _chain, _call, _func, _review -> :maybe end}
 
       chain = [tool(self())] |> chain_with([handler]) |> with_call()
 
@@ -151,7 +153,7 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
 
       handlers = [
         %{
-          on_tool_call_review: fn _chain, _call, _func -> {:deny, "no"} end,
+          on_tool_call_review: fn _chain, _call, _func, _review -> {:deny, "no"} end,
           on_tool_execution_started: fn _chain, call, _func ->
             send(test_pid, {:started, call.name})
           end,
@@ -170,7 +172,7 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
     end
 
     test "an async tool is denied without spawning its Task" do
-      handler = %{on_tool_call_review: fn _chain, _call, _func -> {:deny, "no"} end}
+      handler = %{on_tool_call_review: fn _chain, _call, _func, _review -> {:deny, "no"} end}
 
       chain =
         [tool(self(), async: true)]
@@ -188,7 +190,7 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
 
       handlers = [
         %{
-          on_tool_call_review: fn _chain, _call, _func -> :ok end,
+          on_tool_call_review: fn _chain, _call, _func, _review -> :ok end,
           on_tool_execution_started: fn _chain, call, _func ->
             send(test_pid, {:started, call.name})
           end
@@ -208,13 +210,13 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
       test_pid = self()
 
       first = %{
-        on_tool_call_review: fn _chain, call, _func ->
+        on_tool_call_review: fn _chain, call, _func, _review ->
           {:update_arguments, Map.put(call.arguments, "step", ["first"])}
         end
       }
 
       second = %{
-        on_tool_call_review: fn _chain, call, _func ->
+        on_tool_call_review: fn _chain, call, _func, _review ->
           send(test_pid, {:second_saw, call.arguments})
           {:update_arguments, Map.update!(call.arguments, "step", &(&1 ++ ["second"]))}
         end
@@ -231,10 +233,12 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
     test "the first denial settles the call and later handlers are skipped" do
       test_pid = self()
 
-      first = %{on_tool_call_review: fn _chain, _call, _func -> {:deny, "first says no"} end}
+      first = %{
+        on_tool_call_review: fn _chain, _call, _func, _review -> {:deny, "first says no"} end
+      }
 
       second = %{
-        on_tool_call_review: fn _chain, _call, _func ->
+        on_tool_call_review: fn _chain, _call, _func, _review ->
           send(test_pid, :second_consulted)
           :ok
         end
@@ -265,7 +269,7 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
         })
 
       handler = %{
-        on_tool_call_review: fn _chain, call, _func ->
+        on_tool_call_review: fn _chain, call, _func, _review ->
           if call.name == "ship_order", do: {:deny, "no shipping"}, else: :ok
         end
       }
@@ -305,7 +309,9 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
 
     test "an approved call is still reviewed and can be denied" do
       handler = %{
-        on_tool_call_review: fn _chain, _call, _func -> {:deny, "store policy still says no"} end
+        on_tool_call_review: fn _chain, _call, _func, _review ->
+          {:deny, "store policy still says no"}
+        end
       }
 
       chain = [tool(self())] |> chain_with([handler]) |> with_call()
@@ -320,7 +326,7 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
       test_pid = self()
 
       handler = %{
-        on_tool_call_review: fn _chain, call, _func ->
+        on_tool_call_review: fn _chain, call, _func, _review ->
           send(test_pid, {:reviewed, call.arguments})
           :ok
         end
@@ -336,7 +342,7 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
 
     test "review can rewrite arguments on an approved call" do
       handler = %{
-        on_tool_call_review: fn _chain, call, _func ->
+        on_tool_call_review: fn _chain, call, _func, _review ->
           {:update_arguments, Map.put(call.arguments, "warehouse", "EU-1")}
         end
       }
@@ -366,6 +372,180 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
 
       refute_received {:tool_ran, _}
       assert text(result) =~ "rejected by a human reviewer"
+    end
+  end
+
+  describe "the order results come back in" do
+    defp named_tool(test_pid, name, opts \\ []) do
+      Function.new!(%{
+        name: name,
+        description: "does #{name}",
+        async: Keyword.get(opts, :async, false),
+        parameters_schema: %{type: "object", properties: %{}},
+        function: fn _args, _ctx ->
+          send(test_pid, {:ran, name})
+          {:ok, "did #{name}"}
+        end
+      })
+    end
+
+    defp call_all(chain, names) do
+      calls =
+        names
+        |> Enum.with_index(1)
+        |> Enum.map(fn {name, index} ->
+          ToolCall.new!(%{call_id: "call_#{index}", name: name, arguments: %{}})
+        end)
+
+      LLMChain.add_message(
+        chain,
+        Message.new_assistant!(%{content: "calling", tool_calls: calls})
+      )
+    end
+
+    defp result_ids(%LLMChain{} = chain) do
+      Enum.map(chain.last_message.tool_results, & &1.tool_call_id)
+    end
+
+    test "a denied call keeps the slot its call had" do
+      handler = %{
+        on_tool_call_review: fn _chain, call, _func, _review ->
+          if call.name == "b", do: {:deny, "not b"}, else: :ok
+        end
+      }
+
+      chain =
+        [named_tool(self(), "a"), named_tool(self(), "b"), named_tool(self(), "c")]
+        |> chain_with([handler])
+        |> call_all(["a", "b", "c"])
+
+      assert result_ids(LLMChain.execute_tool_calls(chain)) == ["call_1", "call_2", "call_3"]
+    end
+
+    test "async and sync tools answer in call order" do
+      chain =
+        [
+          named_tool(self(), "s1"),
+          named_tool(self(), "a1", async: true),
+          named_tool(self(), "s2")
+        ]
+        |> chain_with([])
+        |> call_all(["s1", "a1", "s2"])
+
+      assert result_ids(LLMChain.execute_tool_calls(chain)) == ["call_1", "call_2", "call_3"]
+    end
+
+    test "a call naming an unknown tool keeps its slot too" do
+      chain =
+        [named_tool(self(), "a"), named_tool(self(), "c")]
+        |> chain_with([])
+        |> call_all(["a", "nope", "c"])
+
+      updated = LLMChain.execute_tool_calls(chain)
+
+      assert result_ids(updated) == ["call_1", "call_2", "call_3"]
+      assert [_a, missing, _c] = updated.last_message.tool_results
+      assert missing.is_error
+    end
+  end
+
+  describe "the review context" do
+    test "reports no human decision when the model's call runs directly" do
+      test_pid = self()
+
+      handler = %{
+        on_tool_call_review: fn _chain, _call, _func, review ->
+          send(test_pid, {:review_context, review})
+          :ok
+        end
+      }
+
+      chain = [tool(self())] |> chain_with([handler]) |> with_call()
+
+      LLMChain.execute_tool_calls(chain)
+
+      assert_received {:review_context, %{human_decision: nil}}
+    end
+
+    test "names the decision a human made on an approved call" do
+      test_pid = self()
+
+      handler = %{
+        on_tool_call_review: fn _chain, _call, _func, review ->
+          send(test_pid, {:review_context, review})
+          :ok
+        end
+      }
+
+      chain = [tool(self())] |> chain_with([handler]) |> with_call()
+
+      decided(chain, [%{type: :approve}])
+
+      assert_received {:review_context, %{human_decision: :approve}}
+    end
+
+    test "names the decision a human made on an edited call" do
+      test_pid = self()
+
+      handler = %{
+        on_tool_call_review: fn _chain, _call, _func, review ->
+          send(test_pid, {:review_context, review})
+          :ok
+        end
+      }
+
+      chain = [tool(self())] |> chain_with([handler]) |> with_call()
+
+      decided(chain, [%{type: :edit, arguments: %{"amount" => 1}}])
+
+      assert_received {:review_context, %{human_decision: :edit}}
+    end
+
+    test "an escalation stands aside once a human has answered it" do
+      # A handler that escalates every call it has not yet heard back about.
+      # The decision in the review context is what lets it recognize the answer
+      # and let the call through instead of escalating it a second time.
+      handler = %{
+        on_tool_call_review: fn _chain, _call, _func, review ->
+          case review.human_decision do
+            nil -> {:interrupt, "a manager has to approve this", %{reason: :over_limit}}
+            _decided -> :ok
+          end
+        end
+      }
+
+      chain = [tool(self())] |> chain_with([handler]) |> with_call()
+
+      escalated = LLMChain.execute_tool_calls(chain) |> only_result()
+      assert escalated.is_interrupt
+      assert escalated.interrupt_data == %{reason: :over_limit}
+      refute_received {:tool_ran, _}
+
+      resumed = decided(chain, [%{type: :approve}]) |> only_result()
+      refute resumed.is_interrupt
+      assert_received {:tool_ran, _}
+      assert text(resumed) == "shipped"
+    end
+
+    test "carries the context the tool will actually run with" do
+      test_pid = self()
+
+      handler = %{
+        on_tool_call_review: fn _chain, _call, _func, review ->
+          send(test_pid, {:review_context, review})
+          :ok
+        end
+      }
+
+      chain =
+        [tool(self())]
+        |> chain_with([handler])
+        |> Map.put(:custom_context, %{tenant: "default"})
+        |> with_call()
+
+      LLMChain.execute_tool_calls(chain, %{tenant: "override"})
+
+      assert_received {:review_context, %{custom_context: %{tenant: "override"}}}
     end
   end
 end

--- a/test/chains/llm_chain_tool_call_review_test.exs
+++ b/test/chains/llm_chain_tool_call_review_test.exs
@@ -501,30 +501,30 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
       assert_received {:review_context, %{human_decision: :edit}}
     end
 
-    test "an escalation stands aside once a human has answered it" do
-      # A handler that escalates every call it has not yet heard back about.
-      # The decision in the review context is what lets it recognize the answer
-      # and let the call through instead of escalating it a second time.
+    test "a handler stops asking once the user has answered" do
+      # A handler that asks about every call it has not yet heard back about.
+      # The answer in the review context is what lets it recognize the reply and
+      # let the call through instead of asking the same question again.
       handler = %{
         on_tool_call_review: fn _chain, _call, _func, review ->
           case review.human_decision do
-            nil -> {:interrupt, "a manager has to approve this", %{reason: :over_limit}}
-            _decided -> :ok
+            nil -> {:interrupt, "confirm before this runs", %{reason: :over_limit}}
+            _answered -> :ok
           end
         end
       }
 
       chain = [tool(self())] |> chain_with([handler]) |> with_call()
 
-      escalated = LLMChain.execute_tool_calls(chain) |> only_result()
-      assert escalated.is_interrupt
-      assert escalated.interrupt_data == %{reason: :over_limit}
-      assert text(escalated) == "a manager has to approve this"
-      assert escalated.tool_call_id == "call_1"
-      assert escalated.name == "ship_order"
-      assert escalated.display_text == "Shipping the order"
+      asked = LLMChain.execute_tool_calls(chain) |> only_result()
+      assert asked.is_interrupt
+      assert asked.interrupt_data == %{reason: :over_limit}
+      assert text(asked) == "confirm before this runs"
+      assert asked.tool_call_id == "call_1"
+      assert asked.name == "ship_order"
+      assert asked.display_text == "Shipping the order"
       # A call held for a person is not a call that failed.
-      refute escalated.is_error
+      refute asked.is_error
       refute_received {:tool_ran, _}
 
       resumed = decided(chain, [%{type: :approve}]) |> only_result()

--- a/test/chains/llm_chain_tool_call_review_test.exs
+++ b/test/chains/llm_chain_tool_call_review_test.exs
@@ -519,10 +519,18 @@ defmodule LangChain.Chains.LLMChainToolCallReviewTest do
       escalated = LLMChain.execute_tool_calls(chain) |> only_result()
       assert escalated.is_interrupt
       assert escalated.interrupt_data == %{reason: :over_limit}
+      assert text(escalated) == "a manager has to approve this"
+      assert escalated.tool_call_id == "call_1"
+      assert escalated.name == "ship_order"
+      assert escalated.display_text == "Shipping the order"
+      # A call held for a person is not a call that failed.
+      refute escalated.is_error
       refute_received {:tool_ran, _}
 
       resumed = decided(chain, [%{type: :approve}]) |> only_result()
       refute resumed.is_interrupt
+      assert resumed.interrupt_data == nil
+      assert resumed.tool_call_id == "call_1"
       assert_received {:tool_ran, _}
       assert text(resumed) == "shipped"
     end

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -2535,9 +2535,9 @@ defmodule ChatModels.ChatGoogleAITest do
         |> LLMChain.run(mode: :while_needs_response)
 
       # Every tool message answers the calls of the assistant message before it,
-      # one result per call and in the same order. Gemini pairs a functionResponse
-      # with its functionCall by id when the call carries one and by position
-      # otherwise, so a reordered result message is answered against the wrong call.
+      # one result per call and in the same order. A functionResponse carries the
+      # tool's name and its content, so Gemini pairs it with a functionCall by
+      # position and a result out of place is answered against the wrong call.
       updated_chain.messages
       |> Enum.chunk_every(2, 1, :discard)
       |> Enum.filter(fn [first, second] ->

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -2496,4 +2496,65 @@ defmodule ChatModels.ChatGoogleAITest do
       assert error.message =~ "Empty streaming response"
     end
   end
+
+  describe "parallel tool calls" do
+    @tag live_call: true, live_google_ai: true
+    test "each result is paired with the call it answers" do
+      alias LangChain.Chains.LLMChain
+      alias LangChain.Function
+      alias LangChain.Message
+
+      # A distinct number per city, so a result paired with the wrong call shows
+      # up as the wrong number in the reply rather than passing unnoticed.
+      temperatures = %{"Denver" => "11", "Cairo" => "37", "Oslo" => "52"}
+
+      tool =
+        Function.new!(%{
+          name: "get_temperature",
+          description: "Returns the current temperature for a city, in degrees",
+          parameters_schema: %{
+            type: "object",
+            properties: %{"city" => %{type: "string", description: "The city to look up"}},
+            required: ["city"]
+          },
+          function: fn %{"city" => city}, _ctx ->
+            {:ok, Map.get(temperatures, city, "unknown") <> " degrees"}
+          end
+        })
+
+      {:ok, updated_chain} =
+        %{llm: ChatGoogleAI.new!(%{temperature: 0, stream: false, model: @test_model})}
+        |> LLMChain.new!()
+        |> LLMChain.add_message(
+          Message.new_user!(
+            "What is the temperature in Denver, Cairo, and Oslo? " <>
+              "Call get_temperature once for each city, then report all three."
+          )
+        )
+        |> LLMChain.add_tools(tool)
+        |> LLMChain.run(mode: :while_needs_response)
+
+      # Every tool message answers the calls of the assistant message before it,
+      # one result per call and in the same order. Gemini pairs a functionResponse
+      # with its functionCall by id when the call carries one and by position
+      # otherwise, so a reordered result message is answered against the wrong call.
+      updated_chain.messages
+      |> Enum.chunk_every(2, 1, :discard)
+      |> Enum.filter(fn [first, second] ->
+        first.role == :assistant and first.tool_calls not in [nil, []] and second.role == :tool
+      end)
+      |> tap(fn pairs -> assert pairs != [], "expected at least one tool round trip" end)
+      |> Enum.each(fn [call_message, result_message] ->
+        assert Enum.map(call_message.tool_calls, & &1.call_id) ==
+                 Enum.map(result_message.tool_results, & &1.tool_call_id)
+      end)
+
+      # The model repeated each city's own number back, so nothing was mis-paired
+      # on the way out either.
+      answer = ContentPart.parts_to_string(updated_chain.last_message.content)
+      assert answer =~ "11"
+      assert answer =~ "37"
+      assert answer =~ "52"
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Middleware and host applications can observe an individual tool call but cannot intervene in one. `Callbacks.fire/3` discards whatever a handler returns, so `:on_tool_pre_execution` and its siblings can watch a call go by and nothing more.

That leaves withholding the tool from the model as the only way to stop a call. Withholding is decided when the tool list is assembled, so it cannot depend on the arguments the model actually chose, and it cannot change as a conversation proceeds. It also hides the capability entirely, so the model has no way to tell the user why it can't help.

The gap shows up wherever a rule has to be enforced rather than suggested: a refund ceiling that varies per tenant, a write blocked during a maintenance window, an argument that must be rewritten before it reaches a downstream system. Prompt instructions are not a reliable substitute, because the model can ignore them.

## Solution

A new `:on_tool_call_review` callback is consulted for each tool call, and its return value is honored. It is the one tool callback whose result is used.

Review runs in the parent chain process ahead of the `:on_tool_execution_started` fan-out and before any `Task` is spawned. A call that is turned away is never announced as started and never reaches the tool function, so a refusal leaves no trace of a tool that appeared to run. The trade is that reviews for `async: true` tools run serially in the parent rather than inside their own Tasks.

### The callback

    (LLMChain.t(), ToolCall.t(), Function.t(), map() -> decision)

Handlers are registered like any other callback, in a handler map on the chain:

    callbacks = %{
      on_tool_call_review: fn _chain, tool_call, _func, _review ->
        case Policy.check(tool_call.name, tool_call.arguments) do
          :allowed -> :ok
          {:refused, why} -> {:deny, why}
        end
      end
    }

### Supported return values

| Return | Effect |
| --- | --- |
| `:ok` | Express no opinion. The call proceeds to the next handler. |
| `{:update_arguments, map}` | Rewrite the arguments and keep going. Later handlers review the rewritten call, and the tool runs with it. |
| `{:deny, reason}` | Refuse the call. The tool never runs and `reason` is returned to the model as the tool result. |
| `{:interrupt, message, interrupt_data}` | Refuse for now and interrupt, producing a `ToolResult` with `is_interrupt: true`. Puts the call in front of the user before it runs. |

Anything else raises a `LangChainError` naming the tool, rather than failing quietly.

Handlers are consulted in the order their maps were added to the chain. Argument rewrites thread forward, so a later handler reviews what an earlier one produced. The first `{:deny, _}` or `{:interrupt, _, _}` settles the call and the remaining handlers are skipped.

### The review context

The fourth argument describes the circumstances of the call rather than the call itself. It is a map so it can gain keys later without another arity change, and handlers should match it loosely.

- `:human_decision` is `nil` when the model's call is being run directly, or `:approve` / `:edit` once the user has decided on this call through `execute_tool_calls_with_decisions/3`.
- `:custom_context` is the context the tool will actually be given, which is the context passed to `execute_tool_calls/2` when one is supplied and `chain.custom_context` otherwise. A handler scoped to a tenant reads this, because `chain.custom_context` is not always the context the call runs under.

`:human_decision` is what makes `{:interrupt, _, _}` usable. Review applies on the human-decision path too, so a handler that asks the user about a call is consulted again when their answer comes back. Without a way to recognize that answer it would ask the same question forever and the call would never run:

    on_tool_call_review: fn _chain, call, _func, review ->
      cond do
        # The user already answered for this call. Their answer stands.
        review.human_decision ->
          :ok

        call.name == "delete_file" and
            not inside?(call.arguments["path"], review.custom_context.workspace_root) ->
          {:interrupt, "That file is outside your project. Delete it anyway?",
           %{path: call.arguments["path"]}}

        true ->
          :ok
      end
    end

A delete inside the user's project runs without comment; one outside it stops and asks them. Withholding the tool cannot draw that line, because which case a call falls into depends on the path the model chose. The typedoc walks the same example through both passes with the values each produces.

This is also how "stop asking me about this" is built. `:human_decision` answers for one call and is gone by the next, so a standing answer is recorded by the host and read back on later calls, either from `custom_context` for the length of the conversation or from a store keyed to the user:

    cond do
      # This call was answered directly.
      review.human_decision -> :ok

      # This kind of call was answered earlier and that answer still stands.
      call.name in review.custom_context.always_allow -> :ok

      ...
    end

One limit worth knowing: every call in a batch is reviewed before any interrupt reaches anyone, so a model asking to delete three files at once has all three held together and the user is asked about all three. A rule recorded from their answer applies from the next batch on.

### Tool results answer calls in the order they were made

Results were built in execution groups: async, then sync, then anything left over. That is not the order the model asked in. A function response sent to Gemini carries the tool's name and its content, so Gemini pairs it with a function call by position, and a result out of place is answered against the wrong call.

Resolving a call to a disposition now happens once, over `message.tool_calls`, and every later step keeps each call in the slot its call occupies. Async calls hold a `Task` in theirs, sync calls run in theirs, and a call review settled holds its `ToolResult`. Async calls still all start before any sync call runs and still share one `Task.await_many` deadline.

This also settles a mixed async and sync batch, which reordered on its own before review existed.

### Two behaviors worth knowing

**A denial reports `is_error: false`.** It is a decision about the call, not a fault in it. `Message.tool_had_errors?/1` drives `increment_current_failure_count`, which counts against `max_retry_count`, so marking refusals as errors would let a strict policy abort the run instead of letting the model explain itself. A policy that turns down many calls in a row cannot exhaust the retry budget.

That counter is also the only bound on a tool-calling loop, so a model that keeps reaching for a tool that keeps being denied is not stopped by it. The `reason` is the whole of what the model learns about the refusal, and it should name what to do instead of retrying.

**Review applies on the human-decision path too.** `execute_tool_calls_with_decisions/3` reviews approved and edited calls. A human approving a call says a person agreed, not that policy did. Its `:approve` and `:edit` branches differed only in which arguments they carried, so they now share one `dispatch_decided_call/5` and cannot drift apart or miss a hook. `:reject` is unchanged, since a rejected call does not run.

## Changes

- [`lib/chains/chain_callbacks.ex`](https://github.com/brainlid/langchain/blob/me-tool-call-review-callback/lib/chains/chain_callbacks.ex) covers the return values, the review context, ordering, firing position, asking the user to confirm and resuming afterward, and the `is_error: false` rationale, and registers `:on_tool_call_review` in the handler map type. It also documents what review does to the rest of the chain: an exception in a handler abandons the whole batch before any tool runs, rewritten arguments do not reach the recorded assistant message, and a call naming a tool the chain does not have is never reviewed. `:on_tool_execution_failed` now lists policy denial, and `:on_tool_execution_started` says it fires only for calls that will run.
- [`lib/chains/llm_chain.ex`](https://github.com/brainlid/langchain/blob/me-tool-call-review-callback/lib/chains/llm_chain.ex) resolves each call to a disposition in call order, then announces, spawns, awaits and runs against those slots. `review_tool_call/4` and `apply_review_decision/5` consult the handlers, `reviewed_tool_result/3` builds the stand-in `ToolResult`, and `tool_not_found_result/2` covers a call with no tool behind it. `dispatch_decided_call/5` replaces the duplicated `:approve` and `:edit` bodies.
- [`lib/callbacks.ex`](https://github.com/brainlid/langchain/blob/me-tool-call-review-callback/lib/callbacks.ex) adds `reduce/4`, the decision-capable counterpart to `fire/3`. It hands the reducer an `invoke` function rather than the raw handler, so the reducer chooses each handler's arguments while the exception wrapping stays in one place. `fire/3` is that function with the same arguments given to every handler and nothing accumulated, so it delegates rather than repeating the dispatch.
- [`test/chains/llm_chain_tool_call_review_test.exs`](https://github.com/brainlid/langchain/blob/me-tool-call-review-callback/test/chains/llm_chain_tool_call_review_test.exs) holds 28 tests covering the new callback.

Nothing changes for a chain with no `:on_tool_call_review` handler, apart from tool results now answering calls in the order they were made.

## Testing

`mix precommit` passes: 2353 tests, 41 doctests, no warnings under `--warning-as-errors`.

The test file covers each return value, the no-handler case, multi-handler threading and short-circuit, batches where one call is denied and its siblings still run, an async tool denied without spawning its Task, `on_tool_execution_started` not firing for a denied call and still firing for an allowed one, the failure-counter behavior, and the raise on an unrecognized return.

Ordering has three tests: a denied call keeps the slot its call had, a mixed async and sync batch answers in call order, and a call naming an unknown tool keeps its slot too. A live Gemini test (`live_google_ai`, excluded by default) puts three calls in one turn through a real model and checks each result comes back paired with the call it answers.

The review context has seven, including the one that matters most: a handler asks about a call, the result is an interrupt, the user approves, and on resume the same handler reads `:human_decision`, stands aside, and the tool runs. Without that argument it asks the same question again and the call never runs. Two more cover standing approvals: a rule carried on `custom_context` stops the asking on later calls, and a batch is reviewed before any of it is surfaced.

Checked downstream against a consumer that leans on this machinery: the `sagents` suite passes against this branch (1854 of 1855, the one failure a known flaky test that passes in isolation), including its Human-in-the-Loop coverage. A middleware there enforced a per-tenant refund ceiling purely by registering an `:on_tool_call_review` handler, denying a call for one tenant and allowing the identical call for another, with no changes needed outside this library.
