### PR TITLE
Carry the tool call id through a Gemini exchange

### DIFF
--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -479,18 +479,6 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     %{"functionCall" => function_call_for_api(call)}
   end
 
-  # Gemini pairs a functionResponse with the functionCall it answers by `id`
-  # when the two carry one, and by their position among the parts when they do
-  # not. Newer models issue an `id` with every call and expect it back, so the
-  # call's id is sent here and the answering result sends the same one.
-  defp function_call_for_api(%ToolCall{} = call) do
-    %{
-      "args" => ToolCall.arguments_as_map(call),
-      "name" => call.name
-    }
-    |> Utils.conditionally_add_to_map("id", call.call_id)
-  end
-
   def for_api(%ToolResult{} = result) do
     # `content` may be nil, a string, or a list of ContentParts.
     # `content_to_string/1` accepts all three, where `parts_to_string/1`
@@ -539,6 +527,18 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
 
   def for_api(%NativeTool{name: name, configuration: nil}) do
     name
+  end
+
+  # Gemini pairs a functionResponse with the functionCall it answers by `id`
+  # when the two carry one, and by their position among the parts when they do
+  # not. Newer models issue an `id` with every call and expect it back, so the
+  # call's id is sent here and the answering result sends the same one.
+  defp function_call_for_api(%ToolCall{} = call) do
+    %{
+      "args" => ToolCall.arguments_as_map(call),
+      "name" => call.name
+    }
+    |> Utils.conditionally_add_to_map("id", call.call_id)
   end
 
   # A tool result may carry no text at all: `content` can be nil, or a

--- a/lib/chat_models/chat_google_ai.ex
+++ b/lib/chat_models/chat_google_ai.ex
@@ -470,21 +470,25 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
   def for_api(%ToolCall{metadata: %{thought_signature: signature}} = call)
       when is_binary(signature) do
     %{
-      "functionCall" => %{
-        "args" => ToolCall.arguments_as_map(call),
-        "name" => call.name
-      },
+      "functionCall" => function_call_for_api(call),
       "thoughtSignature" => signature
     }
   end
 
   def for_api(%ToolCall{} = call) do
+    %{"functionCall" => function_call_for_api(call)}
+  end
+
+  # Gemini pairs a functionResponse with the functionCall it answers by `id`
+  # when the two carry one, and by their position among the parts when they do
+  # not. Newer models issue an `id` with every call and expect it back, so the
+  # call's id is sent here and the answering result sends the same one.
+  defp function_call_for_api(%ToolCall{} = call) do
     %{
-      "functionCall" => %{
-        "args" => ToolCall.arguments_as_map(call),
-        "name" => call.name
-      }
+      "args" => ToolCall.arguments_as_map(call),
+      "name" => call.name
     }
+    |> Utils.conditionally_add_to_map("id", call.call_id)
   end
 
   def for_api(%ToolResult{} = result) do
@@ -500,13 +504,15 @@ defmodule LangChain.ChatModels.ChatGoogleAI do
     #
     # https://ai.google.dev/gemini-api/docs/function-calling#expandable-7
     %{
-      "functionResponse" => %{
-        "name" => result.name,
-        "response" => %{
+      "functionResponse" =>
+        %{
           "name" => result.name,
-          "content" => content
+          "response" => %{
+            "name" => result.name,
+            "content" => content
+          }
         }
-      }
+        |> Utils.conditionally_add_to_map("id", result.tool_call_id)
     }
   end
 

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -412,21 +412,25 @@ defmodule LangChain.ChatModels.ChatVertexAI do
   defp for_api(%ToolCall{metadata: %{thought_signature: signature}} = call)
        when is_binary(signature) do
     %{
-      "functionCall" => %{
-        "args" => ToolCall.arguments_as_map(call),
-        "name" => call.name
-      },
+      "functionCall" => function_call_for_api(call),
       "thoughtSignature" => signature
     }
   end
 
   defp for_api(%ToolCall{} = call) do
+    %{"functionCall" => function_call_for_api(call)}
+  end
+
+  # Gemini pairs a functionResponse with the functionCall it answers by `id`
+  # when the two carry one, and by their position among the parts when they do
+  # not. Newer models issue an `id` with every call and expect it back, so the
+  # call's id is sent here and the answering result sends the same one.
+  defp function_call_for_api(%ToolCall{} = call) do
     %{
-      "functionCall" => %{
-        "args" => ToolCall.arguments_as_map(call),
-        "name" => call.name
-      }
+      "args" => ToolCall.arguments_as_map(call),
+      "name" => call.name
     }
+    |> Utils.conditionally_add_to_map("id", call.call_id)
   end
 
   defp for_api(%ToolResult{} = result) do
@@ -434,10 +438,12 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     response_parts = tool_result_parts_for_api(result.content)
 
     %{
-      "functionResponse" => %{
-        "name" => result.name,
-        "response" => response
-      }
+      "functionResponse" =>
+        %{
+          "name" => result.name,
+          "response" => response
+        }
+        |> Utils.conditionally_add_to_map("id", result.tool_call_id)
     }
     |> maybe_add_function_response_parts(response_parts)
   end

--- a/lib/chat_models/chat_vertex_ai.ex
+++ b/lib/chat_models/chat_vertex_ai.ex
@@ -421,18 +421,6 @@ defmodule LangChain.ChatModels.ChatVertexAI do
     %{"functionCall" => function_call_for_api(call)}
   end
 
-  # Gemini pairs a functionResponse with the functionCall it answers by `id`
-  # when the two carry one, and by their position among the parts when they do
-  # not. Newer models issue an `id` with every call and expect it back, so the
-  # call's id is sent here and the answering result sends the same one.
-  defp function_call_for_api(%ToolCall{} = call) do
-    %{
-      "args" => ToolCall.arguments_as_map(call),
-      "name" => call.name
-    }
-    |> Utils.conditionally_add_to_map("id", call.call_id)
-  end
-
   defp for_api(%ToolResult{} = result) do
     response = tool_result_response_for_api(result.content)
     response_parts = tool_result_parts_for_api(result.content)
@@ -457,6 +445,18 @@ defmodule LangChain.ChatModels.ChatVertexAI do
   end
 
   defp for_api(nil), do: nil
+
+  # Gemini pairs a functionResponse with the functionCall it answers by `id`
+  # when the two carry one, and by their position among the parts when they do
+  # not. Newer models issue an `id` with every call and expect it back, so the
+  # call's id is sent here and the answering result sends the same one.
+  defp function_call_for_api(%ToolCall{} = call) do
+    %{
+      "args" => ToolCall.arguments_as_map(call),
+      "name" => call.name
+    }
+    |> Utils.conditionally_add_to_map("id", call.call_id)
+  end
 
   defp maybe_add_function_response_parts(
          %{"functionResponse" => function_response} = data,

--- a/test/chat_models/chat_google_ai_test.exs
+++ b/test/chat_models/chat_google_ai_test.exs
@@ -239,6 +239,77 @@ defmodule ChatModels.ChatGoogleAITest do
       assert result["functionCall"]["name"] == "test_function"
     end
 
+    test "for_api includes the call id on a functionCall" do
+      tool_call =
+        ToolCall.new!(%{
+          call_id: "call_123",
+          name: "test_function",
+          arguments: %{"arg" => "value"}
+        })
+
+      assert %{"functionCall" => %{"id" => "call_123"}} = ChatGoogleAI.for_api(tool_call)
+    end
+
+    test "for_api includes the call id alongside a thoughtSignature" do
+      tool_call =
+        ToolCall.new!(%{
+          call_id: "call_123",
+          name: "test_function",
+          arguments: %{"arg" => "value"},
+          metadata: %{thought_signature: "sig_abc123"}
+        })
+
+      result = ChatGoogleAI.for_api(tool_call)
+
+      assert result["thoughtSignature"] == "sig_abc123"
+      assert result["functionCall"]["id"] == "call_123"
+    end
+
+    test "for_api includes the answered call id on a functionResponse" do
+      tool_result =
+        ToolResult.new!(%{
+          tool_call_id: "call_123",
+          name: "test_function",
+          content: "the answer"
+        })
+
+      assert %{"functionResponse" => %{"id" => "call_123"}} = ChatGoogleAI.for_api(tool_result)
+    end
+
+    test "for_api omits the id when a call has none" do
+      tool_call = %ToolCall{status: :incomplete, name: "test_function", arguments: nil}
+
+      refute Map.has_key?(ChatGoogleAI.for_api(tool_call)["functionCall"], "id")
+    end
+
+    test "a call the model identified and the result answering it carry the same id" do
+      model = ChatGoogleAI.new!(%{model: "gemini-3.7-flash"})
+
+      call =
+        ChatGoogleAI.do_process_response(
+          model,
+          %{
+            "functionCall" => %{
+              "name" => "get_temperature",
+              "args" => %{"city" => "Oslo"},
+              "id" => "model-supplied-id"
+            }
+          },
+          nil
+        )
+
+      tool_result =
+        ToolResult.new!(%{
+          tool_call_id: call.call_id,
+          name: call.name,
+          content: "2 degrees"
+        })
+
+      assert %{"functionCall" => %{"id" => sent_id}} = ChatGoogleAI.for_api(call)
+      assert %{"functionResponse" => %{"id" => ^sent_id}} = ChatGoogleAI.for_api(tool_result)
+      assert sent_id == "model-supplied-id"
+    end
+
     test "for_api excludes thoughtSignature when not in ToolCall metadata" do
       tool_call =
         ToolCall.new!(%{
@@ -301,6 +372,7 @@ defmodule ChatModels.ChatGoogleAITest do
           "parts" => [
             %{
               "functionResponse" => %{
+                "id" => "call-find_theaters",
                 "name" => "find_theaters",
                 "response" => %{
                   "name" => "find_theaters",
@@ -345,6 +417,7 @@ defmodule ChatModels.ChatGoogleAITest do
     test "tool result creates expected map" do
       expected = %{
         "functionResponse" => %{
+          "id" => "call-find_theaters",
           "name" => "find_theaters",
           "response" => %{
             "name" => "find_theaters",
@@ -369,6 +442,7 @@ defmodule ChatModels.ChatGoogleAITest do
       # shapes for `content`.
       expected = %{
         "functionResponse" => %{
+          "id" => "call-find_theaters",
           "name" => "find_theaters",
           "response" => %{
             "name" => "find_theaters",
@@ -392,6 +466,7 @@ defmodule ChatModels.ChatGoogleAITest do
       # hand-built structs.
       expected = %{
         "functionResponse" => %{
+          "id" => "call-take_screenshot",
           "name" => "take_screenshot",
           "response" => %{
             "name" => "take_screenshot",
@@ -413,6 +488,7 @@ defmodule ChatModels.ChatGoogleAITest do
     test "tool result with nil content creates expected map" do
       expected = %{
         "functionResponse" => %{
+          "id" => "call-find_theaters",
           "name" => "find_theaters",
           "response" => %{
             "name" => "find_theaters",

--- a/test/chat_models/chat_vertex_ai_test.exs
+++ b/test/chat_models/chat_vertex_ai_test.exs
@@ -241,6 +241,44 @@ defmodule ChatModels.ChatVertexAITest do
              } = data
     end
 
+    test "carries the call id onto a functionCall and the result answering it",
+         %{vertex_ai: vertex_ai} do
+      # Gemini pairs a functionResponse with the functionCall it answers by id,
+      # so the two have to agree.
+      data =
+        ChatVertexAI.for_api(
+          vertex_ai,
+          [
+            Message.new_assistant!(%{
+              tool_calls: [
+                ToolCall.new!(%{
+                  call_id: "call-find_theaters",
+                  name: "find_theaters",
+                  arguments: %{"location" => "Mountain View"}
+                })
+              ]
+            }),
+            Message.new_tool_result!(%{
+              tool_results: [
+                ToolResult.new!(%{
+                  tool_call_id: "call-find_theaters",
+                  name: "find_theaters",
+                  content: "AMC 16"
+                })
+              ]
+            })
+          ],
+          []
+        )
+
+      assert %{"contents" => [call_message, result_message]} = data
+      assert %{"parts" => [%{"functionCall" => function_call}]} = call_message
+      assert %{"parts" => [%{"functionResponse" => function_response}]} = result_message
+
+      assert function_call["id"] == "call-find_theaters"
+      assert function_response["id"] == "call-find_theaters"
+    end
+
     test "generates a map containing user and assistant messages", %{vertex_ai: vertex_ai} do
       user_message = "Hello Assistant!"
       assistant_message = "Hello User!"


### PR DESCRIPTION
## Problem

A Gemini `functionCall` can carry an `id`, and the `functionResponse` answering it carries the same one. Newer models issue an id with every call and expect it back. That is what lets a turn holding several calls to the same tool be matched up unambiguously, instead of relying on the position of each part within the message.

The id a model sends is already read into the `ToolCall`:

    call_id: call["id"] || Utils.generate_tool_call_id()

but it stops there. Both encoders build their parts from the name alone:

    %{"functionCall" => %{"args" => ..., "name" => call.name}}
    %{"functionResponse" => %{"name" => result.name, "response" => ...}}

So the id is read and then dropped, and every exchange falls back to positional matching. A model that issues ids gets none of them back.

This is not a malformed request today. The call and the answer are both sent without an id, which is a consistent pair. It does mean a turn with two calls to the same tool is distinguished only by the order the parts appear in.

## Solution

Send the id on both parts. The `ToolCall` already holds it and every `ToolResult` already knows the call it answers, so nothing new has to be threaded through: the two ends already agree, they just were not reaching the wire.

    defp function_call_for_api(%ToolCall{} = call) do
      %{
        "args" => ToolCall.arguments_as_map(call),
        "name" => call.name
      }
      |> Utils.conditionally_add_to_map("id", call.call_id)
    end

and the same `conditionally_add_to_map/3` on the `functionResponse`.

Both sides draw from the same value, so a call and its answer agree however that value arose: echoed from the model, or assigned locally when the model sent none. A `ToolCall` with no id at all, which the struct permits before one is assigned, sends no id, and its answer then sends none either. The two are never mismatched.

`ChatVertexAI` reaches the same models through its own copy of these encoders and had the same gap, so it gets the same change.

## Changes

- [`lib/chat_models/chat_google_ai.ex`](https://github.com/brainlid/langchain/blob/me-gemini-tool-call-ids/lib/chat_models/chat_google_ai.ex) — `function_call_for_api/1` builds the `functionCall`, shared by the plain clause and the `thoughtSignature` one so the two cannot drift. The `functionResponse` gains the answered call's id.
- [`lib/chat_models/chat_vertex_ai.ex`](https://github.com/brainlid/langchain/blob/me-gemini-tool-call-ids/lib/chat_models/chat_vertex_ai.ex) — the same two changes.
- [`test/chat_models/chat_google_ai_test.exs`](https://github.com/brainlid/langchain/blob/me-gemini-tool-call-ids/test/chat_models/chat_google_ai_test.exs) — the id on a `functionCall`, on a `functionCall` alongside a `thoughtSignature`, on a `functionResponse`, omitted when a call has none, and a round trip asserting a call the model identified and the result answering it leave carrying the same id. Five existing expectations that compare the whole encoded map now include the id.
- [`test/chat_models/chat_vertex_ai_test.exs`](https://github.com/brainlid/langchain/blob/me-gemini-tool-call-ids/test/chat_models/chat_vertex_ai_test.exs) — a call and the result answering it encode with the same id.

## Testing

`mix precommit` passes: 2359 tests, 41 doctests, no warnings under `--warning-as-errors`.

The live coverage for this is `test "each result is paired with the call it answers"` in `chat_google_ai_test.exs`, tagged `live_google_ai`. It puts three calls to one tool in a single turn through a real model, gives each city a distinct number, and checks each result comes back paired with the call it answers and that the reply repeats all three numbers. That test exercises the ids added here on the way out. Run it with:

    mix test --include live_google_ai test/chat_models/chat_google_ai_test.exs

**Not yet run against the live API.** Everything above is verified against the encoders and the documented request shape, not against a real Gemini endpoint. The specific thing worth confirming with a key is that a model which issues no id of its own accepts a matched pair of locally assigned ids, since the published examples for those models simply omit the field rather than forbidding it. If that turns out to be a problem, the narrower change is to send the id only when the model supplied one, which needs a marker recorded at decode time.
