### PR TITLE
Stop merging separate streamed responses into one message

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -297,9 +297,9 @@ defmodule LangChain.Chains.LLMChain do
     # Track the current merged `%MessageDelta{}` struct received when streamed.
     # Set to `nil` when there is no current delta being tracked. This happens
     # when the final delta is received that completes the message. At that point,
-    # the delta is converted to a message and the delta is set to nil. A response
-    # that ends without a completing delta is converted anyway, so a delta never
-    # outlives the LLM call that produced it.
+    # the delta is converted to a message and the delta is set to nil. An LLM
+    # call neither starts nor finishes with a delta attached, so a delta never
+    # outlives the call that produced it.
     field :delta, :any, virtual: true
 
     # Track the last `%Message{}` received in the chain.
@@ -924,6 +924,8 @@ defmodule LangChain.Chains.LLMChain do
   end
 
   defp do_run(%LLMChain{} = chain) do
+    chain = drop_stale_delta(chain)
+
     # submit to LLM. The "llm" is a struct. Match to get the name of the module
     # then execute the `.call` function on that module.
     %module{} = chain.llm
@@ -961,11 +963,11 @@ defmodule LangChain.Chains.LLMChain do
 
       {:ok, [%MessageDelta{} | _] = deltas} ->
         if chain.verbose_deltas, do: IO.inspect(deltas, label: "DELTA MESSAGE LIST RESPONSE")
-        apply_llm_deltas(chain, deltas)
+        apply_deltas_from_ended_stream(chain, deltas)
 
       {:ok, [[%MessageDelta{} | _] | _] = deltas} ->
         if chain.verbose_deltas, do: IO.inspect(deltas, label: "DELTA MESSAGE LIST RESPONSE")
-        apply_llm_deltas(chain, deltas)
+        apply_deltas_from_ended_stream(chain, deltas)
 
       {:error, %LangChainError{} = reason} ->
         if chain.verbose, do: IO.inspect(reason, label: "ERROR")
@@ -1198,43 +1200,54 @@ defmodule LangChain.Chains.LLMChain do
     %LLMChain{chain | delta: nil}
   end
 
-  # Apply the deltas an LLM call returned. The call is over by the time this
-  # runs, so whatever has accumulated is the whole of the response.
+  # Every path that consumes or rejects a streamed delta clears it from the
+  # chain, so a delta present at the start of an LLM call can only be leftover
+  # state from a caller re-running a chain after an errored stream, or from a
+  # host that accumulated deltas onto the chain itself. Drop it: merging it
+  # with the new call's deltas would put text from two responses into one
+  # message.
+  @spec drop_stale_delta(t()) :: t()
+  defp drop_stale_delta(%LLMChain{delta: nil} = chain), do: chain
+
+  defp drop_stale_delta(%LLMChain{} = chain) do
+    Logger.warning("Starting an LLM call with a leftover streaming delta; dropping it")
+    drop_delta(chain)
+  end
+
+  # The streamed response has fully ended by the time apply_deltas/2 runs here,
+  # so a delta still on the chain means the response carried no terminal delta.
+  # Reporting that as success adds no message, which leaves `needs_response`
+  # unchanged and the hanging delta ready to merge with the next call's text:
+  # a looping mode re-invokes the model and several separate generations arrive
+  # as one run-on message. Treat it as a retryable LLM error instead.
   #
-  # A ChatModel is expected to end a streamed response with a delta carrying a
-  # terminal status, which is what converts the accumulated delta into a
-  # message. When one never arrives the delta has nowhere to go: it stays live
-  # on the chain, no message is appended, and `needs_response` stays true. A
-  # looping mode then calls the model again and the next response merges into
-  # the same accumulator at the same content index, so several separate
-  # generations arrive as one run-on message. Close the delta out here so a
-  # single call always yields a single message.
-  @spec apply_llm_deltas(t(), list()) :: {:ok, t()} | {:error, t(), LangChainError.t()}
-  defp apply_llm_deltas(%LLMChain{} = chain, deltas) do
+  # The partial text is discarded rather than salvaged. The chain cannot tell a
+  # response cut off partway through from one that finished and lost only its
+  # terminator, and half-streamed text or an incomplete set of tool calls must
+  # not enter the transcript. A ChatModel that can tell the difference is
+  # expected to close the turn itself.
+  @spec apply_deltas_from_ended_stream(t(), list()) ::
+          {:ok, t()} | {:error, t(), LangChainError.t()}
+  defp apply_deltas_from_ended_stream(%LLMChain{} = chain, deltas) do
     case apply_deltas(chain, deltas) do
-      {:ok, %LLMChain{delta: %MessageDelta{} = hanging} = unfinished_chain} ->
-        Logger.warning(
-          "Response ended without a completed delta. Converting the partial delta to a message."
-        )
-
-        forced_chain = %LLMChain{
-          unfinished_chain
-          | delta: %MessageDelta{hanging | status: :complete}
-        }
-
-        case delta_to_message_when_complete(forced_chain) do
-          {:ok, updated_chain} ->
-            {:ok, updated_chain}
-
-          {:error, _chain, _reason} = error ->
-            handle_delta_error(error)
-        end
-
-      {:ok, updated_chain} ->
+      {:ok, %LLMChain{delta: nil} = updated_chain} ->
         if chain.verbose,
           do: IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
 
         {:ok, updated_chain}
+
+      {:ok, %LLMChain{delta: %MessageDelta{status: status}} = updated_chain} ->
+        Logger.warning(
+          "LLM stream ended without a terminal delta (delta status: #{inspect(status)})"
+        )
+
+        handle_delta_error(
+          {:error, drop_delta(updated_chain),
+           LangChainError.exception(
+             type: "incomplete_stream",
+             message: "LLM stream ended without completing the message"
+           )}
+        )
 
       {:error, _chain, _reason} = error ->
         handle_delta_error(error)

--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -297,7 +297,9 @@ defmodule LangChain.Chains.LLMChain do
     # Track the current merged `%MessageDelta{}` struct received when streamed.
     # Set to `nil` when there is no current delta being tracked. This happens
     # when the final delta is received that completes the message. At that point,
-    # the delta is converted to a message and the delta is set to nil.
+    # the delta is converted to a message and the delta is set to nil. A response
+    # that ends without a completing delta is converted anyway, so a delta never
+    # outlives the LLM call that produced it.
     field :delta, :any, virtual: true
 
     # Track the last `%Message{}` received in the chain.
@@ -959,31 +961,11 @@ defmodule LangChain.Chains.LLMChain do
 
       {:ok, [%MessageDelta{} | _] = deltas} ->
         if chain.verbose_deltas, do: IO.inspect(deltas, label: "DELTA MESSAGE LIST RESPONSE")
-
-        case apply_deltas(chain, deltas) do
-          {:ok, updated_chain} ->
-            if chain.verbose,
-              do: IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
-
-            {:ok, updated_chain}
-
-          {:error, _chain, _reason} = error ->
-            handle_delta_error(error)
-        end
+        apply_llm_deltas(chain, deltas)
 
       {:ok, [[%MessageDelta{} | _] | _] = deltas} ->
         if chain.verbose_deltas, do: IO.inspect(deltas, label: "DELTA MESSAGE LIST RESPONSE")
-
-        case apply_deltas(chain, deltas) do
-          {:ok, updated_chain} ->
-            if chain.verbose,
-              do: IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
-
-            {:ok, updated_chain}
-
-          {:error, _chain, _reason} = error ->
-            handle_delta_error(error)
-        end
+        apply_llm_deltas(chain, deltas)
 
       {:error, %LangChainError{} = reason} ->
         if chain.verbose, do: IO.inspect(reason, label: "ERROR")
@@ -1214,6 +1196,49 @@ defmodule LangChain.Chains.LLMChain do
   @spec reset_streaming_state(t()) :: t()
   defp reset_streaming_state(%LLMChain{} = chain) do
     %LLMChain{chain | delta: nil}
+  end
+
+  # Apply the deltas an LLM call returned. The call is over by the time this
+  # runs, so whatever has accumulated is the whole of the response.
+  #
+  # A ChatModel is expected to end a streamed response with a delta carrying a
+  # terminal status, which is what converts the accumulated delta into a
+  # message. When one never arrives the delta has nowhere to go: it stays live
+  # on the chain, no message is appended, and `needs_response` stays true. A
+  # looping mode then calls the model again and the next response merges into
+  # the same accumulator at the same content index, so several separate
+  # generations arrive as one run-on message. Close the delta out here so a
+  # single call always yields a single message.
+  @spec apply_llm_deltas(t(), list()) :: {:ok, t()} | {:error, t(), LangChainError.t()}
+  defp apply_llm_deltas(%LLMChain{} = chain, deltas) do
+    case apply_deltas(chain, deltas) do
+      {:ok, %LLMChain{delta: %MessageDelta{} = hanging} = unfinished_chain} ->
+        Logger.warning(
+          "Response ended without a completed delta. Converting the partial delta to a message."
+        )
+
+        forced_chain = %LLMChain{
+          unfinished_chain
+          | delta: %MessageDelta{hanging | status: :complete}
+        }
+
+        case delta_to_message_when_complete(forced_chain) do
+          {:ok, updated_chain} ->
+            {:ok, updated_chain}
+
+          {:error, _chain, _reason} = error ->
+            handle_delta_error(error)
+        end
+
+      {:ok, updated_chain} ->
+        if chain.verbose,
+          do: IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
+
+        {:ok, updated_chain}
+
+      {:error, _chain, _reason} = error ->
+        handle_delta_error(error)
+    end
   end
 
   # Handle a delta-conversion error like a retryable LLM error: fire

--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -54,10 +54,17 @@ if Code.ensure_loaded?(ReqLLM) do
 
     A streamed turn is finished when a chunk marks the response terminal, which
     req_llm derives from a provider's terminal event. A stream whose body simply
-    ends carries no such chunk, so the turn is closed here instead, using the
-    finish reason req_llm recorded for the stream, and a warning is logged. A
-    stream req_llm saw end early produces a truncated (`status: :length`)
-    message rather than a clean one.
+    ends carries no such chunk, and the accumulated text would then never become
+    a message.
+
+    The finish reason req_llm records alongside the stream says which case this
+    is. When it reports a finished response (`:stop`, `:tool_calls`, `:length`,
+    `:content_filter`), only the marker went missing and the turn is closed here
+    with that status. When it reports anything else, including the `:incomplete`
+    of a body that ended without a recognized terminal event, the response is
+    left unfinished so `LangChain.Chains.LLMChain` reports it as an
+    `"incomplete_stream"` error and retries rather than admitting half a
+    response into the conversation. Both paths log a warning.
 
     ## Connection Retry Behavior
 
@@ -438,43 +445,61 @@ if Code.ensure_loaded?(ReqLLM) do
       :ok
     end
 
+    # req_llm finish reasons that report a response the provider actually
+    # finished. Nothing else is evidence the turn is whole: not a body that
+    # ended without a recognized terminal event, not an error, and not a reason
+    # that could not be read.
+    @finished_reasons [:stop, :tool_calls, :length, :content_filter]
+
     # A streamed turn is only finished once a delta carries a terminal status;
     # that is what tells `LLMChain` to turn the accumulated delta into a
     # message. req_llm derives terminality from a recognized terminal event in
     # the response body, so a provider whose stream simply ends leaves every
-    # delta `:incomplete`. The text is then never converted, the chain still
-    # wants a response, and the accumulated delta stays live for the next call
-    # to merge into.
+    # delta `:incomplete` and the text is never converted.
     #
-    # Close the turn here with the finish reason req_llm recorded for the
-    # stream. A stream that ended without its terminal event is reported as
-    # `:incomplete`, which maps to a truncated (`:length`) message rather than
-    # a clean one.
+    # Whether that is safe to close here depends on why the stream ended, which
+    # only the finish reason can say. A finished response that lost its marker
+    # is completed with the status the reason maps to. A stream that ended for
+    # any other reason is left alone: `LLMChain` sees the hanging delta, drops
+    # it, and retries, which is the right outcome when the response may be a
+    # fragment.
     defp closing_delta(_stream_response, []), do: nil
 
     defp closing_delta(stream_response, deltas) do
       if Enum.any?(deltas, &(&1.status != :incomplete)) do
         nil
       else
-        finish_reason = stream_finish_reason(stream_response)
-
-        Logger.warning(fn ->
-          "ReqLLM stream ended without a terminal chunk. " <>
-            "Closing the turn using finish_reason #{inspect(finish_reason)}."
-        end)
-
-        MessageDelta.new!(%{
-          role: :assistant,
-          status: translate_finish_reason(finish_reason),
-          index: 0
-        })
+        close_turn(stream_finish_reason(stream_response))
       end
+    end
+
+    defp close_turn(finish_reason) when finish_reason in @finished_reasons do
+      Logger.warning(fn ->
+        "ReqLLM stream carried no terminal chunk. Closing the turn using " <>
+          "finish_reason #{inspect(finish_reason)}."
+      end)
+
+      MessageDelta.new!(%{
+        role: :assistant,
+        status: translate_finish_reason(finish_reason),
+        index: 0
+      })
+    end
+
+    defp close_turn(finish_reason) do
+      Logger.warning(fn ->
+        "ReqLLM stream carried no terminal chunk and finish_reason " <>
+          "#{inspect(finish_reason)} does not report a finished response. " <>
+          "Leaving the turn unfinished."
+      end)
+
+      nil
     end
 
     # req_llm collects the finish reason in a process separate from the chunk
     # stream, and it is settled by the time the stream is exhausted. A collector
-    # that is gone or fails is reported as an unknown reason instead of taking
-    # down a turn that already produced content.
+    # that is gone or fails reports no reason, which leaves the turn unfinished
+    # rather than closing it on a guess.
     defp stream_finish_reason(stream_response) do
       ReqLLM.StreamResponse.finish_reason(stream_response)
     rescue

--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -50,6 +50,15 @@ if Code.ensure_loaded?(ReqLLM) do
           provider_opts: %{"thinking" => %{"type" => "enabled", "budget_tokens" => 2000}}
         })
 
+    ## Stream Completion
+
+    A streamed turn is finished when a chunk marks the response terminal, which
+    req_llm derives from a provider's terminal event. A stream whose body simply
+    ends carries no such chunk, so the turn is closed here instead, using the
+    finish reason req_llm recorded for the stream, and a warning is logged. A
+    stream req_llm saw end early produces a truncated (`status: :length`)
+    message rather than a clean one.
+
     ## Connection Retry Behavior
 
     The `retry_count` option controls how many times a request is retried when
@@ -407,16 +416,72 @@ if Code.ensure_loaded?(ReqLLM) do
         stream_response.stream
         |> Enum.reduce({[], initial_state}, fn chunk, {acc_deltas, state} ->
           {new_deltas, new_state} = process_stream_chunk(chunk, state)
-
-          if new_deltas != [] do
-            :counters.add(delivered, 1, length(new_deltas))
-            Utils.fire_streamed_callback(model, new_deltas)
-          end
-
+          deliver_deltas(model, new_deltas, delivered)
           {acc_deltas ++ new_deltas, new_state}
         end)
 
-      all_deltas
+      case closing_delta(stream_response, all_deltas) do
+        nil ->
+          all_deltas
+
+        %MessageDelta{} = delta ->
+          deliver_deltas(model, [delta], delivered)
+          all_deltas ++ [delta]
+      end
+    end
+
+    defp deliver_deltas(_model, [], _delivered), do: :ok
+
+    defp deliver_deltas(model, deltas, delivered) do
+      :counters.add(delivered, 1, length(deltas))
+      Utils.fire_streamed_callback(model, deltas)
+      :ok
+    end
+
+    # A streamed turn is only finished once a delta carries a terminal status;
+    # that is what tells `LLMChain` to turn the accumulated delta into a
+    # message. req_llm derives terminality from a recognized terminal event in
+    # the response body, so a provider whose stream simply ends leaves every
+    # delta `:incomplete`. The text is then never converted, the chain still
+    # wants a response, and the accumulated delta stays live for the next call
+    # to merge into.
+    #
+    # Close the turn here with the finish reason req_llm recorded for the
+    # stream. A stream that ended without its terminal event is reported as
+    # `:incomplete`, which maps to a truncated (`:length`) message rather than
+    # a clean one.
+    @spec closing_delta(ReqLLM.StreamResponse.t(), [MessageDelta.t()]) :: MessageDelta.t() | nil
+    defp closing_delta(_stream_response, []), do: nil
+
+    defp closing_delta(stream_response, deltas) do
+      if Enum.any?(deltas, &(&1.status != :incomplete)) do
+        nil
+      else
+        finish_reason = stream_finish_reason(stream_response)
+
+        Logger.warning(fn ->
+          "ReqLLM stream ended without a terminal chunk. " <>
+            "Closing the turn using finish_reason #{inspect(finish_reason)}."
+        end)
+
+        MessageDelta.new!(%{
+          role: :assistant,
+          status: translate_finish_reason(finish_reason),
+          index: 0
+        })
+      end
+    end
+
+    # req_llm collects the finish reason in a process separate from the chunk
+    # stream, and it is settled by the time the stream is exhausted. A collector
+    # that is gone or fails is reported as an unknown reason instead of taking
+    # down a turn that already produced content.
+    defp stream_finish_reason(stream_response) do
+      ReqLLM.StreamResponse.finish_reason(stream_response)
+    rescue
+      _error -> nil
+    catch
+      :exit, _reason -> nil
     end
 
     # Turn a failed request into the same shape regardless of which library

--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -450,7 +450,6 @@ if Code.ensure_loaded?(ReqLLM) do
     # stream. A stream that ended without its terminal event is reported as
     # `:incomplete`, which maps to a truncated (`:length`) message rather than
     # a clean one.
-    @spec closing_delta(ReqLLM.StreamResponse.t(), [MessageDelta.t()]) :: MessageDelta.t() | nil
     defp closing_delta(_stream_response, []), do: nil
 
     defp closing_delta(stream_response, deltas) do

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -216,24 +216,18 @@ defmodule LangChain.Chains.LLMChainTest do
     test "remove delta and adds cancelled message" do
       model = ChatOpenAI.new!(%{temperature: 1, stream: true})
 
-      # Made NOT LIVE here
-      fake_messages = [
-        [MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete})],
-        [MessageDelta.new!(%{content: "Sock", status: :incomplete})]
-      ]
-
-      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
-        {:ok, fake_messages}
-      end)
-
-      # We can construct an LLMChain from a PromptTemplate and an LLM.
-      {:ok, updated_chain} =
+      # Cancelling happens partway through a stream, so build the chain up to
+      # the point a live delta is on it.
+      updated_chain =
         %{llm: model, verbose: false}
         |> LLMChain.new!()
         |> LLMChain.add_message(
           Message.new_user!("What is a good name for a company that makes colorful socks?")
         )
-        |> LLMChain.run()
+        |> LLMChain.merge_delta(
+          MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete})
+        )
+        |> LLMChain.merge_delta(MessageDelta.new!(%{content: "Sock", status: :incomplete}))
 
       assert %MessageDelta{} = updated_chain.delta
       new_chain = LLMChain.cancel_delta(updated_chain, :cancelled)
@@ -659,6 +653,75 @@ defmodule LangChain.Chains.LLMChainTest do
       assert {:ok, %LLMChain{} = result} = LLMChain.delta_to_message_when_complete(updated_chain)
       assert %MessageDelta{status: :incomplete} = result.delta
       assert result.messages == []
+    end
+  end
+
+  describe "run/2 with a streamed response that never completes" do
+    setup do
+      %{chain: LLMChain.new!(%{llm: ChatOpenAI.new!(%{stream: true}), verbose: false})}
+    end
+
+    test "converts the partial delta into a message", %{chain: chain} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok,
+         [
+           MessageDelta.new!(%{role: :assistant, content: "Sounds like "}),
+           MessageDelta.new!(%{content: "a shakedown run."})
+         ]}
+      end)
+
+      chain = LLMChain.add_message(chain, Message.new_user!("Testing"))
+
+      assert {:ok, updated_chain} = LLMChain.run(chain)
+      assert updated_chain.delta == nil
+      assert %Message{role: :assistant} = answer = updated_chain.last_message
+      assert ContentPart.parts_to_string(answer.content) == "Sounds like a shakedown run."
+      assert updated_chain.needs_response == false
+    end
+
+    test "does not merge a later response into the unfinished one", %{chain: chain} do
+      # An unfinished delta used to stay live on the chain while `needs_response`
+      # stayed true, so a looping mode called the model again and the next
+      # response merged into the same content slot. One call, one message.
+      expect(ChatOpenAI, :call, 1, fn _model, _messages, _tools ->
+        {:ok, [MessageDelta.new!(%{role: :assistant, content: "First answer."})]}
+      end)
+
+      chain = LLMChain.add_message(chain, Message.new_user!("Testing"))
+
+      assert {:ok, updated_chain} = LLMChain.run(chain, mode: :while_needs_response)
+      assert [_user, %Message{role: :assistant} = answer] = updated_chain.messages
+      assert ContentPart.parts_to_string(answer.content) == "First answer."
+    end
+
+    test "reports an unparsable tool call rather than converting it", %{chain: chain} do
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok,
+         [
+           MessageDelta.new!(%{
+             role: :assistant,
+             tool_calls: [
+               ToolCall.new!(%{
+                 status: :incomplete,
+                 type: :function,
+                 call_id: "call_bad",
+                 name: "search_web",
+                 arguments: "{\"query\": ",
+                 index: 0
+               })
+             ]
+           })
+         ]}
+      end)
+
+      chain =
+        chain
+        |> Map.put(:max_retry_count, 1)
+        |> LLMChain.add_message(Message.new_user!("Testing"))
+
+      assert {:error, error_chain, %LangChainError{} = error} = LLMChain.run(chain)
+      assert error.type == "delta_conversion_failed"
+      assert error_chain.delta == nil
     end
   end
 
@@ -1606,18 +1669,10 @@ defmodule LangChain.Chains.LLMChainTest do
                |> LLMChain.add_messages([Message.new_user!("Hi")])
                |> LLMChain.run()
 
-      assert %MessageDelta{
-               merged_content: [
-                 %ContentPart{
-                   type: :text,
-                   content: "Hello World",
-                   options: []
-                 }
-               ],
-               status: :incomplete,
-               role: :assistant
-             } =
-               updated_chain.delta
+      assert %Message{
+               role: :assistant,
+               content: [%ContentPart{type: :text, content: "Hello World", options: []}]
+             } = updated_chain.last_message
     end
 
     test "returns error when receives overloaded from Anthropic" do

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -2914,6 +2914,30 @@ defmodule LangChain.Chains.LLMChainTest do
       refute_received :retries_exceeded_callback
     end
 
+    test "a looping mode cannot re-invoke the model past the retry budget" do
+      # An unterminated response used to add no message, leaving needs_response
+      # true, so a looping mode re-invoked the model with the same transcript
+      # until something eventually completed. :while_needs_response has no run
+      # bound of its own, so the chain's retry budget is the only ceiling.
+      # Mimic fails the test if a call is made beyond the expected count.
+      incomplete_deltas = [
+        MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete}),
+        MessageDelta.new!(%{content: "Sock", status: :incomplete})
+      ]
+
+      expect(ChatOpenAI, :call, 2, fn _model, _messages, _tools -> {:ok, incomplete_deltas} end)
+
+      chain =
+        LLMChain.new!(%{llm: ChatOpenAI.new!(%{stream: true}), max_retry_count: 2})
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+
+      assert {:error, error_chain, %LangChainError{type: "incomplete_stream"}} =
+               LLMChain.run(chain, mode: :while_needs_response)
+
+      assert error_chain.delta == nil
+      assert [%Message{role: :user}] = error_chain.messages
+    end
+
     test "transient incomplete stream recovers on retry without duplicating text" do
       # The retry starts from a clean chain: the first attempt's partial text
       # must not be prepended to the retry's message.

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -656,75 +656,6 @@ defmodule LangChain.Chains.LLMChainTest do
     end
   end
 
-  describe "run/2 with a streamed response that never completes" do
-    setup do
-      %{chain: LLMChain.new!(%{llm: ChatOpenAI.new!(%{stream: true}), verbose: false})}
-    end
-
-    test "converts the partial delta into a message", %{chain: chain} do
-      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
-        {:ok,
-         [
-           MessageDelta.new!(%{role: :assistant, content: "Sounds like "}),
-           MessageDelta.new!(%{content: "a shakedown run."})
-         ]}
-      end)
-
-      chain = LLMChain.add_message(chain, Message.new_user!("Testing"))
-
-      assert {:ok, updated_chain} = LLMChain.run(chain)
-      assert updated_chain.delta == nil
-      assert %Message{role: :assistant} = answer = updated_chain.last_message
-      assert ContentPart.parts_to_string(answer.content) == "Sounds like a shakedown run."
-      assert updated_chain.needs_response == false
-    end
-
-    test "does not merge a later response into the unfinished one", %{chain: chain} do
-      # An unfinished delta used to stay live on the chain while `needs_response`
-      # stayed true, so a looping mode called the model again and the next
-      # response merged into the same content slot. One call, one message.
-      expect(ChatOpenAI, :call, 1, fn _model, _messages, _tools ->
-        {:ok, [MessageDelta.new!(%{role: :assistant, content: "First answer."})]}
-      end)
-
-      chain = LLMChain.add_message(chain, Message.new_user!("Testing"))
-
-      assert {:ok, updated_chain} = LLMChain.run(chain, mode: :while_needs_response)
-      assert [_user, %Message{role: :assistant} = answer] = updated_chain.messages
-      assert ContentPart.parts_to_string(answer.content) == "First answer."
-    end
-
-    test "reports an unparsable tool call rather than converting it", %{chain: chain} do
-      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
-        {:ok,
-         [
-           MessageDelta.new!(%{
-             role: :assistant,
-             tool_calls: [
-               ToolCall.new!(%{
-                 status: :incomplete,
-                 type: :function,
-                 call_id: "call_bad",
-                 name: "search_web",
-                 arguments: "{\"query\": ",
-                 index: 0
-               })
-             ]
-           })
-         ]}
-      end)
-
-      chain =
-        chain
-        |> Map.put(:max_retry_count, 1)
-        |> LLMChain.add_message(Message.new_user!("Testing"))
-
-      assert {:error, error_chain, %LangChainError{} = error} = LLMChain.run(chain)
-      assert error.type == "delta_conversion_failed"
-      assert error_chain.delta == nil
-    end
-  end
-
   describe "apply_deltas/2" do
     test "applies list of deltas" do
       deltas = [
@@ -1658,7 +1589,8 @@ defmodule LangChain.Chains.LLMChainTest do
              MessageDelta.new!(%{content: "Hello ", role: :assistant}),
              [],
              MessageDelta.new!(%{content: "World", role: :assistant})
-           ]
+           ],
+           [MessageDelta.new!(%{content: nil, status: :complete})]
          ]}
       end)
 
@@ -1669,10 +1601,12 @@ defmodule LangChain.Chains.LLMChainTest do
                |> LLMChain.add_messages([Message.new_user!("Hi")])
                |> LLMChain.run()
 
-      assert %Message{
-               role: :assistant,
-               content: [%ContentPart{type: :text, content: "Hello World", options: []}]
-             } = updated_chain.last_message
+      content = [ContentPart.text!("Hello World")]
+
+      assert %Message{role: :assistant, content: ^content, status: :complete} =
+               updated_chain.last_message
+
+      assert updated_chain.delta == nil
     end
 
     test "returns error when receives overloaded from Anthropic" do
@@ -2929,6 +2863,138 @@ defmodule LangChain.Chains.LLMChainTest do
       # :on_retries_exceeded fired exactly once at the end
       assert_received :retries_exceeded_callback
       refute_received :retries_exceeded_callback
+    end
+
+    test "stream ending without a terminal delta exhausts retries with incomplete_stream" do
+      # A stream whose deltas never reach a terminal status is a failed LLM
+      # call, not a silent success. Each attempt fires :on_llm_error and
+      # retries from a clean chain until max_retry_count is exhausted.
+      handler = %{
+        on_llm_error: fn _chain, error ->
+          send(self(), {:llm_error_callback, error})
+        end,
+        on_retries_exceeded: fn _chain ->
+          send(self(), :retries_exceeded_callback)
+        end
+      }
+
+      incomplete_deltas = [
+        MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete}),
+        MessageDelta.new!(%{content: "Sock", status: :incomplete})
+      ]
+
+      # max_retry_count: 3 -> expect exactly 3 LLM calls before exhausting
+      expect(ChatOpenAI, :call, 3, fn _model, _messages, _tools -> {:ok, incomplete_deltas} end)
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatOpenAI.new!(%{stream: true}),
+          max_retry_count: 3,
+          callbacks: [handler]
+        })
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+
+      assert {:error, error_chain, %LangChainError{type: "incomplete_stream"}} =
+               LLMChain.run(chain)
+
+      # the hanging delta is cleared, never carried into a later call
+      assert error_chain.delta == nil
+
+      # no message was added, so needs_response still reflects the user message
+      assert error_chain.needs_response == true
+
+      # :on_llm_error fired once per attempt (3 total)
+      assert_received {:llm_error_callback, %LangChainError{type: "incomplete_stream"}}
+      assert_received {:llm_error_callback, %LangChainError{type: "incomplete_stream"}}
+      assert_received {:llm_error_callback, %LangChainError{type: "incomplete_stream"}}
+      refute_received {:llm_error_callback, _}
+
+      # :on_retries_exceeded fired exactly once at the end
+      assert_received :retries_exceeded_callback
+      refute_received :retries_exceeded_callback
+    end
+
+    test "transient incomplete stream recovers on retry without duplicating text" do
+      # The retry starts from a clean chain: the first attempt's partial text
+      # must not be prepended to the retry's message.
+      handler = %{
+        on_llm_error: fn _chain, error ->
+          send(self(), {:llm_error_callback, error})
+        end,
+        on_retries_exceeded: fn _chain ->
+          send(self(), :retries_exceeded_callback)
+        end
+      }
+
+      incomplete_deltas = [
+        MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete}),
+        MessageDelta.new!(%{content: "Sock", status: :incomplete})
+      ]
+
+      good_deltas = [
+        MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete}),
+        MessageDelta.new!(%{content: "Socktastic!", status: :incomplete}),
+        MessageDelta.new!(%{content: nil, status: :complete})
+      ]
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools -> {:ok, incomplete_deltas} end)
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools -> {:ok, good_deltas} end)
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatOpenAI.new!(%{stream: true}),
+          max_retry_count: 3,
+          callbacks: [handler]
+        })
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+
+      assert {:ok, updated_chain} = LLMChain.run(chain)
+
+      content = [ContentPart.text!("Socktastic!")]
+
+      assert %Message{role: :assistant, content: ^content, status: :complete} =
+               updated_chain.last_message
+
+      # :on_llm_error fired exactly once for the transient failure
+      assert_received {:llm_error_callback, %LangChainError{type: "incomplete_stream"}}
+      refute_received {:llm_error_callback, _}
+      refute_received :retries_exceeded_callback
+    end
+
+    test "leftover delta from a prior call is dropped before a new run" do
+      # A chain can arrive at do_run with a delta still attached, from an
+      # external caller re-running a chain after an errored stream or from a
+      # host that accumulates deltas onto the chain itself. The stale delta is
+      # dropped so it cannot merge with the new call's deltas.
+      good_deltas = [
+        MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete}),
+        MessageDelta.new!(%{content: "Socktastic!", status: :incomplete}),
+        MessageDelta.new!(%{content: nil, status: :complete})
+      ]
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools -> {:ok, good_deltas} end)
+
+      chain =
+        LLMChain.new!(%{llm: ChatOpenAI.new!(%{stream: true})})
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+        |> LLMChain.merge_delta(
+          MessageDelta.new!(%{role: :assistant, content: ContentPart.text!("stale text")})
+        )
+
+      assert chain.delta != nil
+
+      {result, log} =
+        ExUnit.CaptureLog.with_log(fn ->
+          LLMChain.run(chain)
+        end)
+
+      assert {:ok, updated_chain} = result
+      assert log =~ "leftover streaming delta"
+
+      content = [ContentPart.text!("Socktastic!")]
+
+      assert %Message{role: :assistant, content: ^content, status: :complete} =
+               updated_chain.last_message
     end
 
     test "empty streaming response succeeds in run" do

--- a/test/chat_models/chat_req_llm_test.exs
+++ b/test/chat_models/chat_req_llm_test.exs
@@ -1042,6 +1042,15 @@ if Code.ensure_loaded?(ReqLLM) do
       }
     end
 
+    # Same, with the out-of-band metadata req_llm collects alongside the chunk
+    # stream. Reached only when the stream ends without a terminal chunk.
+    defp fake_stream_response(chunks, finish_reason) do
+      {:ok, handle} =
+        ReqLLM.StreamResponse.MetadataHandle.start_link(fn -> %{finish_reason: finish_reason} end)
+
+      %{fake_stream_response(chunks) | metadata_handle: handle}
+    end
+
     # ============================================================
     # translate_stream_chunk/1
     # ============================================================
@@ -1396,6 +1405,125 @@ if Code.ensure_loaded?(ReqLLM) do
     # ============================================================
     # Streaming transport failures (raised during consumption)
     # ============================================================
+
+    describe "do_api_request/4 streaming without a terminal chunk" do
+      test "closes the turn as truncated when the stream just ends" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
+
+        chunks = [
+          %ReqLLM.StreamChunk{type: :content, text: "Half an "},
+          %ReqLLM.StreamChunk{type: :content, text: "answer"}
+        ]
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response(chunks, :incomplete)}
+        end)
+
+        result = ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
+
+        assert [%MessageDelta{}, %MessageDelta{}, %MessageDelta{} = closing] = result
+        assert closing.status == :length
+        assert closing.content == nil
+      end
+
+      test "closes the turn cleanly when the stream reports a normal finish" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
+
+        chunks = [%ReqLLM.StreamChunk{type: :content, text: "All done"}]
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response(chunks, :stop)}
+        end)
+
+        assert [%MessageDelta{}, %MessageDelta{status: :complete}] =
+                 ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
+      end
+
+      test "delivers the closing delta to the streaming callback" do
+        test_pid = self()
+
+        model =
+          %{
+            ChatReqLLM.new!(%{model: @live_model, stream: true})
+            | callbacks: [%{on_llm_new_delta: fn deltas -> send(test_pid, {:delta, deltas}) end}]
+          }
+
+        chunks = [%ReqLLM.StreamChunk{type: :content, text: "Hi"}]
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response(chunks, :incomplete)}
+        end)
+
+        ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
+
+        assert_received {:delta, [%MessageDelta{status: :incomplete}]}
+        assert_received {:delta, [%MessageDelta{status: :length}]}
+      end
+
+      test "adds nothing when the stream already ended with a terminal chunk" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
+
+        chunks = [
+          %ReqLLM.StreamChunk{type: :content, text: "Complete"},
+          %ReqLLM.StreamChunk{type: :meta, metadata: %{finish_reason: :stop, terminal?: true}}
+        ]
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response(chunks, :stop)}
+        end)
+
+        assert [%MessageDelta{}, %MessageDelta{status: :complete}] =
+                 ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
+      end
+
+      test "closes the turn when the finish reason cannot be read" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
+
+        chunks = [%ReqLLM.StreamChunk{type: :content, text: "Half an answer"}]
+
+        # `fake_stream_response/1` supplies a metadata handle that cannot answer.
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response(chunks)}
+        end)
+
+        assert [%MessageDelta{}, %MessageDelta{status: :complete}] =
+                 ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
+      end
+
+      test "leaves an empty stream alone" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response([], :incomplete)}
+        end)
+
+        assert [] = ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
+      end
+
+      test "a turn of only text becomes one message through the chain" do
+        chunks = [
+          %ReqLLM.StreamChunk{type: :content, text: "Sounds like "},
+          %ReqLLM.StreamChunk{type: :content, text: "a shakedown run."}
+        ]
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response(chunks, :incomplete)}
+        end)
+
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
+
+        assert {:ok, updated_chain} =
+                 %{llm: model}
+                 |> LLMChain.new!()
+                 |> LLMChain.add_message(Message.new_user!("Testing"))
+                 |> LLMChain.run()
+
+        assert updated_chain.delta == nil
+        assert [_user, %Message{role: :assistant} = answer] = updated_chain.messages
+        assert ContentPart.parts_to_string(answer.content) == "Sounds like a shakedown run."
+        assert updated_chain.needs_response == false
+      end
+    end
 
     describe "do_api_request/4 streaming transport failures" do
       # Mirrors req_llm: the lazy stream yields chunks, then raises

--- a/test/chat_models/chat_req_llm_test.exs
+++ b/test/chat_models/chat_req_llm_test.exs
@@ -1407,7 +1407,42 @@ if Code.ensure_loaded?(ReqLLM) do
     # ============================================================
 
     describe "do_api_request/4 streaming without a terminal chunk" do
-      test "closes the turn as truncated when the stream just ends" do
+      test "closes the turn when the finish reason reports a finished response" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
+
+        chunks = [
+          %ReqLLM.StreamChunk{type: :content, text: "All "},
+          %ReqLLM.StreamChunk{type: :content, text: "done"}
+        ]
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response(chunks, :stop)}
+        end)
+
+        assert [%MessageDelta{}, %MessageDelta{}, %MessageDelta{} = closing] =
+                 ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
+
+        assert closing.status == :complete
+        assert closing.content == nil
+      end
+
+      test "carries a truncating finish reason onto the closing delta" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
+
+        chunks = [%ReqLLM.StreamChunk{type: :content, text: "As far as I got"}]
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response(chunks, :length)}
+        end)
+
+        assert [%MessageDelta{}, %MessageDelta{status: :length}] =
+                 ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
+      end
+
+      test "leaves the turn unfinished when the stream ended early" do
+        # req_llm reports `:incomplete` for a body that ended without a
+        # recognized terminal event. The response may be a fragment, so the
+        # deltas are handed over as they are and the chain decides.
         model = ChatReqLLM.new!(%{model: @live_model, stream: true})
 
         chunks = [
@@ -1419,23 +1454,21 @@ if Code.ensure_loaded?(ReqLLM) do
           {:ok, fake_stream_response(chunks, :incomplete)}
         end)
 
-        result = ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
-
-        assert [%MessageDelta{}, %MessageDelta{}, %MessageDelta{} = closing] = result
-        assert closing.status == :length
-        assert closing.content == nil
+        assert [%MessageDelta{status: :incomplete}, %MessageDelta{status: :incomplete}] =
+                 ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
       end
 
-      test "closes the turn cleanly when the stream reports a normal finish" do
+      test "leaves the turn unfinished when the finish reason cannot be read" do
         model = ChatReqLLM.new!(%{model: @live_model, stream: true})
 
-        chunks = [%ReqLLM.StreamChunk{type: :content, text: "All done"}]
+        chunks = [%ReqLLM.StreamChunk{type: :content, text: "Half an answer"}]
 
+        # `fake_stream_response/1` supplies a metadata handle that cannot answer.
         stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
-          {:ok, fake_stream_response(chunks, :stop)}
+          {:ok, fake_stream_response(chunks)}
         end)
 
-        assert [%MessageDelta{}, %MessageDelta{status: :complete}] =
+        assert [%MessageDelta{status: :incomplete}] =
                  ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
       end
 
@@ -1451,13 +1484,13 @@ if Code.ensure_loaded?(ReqLLM) do
         chunks = [%ReqLLM.StreamChunk{type: :content, text: "Hi"}]
 
         stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
-          {:ok, fake_stream_response(chunks, :incomplete)}
+          {:ok, fake_stream_response(chunks, :stop)}
         end)
 
         ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
 
         assert_received {:delta, [%MessageDelta{status: :incomplete}]}
-        assert_received {:delta, [%MessageDelta{status: :length}]}
+        assert_received {:delta, [%MessageDelta{status: :complete}]}
       end
 
       test "adds nothing when the stream already ended with a terminal chunk" do
@@ -1476,38 +1509,24 @@ if Code.ensure_loaded?(ReqLLM) do
                  ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
       end
 
-      test "closes the turn when the finish reason cannot be read" do
-        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
-
-        chunks = [%ReqLLM.StreamChunk{type: :content, text: "Half an answer"}]
-
-        # `fake_stream_response/1` supplies a metadata handle that cannot answer.
-        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
-          {:ok, fake_stream_response(chunks)}
-        end)
-
-        assert [%MessageDelta{}, %MessageDelta{status: :complete}] =
-                 ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
-      end
-
       test "leaves an empty stream alone" do
         model = ChatReqLLM.new!(%{model: @live_model, stream: true})
 
         stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
-          {:ok, fake_stream_response([], :incomplete)}
+          {:ok, fake_stream_response([], :stop)}
         end)
 
         assert [] = ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
       end
 
-      test "a turn of only text becomes one message through the chain" do
+      test "a finished response missing its marker becomes one message through the chain" do
         chunks = [
           %ReqLLM.StreamChunk{type: :content, text: "Sounds like "},
           %ReqLLM.StreamChunk{type: :content, text: "a shakedown run."}
         ]
 
         stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
-          {:ok, fake_stream_response(chunks, :incomplete)}
+          {:ok, fake_stream_response(chunks, :stop)}
         end)
 
         model = ChatReqLLM.new!(%{model: @live_model, stream: true})
@@ -1522,6 +1541,29 @@ if Code.ensure_loaded?(ReqLLM) do
         assert [_user, %Message{role: :assistant} = answer] = updated_chain.messages
         assert ContentPart.parts_to_string(answer.content) == "Sounds like a shakedown run."
         assert updated_chain.needs_response == false
+      end
+
+      test "a stream that ended early is retried by the chain and never merged" do
+        # Each attempt streams its own text. The chain must discard the first
+        # rather than merge the second onto it.
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok,
+           fake_stream_response(
+             [%ReqLLM.StreamChunk{type: :content, text: "First generation."}],
+             :incomplete
+           )}
+        end)
+
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
+
+        assert {:error, error_chain, %LangChainError{type: "incomplete_stream"}} =
+                 %{llm: model, max_retry_count: 2}
+                 |> LLMChain.new!()
+                 |> LLMChain.add_message(Message.new_user!("Testing"))
+                 |> LLMChain.run()
+
+        assert error_chain.delta == nil
+        assert [%Message{role: :user}] = error_chain.messages
       end
     end
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -28,7 +28,10 @@ When `stream: true`, responses arrive as partial `MessageDelta` structs over tim
 **Main Process Context (LLMChain caller):**
 1. After stream ends, LLMChain receives accumulated deltas
 2. `apply_deltas/2` merges them using `MessageDelta.merge_delta/2`
-3. When delta status becomes `:complete`, converts to `Message`
+3. When delta status becomes `:complete`, converts to `Message`. A response
+   whose deltas never reach a terminal status is a failed call, not a silent
+   success: the partial delta is dropped and the call is retried as an
+   `"incomplete_stream"` error
 4. Chain fires `:on_message_processed` with completed message
 
 **Key insight**: The `:on_llm_new_delta` callback runs in the HTTP task context, not the main process. For LiveView/GenServer integrations, these callbacks should send messages to the main process for state updates.


### PR DESCRIPTION
## Problem

`LLMChain` turns its accumulated `chain.delta` into a `Message` only when a delta arrives carrying a terminal status. Nothing enforces that a ChatModel ever produces one, and `delta_to_message_when_complete/1` silently no-ops when it does not.

That makes a non-terminating stream fail invisibly. `do_run/1` returns `{:ok, chain}` having appended no message, so three things stay true at once:

1. No assistant message is added.
2. `needs_response` stays `true`, and a looping mode calls the model again.
3. `chain.delta` is cleared only on completion, so it is still live.

The next generation then merges into the same accumulator at the same content index. The user gets one assistant message containing three to five separate, complete answers concatenated end to end, and the count varies with how many calls it took before one finally completed.

`ChatReqLLM` is where this surfaces. `req_llm` derives terminality from a recognized terminal event in the response body (`[DONE]`, `message_stop`, `response.completed`, `response.incomplete`). A stream whose body simply ends carries no such chunk, so every delta stays `:incomplete` and `consume_stream/3` reports success with no completion in it.

This is not specific to one provider. Any adapter that returns a batch of deltas without a terminal one produces the same run-on message.

## Solution

The chain treats an unterminated response as a failed call. The adapter closes a turn itself only where it can prove nothing was lost.

**`LLMChain` never lets a delta outlive the call that produced it.**

`apply_deltas_from_ended_stream/2` wraps the two `do_run/1` delta branches, which were already identical. The streamed response has fully ended by the time `apply_deltas/2` runs there, so a delta still on the chain means no terminal delta ever arrived. That is logged, the delta is dropped, and the call is routed through the existing `handle_delta_error/1` as a new `"incomplete_stream"` error: `:on_llm_error` per attempt, bounded retries from a clean chain, `:on_retries_exceeded` on exhaustion, matching how `delta_conversion_failed` is already handled.

`drop_stale_delta/1` additionally clears any leftover delta at the top of `do_run/1`. A chain can arrive there with one attached, from a caller re-running after an errored stream or from a host that accumulates deltas onto the chain itself, which `usage-rules.md` documents. Dropping it makes cross-call merging structurally impossible rather than merely unreachable.

The partial text is discarded rather than salvaged. The chain cannot tell a response cut off partway through from one that finished and lost only its terminator, and half-streamed text or an incomplete set of tool calls must not enter the transcript.

**`ChatReqLLM` closes a turn only when the finish reason proves it is whole.**

A ChatModel sometimes can tell the difference, and `req_llm` records it: `finish_reason` is `:stop` when a terminal event was seen and `:incomplete` when the body just ended. `consume_stream/3` now checks, once the stream is exhausted, whether any delta carried a terminal status. If none did:

- A reason reporting a finished response (`:stop`, `:tool_calls`, `:length`, `:content_filter`) means only the marker went missing. A closing delta is synthesized with the status that reason maps to and delivered through the streaming callback like any other, so consumers building their own message from `:on_llm_new_delta` see the turn finish too.
- Anything else, including `:incomplete` and a reason that could not be read, leaves the response unfinished for the chain to retry.

Reading the finish reason means calling into a separate `req_llm` process. It is wrapped so a collector that is gone or fails reports no reason, which leaves the turn unfinished rather than closing it on a guess.

Public contracts are unchanged. `apply_deltas/2` and `delta_to_message_when_complete/1` still return incomplete deltas untouched for incremental and mid-stream callers.

## Changes

- [`lib/chains/llm_chain.ex`](https://github.com/brainlid/langchain/blob/me-fix-multiplied-text/lib/chains/llm_chain.ex#L1203) - New `drop_stale_delta/1` and `apply_deltas_from_ended_stream/2`; both `do_run/1` delta branches route through the latter, and `do_run/1` drops a leftover delta before invoking the model.
- [`lib/chat_models/chat_req_llm.ex`](https://github.com/brainlid/langchain/blob/me-fix-multiplied-text/lib/chat_models/chat_req_llm.ex#L448) - `consume_stream/3` appends a closing delta when the stream carried no terminal chunk and the finish reason reports a finished response; new `closing_delta/2`, `close_turn/1`, `stream_finish_reason/1`, and `deliver_deltas/3`.
- [`lib/chat_models/chat_req_llm.ex`](https://github.com/brainlid/langchain/blob/me-fix-multiplied-text/lib/chat_models/chat_req_llm.ex#L53) (`@moduledoc`) - New "Stream Completion" section covering both outcomes.
- [`test/chains/llm_chain_test.exs`](https://github.com/brainlid/langchain/blob/me-fix-multiplied-text/test/chains/llm_chain_test.exs#L2868) - Retry exhaustion (three attempts, callbacks per attempt, error type preserved through exhaustion, `needs_response` still true), a looping mode held to the retry budget under `:while_needs_response` (the mode with no run bound of its own), transient recovery asserting the retried message contains its text exactly once, and the stale-delta drop.
- [`test/chat_models/chat_req_llm_test.exs`](https://github.com/brainlid/langchain/blob/me-fix-multiplied-text/test/chat_models/chat_req_llm_test.exs#L1409) - New describe block covering both branches of the finish-reason decision: closed for `:stop` and `:length`, left unfinished for `:incomplete` and an unreadable reason, callback delivery, no-op when a terminal chunk is present, empty streams, and end-to-end runs through `LLMChain` for both outcomes. Adds a `fake_stream_response/2` helper supplying a real metadata handle.
- [`usage-rules.md`](https://github.com/brainlid/langchain/blob/me-fix-multiplied-text/usage-rules.md#L28) - The streaming flow now records that a response which never terminates is a retried error rather than a silent success.

Two existing tests had encoded the old silent-success behavior in their setup and were updated intent-preservingly. "ignores empty lists in the list of messages" now uses a terminated stream and asserts the merged message, so the fixture represents a real stream and the test still tests what its name says. "remove delta and adds cancelled message" now builds its mid-stream state through the public `merge_delta/2`, matching how a real cancellation host accumulates deltas, since cancelling happens partway through a stream rather than after a completed run.

## Call volume

The old path multiplied calls *because* it concatenated. The hanging delta is what kept `needs_response` true, and that is what re-entered the mode loop, so the two were the same defect seen from either end.

| | Before | After |
|---|---|---|
| What drives the re-call | `needs_response` still true, so the mode loop re-enters | `handle_delta_error/1`, the chain's existing failure path |
| Bound | None. `WhileNeedsResponse` has no `check_max_runs` | `max_retry_count`, default 3, per turn |
| Delta between calls | Left live, so call N+1 merges into call N's accumulator | Dropped before every attempt |
| Result | One message, N generations concatenated | One clean message, or one error |
| Observability | None. Reported as success | `:on_llm_error` per attempt, `:on_retries_exceeded` on exhaustion |

A response that finished and lost only its terminal marker is now one call that succeeds, since the adapter closes the turn from the finish reason and never reaches the retry path. Only a stream reported as genuinely cut short retries, and that response really is a fragment.

## Testing

`mix precommit` is clean: 2372 tests pass (41 doctests), no formatting, Credo, or dependency-audit issues. `mix dialyzer` passes. No live API calls are involved; the new tests stub `ReqLLM.stream_text/3` with Mimic and drive `LLMChain` with a stubbed `ChatOpenAI.call/3`, following the existing conventions in both files.

## Notes for reviewers

- A retry replays. The partial text reached consumers through `:on_llm_new_delta` before the retry started, so a host that appends deltas to a live buffer shows both attempts until the final message replaces it. `ChatReqLLM.handle_request_failure/6` declines to retry for exactly this reason at the transport layer. Retrying here is still the right call, since the alternative is admitting a fragment into the transcript, but hosts that render raw deltas should reset their buffer on `:on_llm_error`.
- `LangChain.Chains.LLMChain.Modes.WhileNeedsResponse` has no run bound, unlike `UntilToolUsed`, whose pipeline includes `check_max_runs/2`. `UntilSuccess` is similarly exposed, since it recurses on any last message that is not an assistant response or a clean tool result. Both are made safe against this failure by the change above, but adding a default `max_runs` would break legitimate long tool loops and deserves its own decision.
- `ChatReqLLM` assigns one content index per chunk type rather than per content block, so several text blocks in a single response merge into one. That cannot be fixed here yet: `req_llm`'s Responses decoder threads an output index through tool-call chunks but not text ones, so separate blocks are indistinguishable downstream.
