### PR TITLE
fix handle failed streams and drop stale deltas

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -922,6 +922,8 @@ defmodule LangChain.Chains.LLMChain do
   end
 
   defp do_run(%LLMChain{} = chain) do
+    chain = drop_stale_delta(chain)
+
     # submit to LLM. The "llm" is a struct. Match to get the name of the module
     # then execute the `.call` function on that module.
     %module{} = chain.llm
@@ -960,30 +962,12 @@ defmodule LangChain.Chains.LLMChain do
       {:ok, [%MessageDelta{} | _] = deltas} ->
         if chain.verbose_deltas, do: IO.inspect(deltas, label: "DELTA MESSAGE LIST RESPONSE")
 
-        case apply_deltas(chain, deltas) do
-          {:ok, updated_chain} ->
-            if chain.verbose,
-              do: IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
-
-            {:ok, updated_chain}
-
-          {:error, _chain, _reason} = error ->
-            handle_delta_error(error)
-        end
+        apply_deltas_from_ended_stream(chain, deltas)
 
       {:ok, [[%MessageDelta{} | _] | _] = deltas} ->
         if chain.verbose_deltas, do: IO.inspect(deltas, label: "DELTA MESSAGE LIST RESPONSE")
 
-        case apply_deltas(chain, deltas) do
-          {:ok, updated_chain} ->
-            if chain.verbose,
-              do: IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
-
-            {:ok, updated_chain}
-
-          {:error, _chain, _reason} = error ->
-            handle_delta_error(error)
-        end
+        apply_deltas_from_ended_stream(chain, deltas)
 
       {:error, %LangChainError{} = reason} ->
         if chain.verbose, do: IO.inspect(reason, label: "ERROR")
@@ -1214,6 +1198,52 @@ defmodule LangChain.Chains.LLMChain do
   @spec reset_streaming_state(t()) :: t()
   defp reset_streaming_state(%LLMChain{} = chain) do
     %LLMChain{chain | delta: nil}
+  end
+
+  # Every path that consumes or rejects a streamed delta clears it from the
+  # chain, so a delta present at the start of an LLM call can only be leftover
+  # state from a caller re-running a chain after an errored stream. Drop it —
+  # merging it with the new call's deltas would corrupt the new message.
+  defp drop_stale_delta(%LLMChain{delta: nil} = chain), do: chain
+
+  defp drop_stale_delta(%LLMChain{} = chain) do
+    Logger.warning("Starting an LLM call with a leftover streaming delta; dropping it")
+    drop_delta(chain)
+  end
+
+  # The streamed response has fully ended by the time apply_deltas/2 runs here,
+  # so a delta still on the chain means the provider never sent a terminal
+  # chunk (the stream was cut off, or ended with a frame the provider decoder
+  # does not recognize). Reporting that as success adds no message, leaving
+  # `needs_response` unchanged and the hanging delta ready to merge with the
+  # next call's text — an agent loop would re-invoke the LLM indefinitely while
+  # the answer text accumulates. Treat it as a retryable LLM error instead.
+  @spec apply_deltas_from_ended_stream(t(), list()) ::
+          {:ok, t()} | {:error, t(), LangChainError.t()}
+  defp apply_deltas_from_ended_stream(%LLMChain{} = chain, deltas) do
+    case apply_deltas(chain, deltas) do
+      {:ok, %LLMChain{delta: nil} = updated_chain} ->
+        if chain.verbose,
+          do: IO.inspect(updated_chain.last_message, label: "COMBINED DELTA MESSAGE RESPONSE")
+
+        {:ok, updated_chain}
+
+      {:ok, %LLMChain{delta: %MessageDelta{status: status}} = updated_chain} ->
+        Logger.warning(
+          "LLM stream ended without a terminal chunk (delta status: #{inspect(status)})"
+        )
+
+        handle_delta_error(
+          {:error, reset_streaming_state(updated_chain),
+           LangChainError.exception(
+             type: "incomplete_stream",
+             message: "LLM stream ended without completing the message"
+           )}
+        )
+
+      {:error, _chain, _reason} = error ->
+        handle_delta_error(error)
+    end
   end
 
   # Handle a delta-conversion error like a retryable LLM error: fire

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -216,24 +216,18 @@ defmodule LangChain.Chains.LLMChainTest do
     test "remove delta and adds cancelled message" do
       model = ChatOpenAI.new!(%{temperature: 1, stream: true})
 
-      # Made NOT LIVE here
-      fake_messages = [
-        [MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete})],
-        [MessageDelta.new!(%{content: "Sock", status: :incomplete})]
-      ]
-
-      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
-        {:ok, fake_messages}
-      end)
-
-      # We can construct an LLMChain from a PromptTemplate and an LLM.
-      {:ok, updated_chain} =
+      # Build the mid-stream state the way a streaming host does: deltas
+      # accumulated onto the chain with no terminal delta received yet.
+      updated_chain =
         %{llm: model, verbose: false}
         |> LLMChain.new!()
         |> LLMChain.add_message(
           Message.new_user!("What is a good name for a company that makes colorful socks?")
         )
-        |> LLMChain.run()
+        |> LLMChain.merge_delta(
+          MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete})
+        )
+        |> LLMChain.merge_delta(MessageDelta.new!(%{content: "Sock", status: :incomplete}))
 
       assert %MessageDelta{} = updated_chain.delta
       new_chain = LLMChain.cancel_delta(updated_chain, :cancelled)
@@ -1595,7 +1589,8 @@ defmodule LangChain.Chains.LLMChainTest do
              MessageDelta.new!(%{content: "Hello ", role: :assistant}),
              [],
              MessageDelta.new!(%{content: "World", role: :assistant})
-           ]
+           ],
+           [MessageDelta.new!(%{content: nil, status: :complete})]
          ]}
       end)
 
@@ -1606,18 +1601,12 @@ defmodule LangChain.Chains.LLMChainTest do
                |> LLMChain.add_messages([Message.new_user!("Hi")])
                |> LLMChain.run()
 
-      assert %MessageDelta{
-               merged_content: [
-                 %ContentPart{
-                   type: :text,
-                   content: "Hello World",
-                   options: []
-                 }
-               ],
-               status: :incomplete,
-               role: :assistant
-             } =
-               updated_chain.delta
+      content = [ContentPart.text!("Hello World")]
+
+      assert %Message{role: :assistant, content: ^content, status: :complete} =
+               updated_chain.last_message
+
+      assert updated_chain.delta == nil
     end
 
     test "returns error when receives overloaded from Anthropic" do
@@ -2874,6 +2863,139 @@ defmodule LangChain.Chains.LLMChainTest do
       # :on_retries_exceeded fired exactly once at the end
       assert_received :retries_exceeded_callback
       refute_received :retries_exceeded_callback
+    end
+
+    test "stream ending without a terminal delta exhausts retries with incomplete_stream" do
+      # A stream whose deltas never reach status :complete (no terminal frame
+      # from the provider) is a failed LLM call, not a silent success. Each
+      # attempt fires :on_llm_error and retries from a clean chain until
+      # max_retry_count is exhausted.
+      handler = %{
+        on_llm_error: fn _chain, error ->
+          send(self(), {:llm_error_callback, error})
+        end,
+        on_retries_exceeded: fn _chain ->
+          send(self(), :retries_exceeded_callback)
+        end
+      }
+
+      incomplete_deltas = [
+        MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete}),
+        MessageDelta.new!(%{content: "Sock", status: :incomplete})
+      ]
+
+      # max_retry_count: 3 → expect exactly 3 LLM calls before exhausting
+      expect(ChatOpenAI, :call, 3, fn _model, _messages, _tools -> {:ok, incomplete_deltas} end)
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatOpenAI.new!(%{stream: true}),
+          max_retry_count: 3,
+          callbacks: [handler]
+        })
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+
+      assert {:error, error_chain, %LangChainError{type: "incomplete_stream"}} =
+               LLMChain.run(chain)
+
+      # the hanging delta is cleared, never carried into a later call
+      assert error_chain.delta == nil
+
+      # no message was added, so needs_response still reflects the user message
+      assert error_chain.needs_response == true
+
+      # :on_llm_error fired once per attempt (3 total)
+      assert_received {:llm_error_callback, %LangChainError{type: "incomplete_stream"}}
+      assert_received {:llm_error_callback, %LangChainError{type: "incomplete_stream"}}
+      assert_received {:llm_error_callback, %LangChainError{type: "incomplete_stream"}}
+      refute_received {:llm_error_callback, _}
+
+      # :on_retries_exceeded fired exactly once at the end
+      assert_received :retries_exceeded_callback
+      refute_received :retries_exceeded_callback
+    end
+
+    test "transient incomplete stream recovers on retry without duplicating text" do
+      # The retry starts from a clean chain: the first attempt's partial text
+      # must not be prepended to the retry's message.
+      handler = %{
+        on_llm_error: fn _chain, error ->
+          send(self(), {:llm_error_callback, error})
+        end,
+        on_retries_exceeded: fn _chain ->
+          send(self(), :retries_exceeded_callback)
+        end
+      }
+
+      incomplete_deltas = [
+        MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete}),
+        MessageDelta.new!(%{content: "Sock", status: :incomplete})
+      ]
+
+      good_deltas = [
+        MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete}),
+        MessageDelta.new!(%{content: "Socktastic!", status: :incomplete}),
+        MessageDelta.new!(%{content: nil, status: :complete})
+      ]
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools -> {:ok, incomplete_deltas} end)
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools -> {:ok, good_deltas} end)
+
+      chain =
+        LLMChain.new!(%{
+          llm: ChatOpenAI.new!(%{stream: true}),
+          max_retry_count: 3,
+          callbacks: [handler]
+        })
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+
+      assert {:ok, updated_chain} = LLMChain.run(chain)
+
+      content = [ContentPart.text!("Socktastic!")]
+
+      assert %Message{role: :assistant, content: ^content, status: :complete} =
+               updated_chain.last_message
+
+      # :on_llm_error fired exactly once for the transient failure
+      assert_received {:llm_error_callback, %LangChainError{type: "incomplete_stream"}}
+      refute_received {:llm_error_callback, _}
+      refute_received :retries_exceeded_callback
+    end
+
+    test "leftover delta from a prior call is dropped before a new run" do
+      # A chain can arrive at do_run with a delta still attached (e.g. an
+      # external caller re-running a chain after an errored stream). The stale
+      # delta is dropped with a warning so it cannot merge with the new call's
+      # deltas.
+      good_deltas = [
+        MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete}),
+        MessageDelta.new!(%{content: "Socktastic!", status: :incomplete}),
+        MessageDelta.new!(%{content: nil, status: :complete})
+      ]
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools -> {:ok, good_deltas} end)
+
+      chain =
+        LLMChain.new!(%{llm: ChatOpenAI.new!(%{stream: true})})
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+        |> LLMChain.merge_delta(
+          MessageDelta.new!(%{role: :assistant, content: ContentPart.text!("stale text")})
+        )
+
+      assert chain.delta != nil
+
+      {result, log} =
+        ExUnit.CaptureLog.with_log(fn ->
+          LLMChain.run(chain)
+        end)
+
+      assert {:ok, updated_chain} = result
+      assert log =~ "leftover streaming delta"
+
+      content = [ContentPart.text!("Socktastic!")]
+
+      assert %Message{role: :assistant, content: ^content, status: :complete} =
+               updated_chain.last_message
     end
 
     test "empty streaming response succeeds in run" do


### PR DESCRIPTION
## Problem

When a streamed LLM response ends without a terminal chunk (the provider stream
was cut off, or ended with a frame the provider decoder doesn't recognize —
e.g. the OpenAI Responses API's `response.failed`), the merged delta never
reaches `status: :complete`. `apply_deltas/2` returns `{:ok, chain}` with no
message added and the hanging delta still on the chain, so `do_run/1` reports
the LLM call as a **success that produced nothing**.

Two bad things follow:

1. `needs_response` never updates (it only changes when a message is added), so
   agent loops built on it re-invoke the LLM with the identical transcript —
   in our production case, up to `max_runs` times.
2. The hanging delta is never cleared, so each re-invocation's text merges onto
   the previous attempt's — the eventual message contains the answer repeated
   N times (or fails `to_message/1` with `delta_conversion_failed`).

## Fix

- `do_run/1`'s streaming arms now check the chain after `apply_deltas/2`: a
  delta still present means the stream ended without a terminal. That case is
  logged and routed through the existing `handle_delta_error/1` as a new
  `"incomplete_stream"` error type — so it gets `:on_llm_error`, bounded
  retries from a clean chain (`max_retry_count`), and `:on_retries_exceeded`,
  matching how `delta_conversion_failed` is handled.
- `do_run/1` also drops (with a warning) any leftover delta from a prior
  errored call before invoking the model, so cross-call delta merging is
  structurally impossible.

Public contracts are unchanged: `apply_deltas/2` and
`delta_to_message_when_complete/1` still return incomplete deltas untouched
for incremental/mid-stream callers. The partial text is deliberately discarded
on retry rather than salvaged — half-streamed text or tool-call JSON must not
enter the transcript.

## Tests

Three new tests in `llm_chain_test.exs`: retry exhaustion (3 attempts,
callbacks fired per attempt, error type preserved), transient recovery
asserting the retried message contains its text exactly once (the duplication
regression), and the stale-delta drop.

Two existing tests had encoded the old silent-success behavior in their setup
and were updated intent-preservingly: "ignores empty lists in the list of
messages" now uses a terminated stream and asserts the merged message;
"remove delta and adds cancelled message" now builds its mid-stream state via
the public `merge_delta/2` (matching how a real cancellation host accumulates
deltas) instead of running an unterminated stream through `run/1`.
```

