### PR TITLE
Surface ChatReqLLM stream failures instead of completing the partial message

### DIFF
--- a/lib/chains/llm_chain.ex
+++ b/lib/chains/llm_chain.ex
@@ -999,6 +999,14 @@ defmodule LangChain.Chains.LLMChain do
         Logger.error("Error during chat call. Reason: #{inspect(reason)}")
         {:error, chain, reason}
 
+      # A streamed response can fail before producing any delta (e.g. a
+      # provider error frame as the first event), arriving as a flat list
+      # whose head is an error tuple.
+      {:ok, [{:error, %LangChainError{} = reason} | _]} ->
+        if chain.verbose, do: IO.inspect(reason, label: "ERROR")
+        Callbacks.fire(chain.callbacks, :on_llm_error, [chain, reason])
+        {:error, chain, reason}
+
       {:ok, unexpected} ->
         Logger.warning("Unexpected LLM response format: #{inspect(unexpected)}")
 

--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -832,11 +832,28 @@ if Code.ensure_loaded?(ReqLLM) do
         end
 
       finish_deltas =
-        if meta[:terminal?] do
-          status = translate_finish_reason(meta[:finish_reason])
-          [MessageDelta.new!(%{role: :assistant, status: status, index: 0})]
-        else
-          []
+        cond do
+          meta[:terminal?] != true ->
+            []
+
+          meta[:finish_reason] == :error ->
+            # The provider reported the stream as failed (e.g. OpenAI Responses
+            # `response.failed`). Emitting a :complete finish delta here would
+            # present the partial text as a finished answer and drop the
+            # provider's error message. An error tuple routes through
+            # LLMChain's cancel_delta path instead: the partial text becomes a
+            # :stream_error message carrying this error in metadata.
+            [
+              {:error,
+               LangChainError.exception(
+                 type: "stream_error",
+                 message: meta[:error] || "stream error"
+               )}
+            ]
+
+          true ->
+            status = translate_finish_reason(meta[:finish_reason])
+            [MessageDelta.new!(%{role: :assistant, status: status, index: 0})]
         end
 
       usage_deltas ++ finish_deltas

--- a/lib/chat_models/chat_req_llm.ex
+++ b/lib/chat_models/chat_req_llm.ex
@@ -466,12 +466,18 @@ if Code.ensure_loaded?(ReqLLM) do
     defp closing_delta(_stream_response, []), do: nil
 
     defp closing_delta(stream_response, deltas) do
-      if Enum.any?(deltas, &(&1.status != :incomplete)) do
+      if Enum.any?(deltas, &turn_closed?/1) do
         nil
       else
         close_turn(stream_finish_reason(stream_response))
       end
     end
+
+    # A stream error ends the turn the same way a terminal delta does:
+    # `LLMChain` turns the text streamed so far into a `:stream_error` message
+    # and stops. Nothing is missing, so there is no closing delta to add.
+    defp turn_closed?({:error, _reason}), do: true
+    defp turn_closed?(%MessageDelta{status: status}), do: status != :incomplete
 
     defp close_turn(finish_reason) when finish_reason in @finished_reasons do
       Logger.warning(fn ->

--- a/test/chains/llm_chain_test.exs
+++ b/test/chains/llm_chain_test.exs
@@ -3021,6 +3021,61 @@ defmodule LangChain.Chains.LLMChainTest do
                updated_chain.last_message
     end
 
+    test "stream ending with an error terminal preserves partial text as a stream_error message" do
+      # A provider failure frame (e.g. OpenAI Responses `response.failed`)
+      # arrives as an error tuple in the delta stream. The partial text is
+      # kept, but marked :stream_error with the provider's error in metadata,
+      # and the turn ends.
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok,
+         [
+           MessageDelta.new!(%{role: :assistant, content: nil, status: :incomplete}),
+           MessageDelta.new!(%{content: "Partial answ", status: :incomplete}),
+           {:error,
+            LangChainError.exception(type: "stream_error", message: "The model run failed")}
+         ]}
+      end)
+
+      {:ok, updated_chain} =
+        %{llm: ChatOpenAI.new!(%{stream: true})}
+        |> LLMChain.new!()
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+        |> LLMChain.run()
+
+      content = [ContentPart.text!("Partial answ")]
+
+      assert %Message{role: :assistant, content: ^content, status: :stream_error} =
+               updated_chain.last_message
+
+      assert %LangChainError{message: "The model run failed"} =
+               updated_chain.last_message.metadata.streaming_error
+
+      assert updated_chain.delta == nil
+      assert updated_chain.needs_response == false
+    end
+
+    test "stream that fails before any content returns the stream error" do
+      handler = %{
+        on_llm_error: fn _chain, error ->
+          send(self(), {:llm_error_callback, error})
+        end
+      }
+
+      expect(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok,
+         [{:error, LangChainError.exception(type: "stream_error", message: "Invalid request")}]}
+      end)
+
+      chain =
+        LLMChain.new!(%{llm: ChatOpenAI.new!(%{stream: true}), callbacks: [handler]})
+        |> LLMChain.add_message(Message.new_user!("Hello"))
+
+      assert {:error, _chain, %LangChainError{type: "stream_error", message: "Invalid request"}} =
+               LLMChain.run(chain)
+
+      assert_received {:llm_error_callback, %LangChainError{type: "stream_error"}}
+    end
+
     test "empty streaming response succeeds in run" do
       # Return deltas that produce an empty assistant message (no content, no tool_calls).
       # This is valid -- e.g., LLM has nothing to say after processing tool results.

--- a/test/chat_models/chat_req_llm_test.exs
+++ b/test/chat_models/chat_req_llm_test.exs
@@ -1128,6 +1128,43 @@ if Code.ensure_loaded?(ReqLLM) do
         assert delta.status == :length
       end
 
+      test "terminal meta with :error finish reason produces a stream error tuple" do
+        chunk = %ReqLLM.StreamChunk{
+          type: :meta,
+          metadata: %{finish_reason: :error, terminal?: true, error: "The model run failed"}
+        }
+
+        assert [{:error, %LangChainError{type: "stream_error", message: "The model run failed"}}] =
+                 ChatReqLLM.translate_stream_chunk(chunk)
+      end
+
+      test "terminal meta with :error finish reason falls back to a generic message" do
+        chunk = %ReqLLM.StreamChunk{
+          type: :meta,
+          metadata: %{finish_reason: :error, terminal?: true}
+        }
+
+        assert [{:error, %LangChainError{type: "stream_error", message: "stream error"}}] =
+                 ChatReqLLM.translate_stream_chunk(chunk)
+      end
+
+      test "terminal meta with :error finish reason still emits usage" do
+        chunk = %ReqLLM.StreamChunk{
+          type: :meta,
+          metadata: %{
+            finish_reason: :error,
+            terminal?: true,
+            error: "boom",
+            usage: %{input_tokens: 10, output_tokens: 5}
+          }
+        }
+
+        assert [%MessageDelta{} = usage_delta, {:error, %LangChainError{type: "stream_error"}}] =
+                 ChatReqLLM.translate_stream_chunk(chunk)
+
+        assert %TokenUsage{input: 10, output: 5} = usage_delta.metadata[:usage]
+      end
+
       test "meta chunk with usage produces a usage MessageDelta" do
         chunk = %ReqLLM.StreamChunk{
           type: :meta,

--- a/test/chat_models/chat_req_llm_test.exs
+++ b/test/chat_models/chat_req_llm_test.exs
@@ -1437,6 +1437,58 @@ if Code.ensure_loaded?(ReqLLM) do
 
         assert text == "Hello there!"
       end
+
+      test "a provider failure frame ends the stream with a stream error" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
+
+        chunks = [
+          %ReqLLM.StreamChunk{type: :content, text: "Partial answ"},
+          %ReqLLM.StreamChunk{
+            type: :meta,
+            metadata: %{terminal?: true, finish_reason: :error, error: "The model run failed"}
+          }
+        ]
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response(chunks, :error)}
+        end)
+
+        assert [
+                 %MessageDelta{},
+                 {:error, %LangChainError{type: "stream_error", message: "The model run failed"}}
+               ] = ChatReqLLM.do_api_request(model, [Message.new_user!("hi")], [], 3)
+      end
+
+      test "LLMChain keeps the partial text of a failed stream as a stream_error message" do
+        model = ChatReqLLM.new!(%{model: @live_model, stream: true})
+
+        chunks = [
+          %ReqLLM.StreamChunk{type: :content, text: "Partial answ"},
+          %ReqLLM.StreamChunk{
+            type: :meta,
+            metadata: %{terminal?: true, finish_reason: :error, error: "The model run failed"}
+          }
+        ]
+
+        stub(ReqLLM, :stream_text, fn _model, _context, _opts ->
+          {:ok, fake_stream_response(chunks, :error)}
+        end)
+
+        assert {:ok, chain} =
+                 %{llm: model}
+                 |> LLMChain.new!()
+                 |> LLMChain.add_message(Message.new_user!("Say hello"))
+                 |> LLMChain.run()
+
+        assert %Message{role: :assistant, status: :stream_error} = chain.last_message
+        assert ContentPart.parts_to_string(chain.last_message.content) == "Partial answ"
+
+        assert %LangChainError{type: "stream_error", message: "The model run failed"} =
+                 chain.last_message.metadata.streaming_error
+
+        assert chain.delta == nil
+        refute chain.needs_response
+      end
     end
 
     # ============================================================

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -32,7 +32,11 @@ When `stream: true`, responses arrive as partial `MessageDelta` structs over tim
    whose deltas never reach a terminal status is a failed call, not a silent
    success: the partial delta is dropped and the call is retried as an
    `"incomplete_stream"` error
-4. Chain fires `:on_message_processed` with completed message
+4. A provider that reports the stream as failed puts an
+   `{:error, %LangChainError{type: "stream_error"}}` tuple in the delta list.
+   The text streamed so far is kept as a message with status `:stream_error`,
+   carrying the error under `metadata.streaming_error`, and the turn ends
+5. Chain fires `:on_message_processed` with completed message
 
 **Key insight**: The `:on_llm_new_delta` callback runs in the HTTP task context, not the main process. For LiveView/GenServer integrations, these callbacks should send messages to the main process for state updates.
 


### PR DESCRIPTION
## Problem

As of req_llm v1.21.1 ([agentjido/req_llm#977](https://github.com/agentjido/req_llm/pull/977)),
OpenAI Responses API failure frames (`response.failed`, `error`) are decoded into
terminal meta chunks carrying `finish_reason: :error` and the provider's error
message. `ChatReqLLM` needs 2 updates to how it handles that signal:

1. `translate_finish_reason(:error)` maps to `:complete`, and the finish-delta
   builder drops `meta[:error]` entirely. A stream that *failed* produces an
   ordinary `status: :complete` assistant message — a truncated answer is
   presented as a finished one, and the provider's error message is discarded.
2. A stream that fails before producing any content yields a delta list whose
   head is an error tuple, which no `do_run/1` arm matches — it falls through
   to a generic `unexpected_response`.

## Fix

- A terminal meta chunk with `finish_reason: :error` now emits
  `{:error, %LangChainError{type: "stream_error", message: <provider's message>}}`
  into the delta stream instead of a fake-complete finish delta. This routes
  through the existing `merge_delta/2` → `cancel_delta/3` machinery, so the
  behavior matches how streamed provider errors (e.g. Anthropic `overloaded`)
  are already handled: the partial text is preserved as a `:stream_error`
  message with the error in `metadata.streaming_error`, and the turn ends.
  Usage metadata on the same chunk is still captured.
- `do_run/1` gains a clause for a delta list headed by an error tuple
  (stream failed before any content): fires `:on_llm_error` and returns the
  error with its type intact.

No new conventions introduced — `"stream_error"` and the `cancel_delta` path
are existing, tested machinery.

## Tests

- Three unit tests on `translate_stream_chunk/1`: error terminal with a
  message, fallback when no message is present, and usage + error emitted
  together.
- Two end-to-end tests on `LLMChain.run/1`: partial text preserved and marked
  `:stream_error` with the provider's error in metadata, and a
  fails-before-content stream returning the error (with `:on_llm_error` fired).
