### PR TITLE
Keep whitespace-only Ollama stop sequences through casting

### DIFF
--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -346,7 +346,15 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
   @spec new(attrs :: map()) :: {:ok, t} | {:error, Ecto.Changeset.t()}
   def new(%{} = attrs \\ %{}) do
     %ChatOllamaAI{}
-    |> cast(attrs, @create_fields, empty_values: [""])
+    # Ecto trims a value before checking it against `:empty_values`, so a
+    # whitespace-only string counts as empty and is dropped from an array
+    # field. Stop sequences are frequently exactly that: "\n" and "\t" are
+    # ordinary stop sequences. Comparing untrimmed keeps them, while an empty
+    # string is still discarded.
+    |> cast(attrs, @create_fields,
+      empty_values: [""],
+      trim_values: fn _type, value -> value end
+    )
     |> common_validation()
     |> apply_action(:insert)
   end


### PR DESCRIPTION
## Problem

`ChatOllamaAI.new/1` silently drops whitespace-only stop sequences. `ChatOllamaAI.new!(%{"stop" => ["\n"]})` produces a model with no stop sequence at all, so the LLM does not stop where the caller asked and there is no error or warning to say why.

`"\n"` and `"\t"` are ordinary stop sequences for Ollama. Losing them changes generation behavior without any signal.

The cause is a change in how Ecto decides a cast value is empty:

| Version | Behavior |
|---|---|
| 3.10.0 | `:empty_values` may hold a function, and the default becomes a trimmed-string check. Supplying your own list replaces that default, opting out of trimming |
| 3.14.0 | Trimming moves into a separate `:trim_values` option applied *before* the `:empty_values` comparison. Functions in `:empty_values` now raise |

`ChatOllamaAI` is the only module in `lib/` that passes `empty_values: [""]`. That was a deliberate opt-out of trimming, and 3.14 disabled it without changing the line: a value is now trimmed first, so `"\n"` becomes `""`, matches `empty_values`, and is removed from the `stop` array.

## Solution

Pass `trim_values: fn _type, value -> value end` alongside the existing `empty_values: [""]`. Comparing untrimmed restores exactly what that line already meant: an empty string is discarded, anything else is kept.

`:trim_values` is Ecto's own documented replacement for the opt-out, so this restores the intent rather than introducing a new mechanism. On Ecto below 3.14 the option is ignored, since `cast/4` reads options with `Keyword.get` and does not validate unknown keys, and those versions already compared untrimmed when given a custom `:empty_values`. No change to the `{:ecto, "~> 3.10 or ~> 3.11"}` requirement is needed.

`Utils.assign_string_value/3`, which `LangChain.Message.ContentPart` and `LangChain.MessageDelta` use to protect their content fields, does not apply here. It only re-puts a value when `is_binary(val)`, so a `{:array, :string}` field like `stop` falls straight through it and the already-filtered cast result stands.

## Scope

Only `ChatOllamaAI` is affected.

- `LangChain.Message`, `LangChain.Message.ContentPart`, and `LangChain.MessageDelta` cast with Ecto's default, which has trimmed since 3.10. Their behavior is unchanged by 3.14, and `ContentPart` and `MessageDelta` bypass the cast for content entirely via `Utils.assign_string_value/3`.
- Both text splitters pass `empty_values: [nil]`. A binary trims to `""`, and `"" in [nil]` is false, so nothing is filtered, which is what they want.
- The remaining `{:array, :string}` fields (`beta_headers`, `file_ids`, `search_domain_filter`, `include`, `examples`) carry no meaningful whitespace-only entries.

## Changes

- [`lib/chat_models/chat_ollama_ai.ex`](https://github.com/brainlid/langchain/blob/me-fix-chat-ollama-issue/lib/chat_models/chat_ollama_ai.ex#L346) - `new/1` compares cast values untrimmed, with a comment stating why stop sequences need it.

## Testing

`mix precommit` is clean: 2372 tests pass (41 doctests), no formatting, Credo, or dependency-audit issues.

Existing coverage in `test/chat_models/chat_ollama_ai_test.exs` guards both halves of the contract, and no new test was needed to catch this:

- `"handles complex stop sequence scenarios"` asserts `["\\n", "\\t", "\n", "\t", "\"", "'"]` survives intact. This is the test that failed and surfaced the bug, and it fails again if the fix is reverted.
- `"handles edge cases for stop sequences"` asserts `["valid", "", "also_valid"]` still drops the empty string, confirming the fix does not over-correct.

A dedicated regression test naming the whitespace contract directly would be a reasonable follow-up, since today it is covered as part of two broader tests.