### PR TITLE
Document using ChatOllamaAI with llmman

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Elixir LangChain enables Elixir applications to integrate AI services and self-h
 - **Google Vertex AI** - Google's enterprise AI offering
 - **DeepSeek** - DeepSeek models with prompt caching support
 - **Ollama** - Locally hosted open-source models
+- **llmman** - Local model runner serving the Ollama API on port 17434, via `ChatOllamaAI`
 - **Mistral** - Mistral AI models
 - **Perplexity** - Perplexity AI models
 - **orq.ai** - orq.ai Deployments API
@@ -322,6 +323,18 @@ endpoint =
 ```
 
 Streaming and tool calling work the same as with native OpenAI: set `stream: true` and add tools via `LLMChain.add_tools/2`.
+
+### llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API on port 17434, so it works through `ChatOllamaAI` by overriding `endpoint` (adjust if `LLMMAN_HOST` binds elsewhere):
+
+```elixir
+{:ok, chat} =
+  ChatOllamaAI.new(%{
+    endpoint: "http://localhost:17434/api/chat",
+    model: "gemma4"
+  })
+```
 
 ### Bumblebee Chat Support
 

--- a/README.md
+++ b/README.md
@@ -326,15 +326,23 @@ Streaming and tool calling work the same as with native OpenAI: set `stream: tru
 
 ### llmman
 
-[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API on port 17434, so it works through `ChatOllamaAI` by overriding `endpoint` (adjust if `LLMMAN_HOST` binds elsewhere):
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API on port 17434, so it works through `ChatOllamaAI` by overriding `endpoint`:
 
 ```elixir
+alias LangChain.ChatModels.ChatOllamaAI
+
 {:ok, chat} =
   ChatOllamaAI.new(%{
     endpoint: "http://localhost:17434/api/chat",
     model: "gemma4"
   })
 ```
+
+`ChatOllamaAI` sends no credentials, so it reaches llmman only while the daemon
+accepts unauthenticated requests. This is the case for the default loopback
+bind. A daemon the network can reach, such as one bound wider through
+`LLMMAN_HOST`, requires an API key on every request and rejects these calls
+unless it runs with `LLMMAN_AUTH=off`.
 
 ### Bumblebee Chat Support
 

--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -88,6 +88,17 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
         endpoint: "http://my-ollama-host:11434/api/chat"
       })
 
+  ### Using with llmman
+
+  [llmman](https://github.com/llmmanorg/llmman) is a local model runner that
+  serves the Ollama API on port 17434, so `ChatOllamaAI` works against it
+  unchanged (adjust the port if `LLMMAN_HOST` binds it elsewhere):
+
+      ChatOllamaAI.new(%{
+        model: "gemma4",
+        endpoint: "http://localhost:17434/api/chat"
+      })
+
   ## Structured Outputs (`:format`)
 
   Ollama supports server-side structured output via the request's top-level

--- a/lib/chat_models/chat_ollama_ai.ex
+++ b/lib/chat_models/chat_ollama_ai.ex
@@ -92,12 +92,18 @@ defmodule LangChain.ChatModels.ChatOllamaAI do
 
   [llmman](https://github.com/llmmanorg/llmman) is a local model runner that
   serves the Ollama API on port 17434, so `ChatOllamaAI` works against it
-  unchanged (adjust the port if `LLMMAN_HOST` binds it elsewhere):
+  unchanged:
 
       ChatOllamaAI.new(%{
         model: "gemma4",
         endpoint: "http://localhost:17434/api/chat"
       })
+
+  `ChatOllamaAI` sends no credentials, matching Ollama's own unauthenticated
+  loopback service. llmman accepts these calls on its default loopback bind.
+  A daemon the network can reach, such as one bound wider through
+  `LLMMAN_HOST`, requires an API key on every request and rejects them unless
+  it runs with `LLMMAN_AUTH=off`.
 
   ## Structured Outputs (`:format`)
 


### PR DESCRIPTION
[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API on port 17434.

- No new chat model module: llmman's `/api/chat` is the Ollama chat API, so `ChatOllamaAI` works unchanged with `endpoint: "http://localhost:17434/api/chat"`. This mirrors the existing "Cloudflare Workers AI via `ChatOpenAI`" pattern instead of duplicating the module.
- README: one bullet in the supported chat models list and a short `### llmman` section showing the endpoint override.
- `ChatOllamaAI` moduledoc: a `### Using with llmman` subsection so hexdocs covers it too.
- No `provider/0`, telemetry, CHANGELOG or test changes since no code path changes; happy to add a CHANGELOG line if preferred.

**Testing:** `mix format --check-formatted` and `mix test test/chat_models/chat_ollama_ai_test.exs` (48 passed) pass; docs-only change.

> AI-assisted, reviewed before submitting.
