### PR TITLE
Capture reasoning model thinking on OpenAI-compatible endpoints

### DIFF
--- a/lib/chat_models/chat_aws_mantle.ex
+++ b/lib/chat_models/chat_aws_mantle.ex
@@ -374,7 +374,6 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
       stream: model.stream,
       messages:
         messages
-        |> Enum.map(&strip_thinking_parts/1)
         |> Enum.reduce([], fn m, acc ->
           case ChatOpenAI.for_api(model, m) do
             %{} = data -> [data | acc]
@@ -397,25 +396,6 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
       stream_options_for_api(model.stream_options)
     )
   end
-
-  # Strip :thinking ContentParts before sending a message back to Mantle.
-  # Mantle's wire format (OpenAI Chat Completions) has no representation for
-  # reasoning blocks — they're a response-side artifact we surface for UI
-  # display. `ChatOpenAI.content_part_for_api/2` has no clause for :thinking
-  # and will crash if one round-trips, so we filter them here.
-  @spec strip_thinking_parts(Message.t()) :: Message.t()
-  defp strip_thinking_parts(%Message{content: content} = msg) when is_list(content) do
-    cleaned =
-      Enum.reject(content, fn
-        %ContentPart{type: :thinking} -> true
-        %ContentPart{type: :unsupported} -> true
-        _ -> false
-      end)
-
-    %{msg | content: cleaned}
-  end
-
-  defp strip_thinking_parts(msg), do: msg
 
   defp response_format(%ChatAwsMantle{json_response: true, json_schema: schema})
        when not is_nil(schema) do

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -726,17 +726,22 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   @doc """
   Convert a list of ContentParts to the expected map of data for the OpenAI API.
 
-  Thinking parts are omitted.
+  Thinking and unsupported parts are omitted. Both are response-side artifacts
+  that this API surface has no request representation for, and both reach it by
+  round-tripping a message the provider itself produced.
 
   There is no agreed request representation for thinking across the services
   that speak this API. A provider returning it in `reasoning_content` may
   accept that field back, ignore it, or accept it only in a particular mode,
   and the field is absent from the OpenAI request schema the rest of these
-  services are modeled on.
+  services are modeled on. Unsupported parts, such as the `redacted_thinking`
+  block Anthropic returns, hold opaque provider data with no meaning here at
+  all.
 
-  Nothing depends on returning it. Reasoning here carries no signature to
-  validate and no continuity requirement, so a conversation sends the answer
-  text and any tool calls, and the model reasons afresh on the next turn.
+  Nothing depends on returning either. Reasoning on this surface carries no
+  signature to validate and no continuity requirement, so a conversation sends
+  the answer text and any tool calls, and the model reasons afresh on the next
+  turn.
 
   The omission is unconditional, which is what keeps prompt caching working.
   A prefix cache is built from what the client sends rather than from what the
@@ -747,7 +752,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
   """
   def content_parts_for_api(%_{} = model, content_parts) when is_list(content_parts) do
     content_parts
-    |> Enum.reject(&(&1.type == :thinking))
+    |> Enum.reject(&(&1.type in [:thinking, :unsupported]))
     |> Enum.map(&content_part_for_api(model, &1))
   end
 

--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -256,6 +256,32 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     be spent on thinking through and reasoning about the request and the
     response.
 
+  ### Returned Thinking
+
+  OpenAI-compatible services other than OpenAI itself return a reasoning
+  model's thinking in a `reasoning_content` field beside `content`. It arrives
+  on the message for a single response and on each chunk when streaming.
+
+  That thinking becomes a `LangChain.Message.ContentPart` of type `:thinking`,
+  held separately from the answer text and ordered ahead of it:
+
+      [
+        %ContentPart{type: :thinking, content: "Comparing the tenths place..."},
+        %ContentPart{type: :text, content: "9.9 is larger."}
+      ]
+
+  Reaching such a service takes an `endpoint` for it, and often an extra header
+  supplied through `req_config`:
+
+      ChatOpenAI.new!(%{
+        endpoint: "https://api.cloudflare.com/client/v4/accounts/\#{account_id}/ai/v1/chat/completions",
+        api_key: api_key,
+        model: "@cf/zai-org/glm-5.3-flash",
+        reasoning_mode: true,
+        reasoning_effort: "medium",
+        req_config: %{headers: [{"cf-aig-gateway-id", gateway_id}]}
+      })
+
   ## Connection Retry Behavior
 
   The `retry_count` option controls how many times a request is retried when
@@ -699,9 +725,30 @@ defmodule LangChain.ChatModels.ChatOpenAI do
 
   @doc """
   Convert a list of ContentParts to the expected map of data for the OpenAI API.
+
+  Thinking parts are omitted.
+
+  There is no agreed request representation for thinking across the services
+  that speak this API. A provider returning it in `reasoning_content` may
+  accept that field back, ignore it, or accept it only in a particular mode,
+  and the field is absent from the OpenAI request schema the rest of these
+  services are modeled on.
+
+  Nothing depends on returning it. Reasoning here carries no signature to
+  validate and no continuity requirement, so a conversation sends the answer
+  text and any tool calls, and the model reasons afresh on the next turn.
+
+  The omission is unconditional, which is what keeps prompt caching working.
+  A prefix cache is built from what the client sends rather than from what the
+  model produced, so a conversation that always omits thinking presents a
+  prefix that matches itself turn after turn. Omitting it on some turns and
+  including it on others would break the prefix at the first message that
+  differs and cost a cache miss for everything after it.
   """
   def content_parts_for_api(%_{} = model, content_parts) when is_list(content_parts) do
-    Enum.map(content_parts, &content_part_for_api(model, &1))
+    content_parts
+    |> Enum.reject(&(&1.type == :thinking))
+    |> Enum.map(&content_part_for_api(model, &1))
   end
 
   @doc """
@@ -1144,6 +1191,32 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     end
   end
 
+  # Complete message carrying a reasoning model's thinking.
+  #
+  # OpenAI-compatible providers that expose reasoning models return the
+  # thinking in a `reasoning_content` field beside `content`. The two become
+  # separate content parts, thinking first, matching the order the model
+  # produced them.
+  #
+  # Handled ahead of the tool call and plain message clauses so a reasoning
+  # model that also calls a tool keeps both. Once the thinking is folded into
+  # `content`, the message is dispatched again for the clause that matches its
+  # shape.
+  def do_process_response(
+        model,
+        %{"message" => %{"reasoning_content" => reasoning} = message} = data
+      )
+      when is_binary(reasoning) and reasoning != "" do
+    content = reasoning_content_parts(reasoning, message["content"])
+
+    data
+    |> Map.put(
+      "message",
+      message |> Map.delete("reasoning_content") |> Map.put("content", content)
+    )
+    |> then(&do_process_response(model, &1))
+  end
+
   # Full message with tool call
   def do_process_response(
         model,
@@ -1167,6 +1240,41 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       {:error, %Ecto.Changeset{} = changeset} ->
         {:error, LangChainError.exception(changeset)}
     end
+  end
+
+  # Delta carrying a reasoning model's thinking.
+  #
+  # Providers streaming a reasoning model send `reasoning_content` alongside
+  # `content` on every chunk, carrying the thinking while it is being produced
+  # and `nil` once the answer begins. Thinking accumulates as a content part at
+  # position 0 and the answer text at position 1, keeping them distinct in the
+  # assembled message.
+  #
+  # `index` selects the position to merge into, so this repurposes the choice
+  # index. A request asking for multiple choices from a reasoning model would
+  # collapse them together.
+  def do_process_response(
+        model,
+        %{"delta" => %{"reasoning_content" => _} = delta_body} = msg
+      ) do
+    {index, content} =
+      case delta_body["reasoning_content"] do
+        reasoning when is_binary(reasoning) and reasoning != "" ->
+          {0, ContentPart.thinking!(reasoning)}
+
+        _no_reasoning ->
+          {1, delta_body["content"]}
+      end
+
+    delta_body =
+      delta_body
+      |> Map.delete("reasoning_content")
+      |> Map.put("content", content)
+
+    msg
+    |> Map.put("delta", delta_body)
+    |> Map.put("index", index)
+    |> then(&do_process_response(model, &1))
   end
 
   # Delta message tool call
@@ -1326,6 +1434,17 @@ defmodule LangChain.ChatModels.ChatOpenAI do
        message: "Unexpected response",
        original: other
      )}
+  end
+
+  # Build the content parts for a message that carried thinking, keeping the
+  # thinking ahead of the answer text. A response can be thinking-only, such as
+  # when the model stops on a token limit before answering.
+  defp reasoning_content_parts(reasoning, content) when is_binary(content) and content != "" do
+    [ContentPart.thinking!(reasoning), ContentPart.text!(content)]
+  end
+
+  defp reasoning_content_parts(reasoning, _content) do
+    [ContentPart.thinking!(reasoning)]
   end
 
   # Extract logprobs from a choice-level response map and return a metadata map.

--- a/test/chat_models/chat_aws_mantle_test.exs
+++ b/test/chat_models/chat_aws_mantle_test.exs
@@ -213,10 +213,10 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
 
     test "strips :thinking ContentParts from assistant messages before serialization", %{model: m} do
       # Mantle's wire format has no representation for thinking blocks.
-      # ChatAwsMantle surfaces them from delta.reasoning for UI display, but
-      # on the way back out (when a multi-turn conversation re-sends the
-      # assistant message as history), they must be filtered or ChatOpenAI's
-      # content_part_for_api/2 crashes (no clause for :thinking).
+      # ChatAwsMantle surfaces them from delta.reasoning for UI display. On the
+      # way back out, when a multi-turn conversation re-sends the assistant
+      # message as history, serialization goes through
+      # ChatOpenAI.content_parts_for_api/2, which omits them.
       history = [
         Message.new_user!("What model are you?"),
         %Message{
@@ -230,8 +230,6 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
         Message.new_user!("Great, what files do I have?")
       ]
 
-      # Should not raise — crashes pre-fix because the assistant message has
-      # a thinking part that ChatOpenAI can't serialize.
       body = ChatAwsMantle.for_api(m, history, [])
 
       assistant_serialized = Enum.at(body.messages, 1)
@@ -248,9 +246,9 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
       # Anthropic returns `redacted_thinking` blocks when extended thinking is
       # enabled but the content is encrypted. LangChain stores these as
       # %ContentPart{type: :unsupported, options: [type: "redacted_thinking"]}.
-      # If such a message is sent back to Mantle as history, the :unsupported
-      # part must be stripped — ChatOpenAI.content_part_for_api/2 has no clause
-      # for it and will crash.
+      # When such a message is sent back to Mantle as history, the
+      # :unsupported part is omitted by ChatOpenAI.content_parts_for_api/2,
+      # which holds no meaning on this wire format.
       redacted_thinking = %ContentPart{
         type: :unsupported,
         content: "<encrypted_thinking_data>",

--- a/test/chat_models/chat_open_ai_reasoning_live_test.exs
+++ b/test/chat_models/chat_open_ai_reasoning_live_test.exs
@@ -1,0 +1,379 @@
+defmodule LangChain.ChatModels.ChatOpenAIReasoningLiveTest do
+  @moduledoc """
+  Live coverage for reasoning models reached through the OpenAI-compatible
+  API surface, using Cloudflare Workers AI as the provider.
+
+  A reasoning model returns its thinking separately from its answer. On this
+  API surface the thinking arrives in a `reasoning_content` field that sits
+  beside `content` - on `choices[].message` for a single response, and on
+  `choices[].delta` for each streamed chunk.
+
+  The "raw wire format" tests dump the unparsed provider payload so the field
+  shape is visible. The "ChatOpenAI parsing" tests assert that thinking lands
+  in the parsed structs as a `:thinking` `ContentPart`.
+
+  Run with:
+
+      mix test test/chat_models/chat_open_ai_reasoning_live_test.exs --include live_cloudflare
+  """
+  use LangChain.BaseCase
+
+  alias LangChain.ChatModels.ChatOpenAI
+  alias LangChain.Chains.LLMChain
+  alias LangChain.Function
+  alias LangChain.FunctionParam
+  alias LangChain.Message
+  alias LangChain.Message.ContentPart
+  alias LangChain.MessageDelta
+
+  # A reasoning model served over Cloudflare's OpenAI-compatible endpoint.
+  @model "@cf/zai-org/glm-5.3-flash"
+
+  # A prompt that reliably provokes visible deliberation.
+  @prompt "Which is larger, 9.11 or 9.9? Think it through."
+
+  defp endpoint do
+    account_id = System.fetch_env!("CLOUDFLARE_ACCOUNT_ID")
+    "https://api.cloudflare.com/client/v4/accounts/#{account_id}/ai/v1/chat/completions"
+  end
+
+  defp api_key, do: System.fetch_env!("CLOUDFLARE_AI_API_TOKEN")
+
+  # Requests are routed through a named AI Gateway. The gateway is identified
+  # by a header; without it the call goes straight to Workers AI.
+  defp gateway_headers do
+    case System.get_env("CLOUDFLARE_AI_GATEWAY_ID") do
+      nil -> []
+      "" -> []
+      id -> [{"cf-aig-gateway-id", id}]
+    end
+  end
+
+  defp chat_model(overrides) do
+    ChatOpenAI.new!(
+      Map.merge(
+        %{
+          endpoint: endpoint(),
+          api_key: api_key(),
+          model: @model,
+          temperature: 1,
+          # `:reasoning_effort` is only placed on the request when
+          # `:reasoning_mode` is enabled.
+          reasoning_mode: true,
+          reasoning_effort: "medium",
+          req_config: %{headers: gateway_headers()}
+        },
+        overrides
+      )
+    )
+  end
+
+  # Pull every `:thinking` part out of a message or delta's content.
+  defp thinking_parts(%Message{content: content}), do: thinking_parts(content)
+  defp thinking_parts(%MessageDelta{merged_content: content}), do: thinking_parts(content)
+
+  defp thinking_parts(content) when is_list(content),
+    do: Enum.filter(content, &(&1.type == :thinking))
+
+  defp thinking_parts(_other), do: []
+
+  describe "raw wire format" do
+    @tag live_call: true, live_cloudflare: true
+    test "streamed chunks carry thinking in a reasoning_content delta field" do
+      body = %{
+        model: @model,
+        stream: true,
+        reasoning_effort: "medium",
+        messages: [%{role: "user", content: @prompt}]
+      }
+
+      IO.puts("\n=== REQUEST BODY ===")
+      IO.puts(Jason.encode!(body))
+
+      resp =
+        Req.post!(endpoint(),
+          json: body,
+          auth: {:bearer, api_key()},
+          headers: gateway_headers(),
+          receive_timeout: 120_000,
+          into: []
+        )
+
+      assert resp.status == 200
+
+      raw = IO.iodata_to_binary(resp.body)
+
+      IO.puts("\n=== RAW SSE ===")
+      IO.puts(raw)
+
+      deltas =
+        raw
+        |> String.split("\n")
+        |> Enum.filter(&String.starts_with?(&1, "data: "))
+        |> Enum.map(&String.replace_prefix(&1, "data: ", ""))
+        |> Enum.reject(&(&1 == "[DONE]"))
+        |> Enum.flat_map(fn line ->
+          case Jason.decode(line) do
+            {:ok, %{"choices" => choices}} -> Enum.map(choices, &(&1["delta"] || %{}))
+            _other -> []
+          end
+        end)
+
+      IO.puts("\n=== DISTINCT DELTA KEYS ===")
+      deltas |> Enum.flat_map(&Map.keys/1) |> Enum.uniq() |> Enum.sort() |> IO.inspect()
+
+      reasoning = deltas |> Enum.map(& &1["reasoning_content"]) |> Enum.reject(&is_nil/1)
+
+      IO.puts("\n=== ASSEMBLED reasoning_content ===")
+      IO.puts(Enum.join(reasoning))
+
+      assert reasoning != [], "expected the provider to stream reasoning_content chunks"
+    end
+
+    @tag live_call: true, live_cloudflare: true
+    test "a single response carries thinking in a reasoning_content message field" do
+      resp =
+        Req.post!(endpoint(),
+          json: %{
+            model: @model,
+            stream: false,
+            reasoning_effort: "medium",
+            messages: [%{role: "user", content: @prompt}]
+          },
+          auth: {:bearer, api_key()},
+          headers: gateway_headers(),
+          receive_timeout: 120_000
+        )
+
+      assert resp.status == 200
+
+      IO.puts("\n=== RAW RESPONSE BODY ===")
+      IO.inspect(resp.body, limit: :infinity, printable_limit: :infinity)
+
+      message = get_in(resp.body, ["choices", Access.at(0), "message"])
+
+      assert is_binary(message["reasoning_content"]),
+             "expected reasoning_content on the message, got keys: #{inspect(Map.keys(message))}"
+    end
+  end
+
+  describe "ChatOpenAI parsing" do
+    @tag live_call: true, live_cloudflare: true
+    test "streamed reasoning becomes a thinking ContentPart" do
+      test_pid = self()
+
+      handler = %{
+        on_llm_new_delta: fn _chain, deltas -> send(test_pid, {:deltas, deltas}) end,
+        on_message_processed: fn _chain, message -> send(test_pid, {:processed, message}) end
+      }
+
+      {:ok, chain} =
+        %{llm: chat_model(%{stream: true})}
+        |> LLMChain.new!()
+        |> LLMChain.add_callback(handler)
+        |> LLMChain.add_message(Message.new_user!(@prompt))
+        |> LLMChain.run()
+
+      message = chain.last_message
+
+      IO.puts("\n=== MERGED MESSAGE ===")
+      IO.inspect(message, limit: :infinity, printable_limit: :infinity)
+
+      IO.puts("\n=== CONTENT PART TYPES ===")
+      IO.inspect(Enum.map(message.content, & &1.type))
+
+      parts = thinking_parts(message)
+
+      assert parts != [],
+             "streamed reasoning was dropped; content parts were " <>
+               inspect(Enum.map(message.content, & &1.type))
+
+      [%ContentPart{type: :thinking} = thinking | _rest] = parts
+
+      assert String.length(thinking.content) > 0
+
+      assert Enum.any?(message.content, &(&1.type == :text)),
+             "expected the answer text alongside the thinking part"
+    end
+
+    @tag live_call: true, live_cloudflare: true
+    test "non-streamed reasoning becomes a thinking ContentPart" do
+      {:ok, chain} =
+        %{llm: chat_model(%{stream: false})}
+        |> LLMChain.new!()
+        |> LLMChain.add_message(Message.new_user!(@prompt))
+        |> LLMChain.run()
+
+      message = chain.last_message
+
+      IO.puts("\n=== MESSAGE ===")
+      IO.inspect(message, limit: :infinity, printable_limit: :infinity)
+
+      IO.puts("\n=== CONTENT PART TYPES ===")
+      IO.inspect(Enum.map(message.content, & &1.type))
+
+      parts = thinking_parts(message)
+
+      assert parts != [],
+             "reasoning was dropped; content parts were " <>
+               inspect(Enum.map(message.content, & &1.type))
+
+      [%ContentPart{type: :thinking} = thinking | _rest] = parts
+
+      assert String.length(thinking.content) > 0
+
+      assert Enum.any?(message.content, &(&1.type == :text)),
+             "expected the answer text alongside the thinking part"
+    end
+  end
+
+  describe "reasoning with tool calls" do
+    @tag live_call: true, live_cloudflare: true
+    test "completes a tool call round trip when the response includes thinking" do
+      weather =
+        Function.new!(%{
+          name: "get_weather",
+          description: "Get the current weather in a given US location",
+          parameters: [
+            FunctionParam.new!(%{
+              name: "city",
+              type: "string",
+              description: "The city name, e.g. San Francisco",
+              required: true
+            })
+          ],
+          function: fn _args, _context -> {:ok, "75 degrees and sunny"} end
+        })
+
+      {:ok, chain} =
+        %{llm: chat_model(%{stream: true})}
+        |> LLMChain.new!()
+        |> LLMChain.add_tools([weather])
+        |> LLMChain.add_message(
+          Message.new_user!("What is the weather in Moab, Utah? Use the get_weather tool.")
+        )
+        |> LLMChain.run(mode: :while_needs_response)
+
+      IO.puts("\n=== MESSAGE ROLES AND CONTENT TYPES ===")
+
+      Enum.each(chain.messages, fn msg ->
+        types =
+          case msg.content do
+            parts when is_list(parts) -> Enum.map(parts, & &1.type)
+            other -> other
+          end
+
+        IO.puts("#{msg.role}: #{inspect(types)} tool_calls=#{length(msg.tool_calls || [])}")
+      end)
+
+      # The assistant asked for the tool, the tool ran, and the model answered
+      # from the result. Reaching the final answer means the thinking part in
+      # the tool-calling message serialized without error on the second request.
+      assert Enum.any?(chain.messages, fn msg ->
+               msg.role == :assistant and msg.tool_calls not in [nil, []]
+             end)
+
+      assert Enum.any?(chain.messages, &(&1.role == :tool))
+
+      assert %Message{role: :assistant, status: :complete} = chain.last_message
+      assert ContentPart.parts_to_string(chain.last_message.content) =~ "75"
+    end
+
+    @tag live_call: true, live_cloudflare: true
+    test "runs a multi-turn chain where each tool call depends on the last" do
+      test_pid = self()
+
+      lookup_employee =
+        Function.new!(%{
+          name: "lookup_employee_id",
+          description: "Look up an employee's ID number by their first name",
+          parameters: [
+            FunctionParam.new!(%{
+              name: "name",
+              type: "string",
+              description: "The employee's first name",
+              required: true
+            })
+          ],
+          function: fn args, _context ->
+            send(test_pid, {:tool_called, "lookup_employee_id", args})
+            {:ok, "EMP-4471"}
+          end
+        })
+
+      vacation_days =
+        Function.new!(%{
+          name: "get_vacation_days",
+          description:
+            "Get remaining vacation days for an employee ID. Requires the ID, not a name.",
+          parameters: [
+            FunctionParam.new!(%{
+              name: "employee_id",
+              type: "string",
+              description: "The employee ID, in the form EMP-0000",
+              required: true
+            })
+          ],
+          function: fn args, _context ->
+            send(test_pid, {:tool_called, "get_vacation_days", args})
+            {:ok, "12 days remaining"}
+          end
+        })
+
+      {:ok, chain} =
+        %{llm: chat_model(%{stream: true})}
+        |> LLMChain.new!()
+        |> LLMChain.add_tools([lookup_employee, vacation_days])
+        |> LLMChain.add_message(
+          Message.new_user!(
+            "How many vacation days does Marcy have left? " <>
+              "Look up her employee ID first, then use that ID to check her vacation days."
+          )
+        )
+        |> LLMChain.run(mode: :while_needs_response)
+
+      IO.puts("\n=== CONVERSATION ===")
+
+      Enum.each(chain.messages, fn msg ->
+        types =
+          case msg.content do
+            parts when is_list(parts) -> Enum.map(parts, & &1.type)
+            other -> inspect(other)
+          end
+
+        calls = Enum.map(msg.tool_calls || [], & &1.name)
+        results = Enum.map(msg.tool_results || [], & &1.name)
+
+        IO.puts(
+          "#{msg.role}: content=#{inspect(types)} calls=#{inspect(calls)} results=#{inspect(results)}"
+        )
+      end)
+
+      # Both tools ran, and the second received the ID the first returned rather
+      # than the name from the prompt.
+      assert_received {:tool_called, "lookup_employee_id", %{"name" => name}}
+      assert String.downcase(name) =~ "marcy"
+      assert_received {:tool_called, "get_vacation_days", %{"employee_id" => "EMP-4471"}}
+
+      # Two separate assistant turns requested tools, so the chain made at least
+      # three requests. Every request after the first re-serialized the assistant
+      # messages already in the conversation, thinking parts included.
+      tool_calling_turns =
+        Enum.filter(chain.messages, fn msg ->
+          msg.role == :assistant and msg.tool_calls not in [nil, []]
+        end)
+
+      assert [_first, _second | _rest] = tool_calling_turns
+
+      thinking_turns =
+        Enum.filter(chain.messages, fn msg ->
+          is_list(msg.content) and Enum.any?(msg.content, &(&1.type == :thinking))
+        end)
+
+      IO.puts("\nassistant turns carrying thinking: #{length(thinking_turns)}")
+
+      assert %Message{role: :assistant, status: :complete} = chain.last_message
+      assert ContentPart.parts_to_string(chain.last_message.content) =~ "12"
+    end
+  end
+end

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -682,6 +682,39 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
     end
   end
 
+  describe "content_parts_for_api/2" do
+    test "omits thinking parts" do
+      model = ChatOpenAI.new!(%{"model" => @test_model})
+
+      parts = [
+        ContentPart.thinking!("Let me work through this."),
+        ContentPart.text!("The answer is 42.")
+      ]
+
+      assert [%{"type" => "text", "text" => "The answer is 42."}] =
+               ChatOpenAI.content_parts_for_api(model, parts)
+    end
+
+    test "a message of only thinking serializes with empty content" do
+      model = ChatOpenAI.new!(%{"model" => @test_model})
+
+      message =
+        Message.new_assistant!(%{
+          content: [ContentPart.thinking!("The user wants the weather, so call the tool.")],
+          tool_calls: [
+            ToolCall.new!(%{
+              call_id: "call_123",
+              name: "get_weather",
+              arguments: %{"city" => "Moab"}
+            })
+          ]
+        })
+
+      assert %{"role" => :assistant, "content" => [], "tool_calls" => [_call]} =
+               ChatOpenAI.for_api(model, message)
+    end
+  end
+
   describe "content_part_for_api/2" do
     test "turns a text ContentPart into the expected JSON format" do
       expected = %{"type" => "text", "text" => "Tell me about this image:"}
@@ -2216,6 +2249,120 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert %Message{role: :assistant} = response
       assert String.contains?(ContentPart.parts_to_string(response.content), "boardwalk")
       assert String.contains?(ContentPart.parts_to_string(response.content), "grass")
+    end
+  end
+
+  describe "do_process_response/2 with reasoning content" do
+    setup do
+      model = ChatOpenAI.new!(%{"model" => @test_model})
+      %{model: model}
+    end
+
+    test "splits a complete message into thinking and text parts", %{model: model} do
+      response = %{
+        "finish_reason" => "stop",
+        "index" => 0,
+        "message" => %{
+          "role" => "assistant",
+          "content" => "9.9 is larger.",
+          "reasoning_content" => "Compare the tenths place: 9 beats 1."
+        }
+      }
+
+      assert %Message{role: :assistant, status: :complete} =
+               message = ChatOpenAI.do_process_response(model, response)
+
+      assert [
+               %ContentPart{type: :thinking, content: "Compare the tenths place: 9 beats 1."},
+               %ContentPart{type: :text, content: "9.9 is larger."}
+             ] = message.content
+    end
+
+    test "keeps thinking when the message also calls a tool", %{model: model} do
+      response = %{
+        "finish_reason" => "tool_calls",
+        "index" => 0,
+        "message" => %{
+          "role" => "assistant",
+          "content" => nil,
+          "reasoning_content" => "The user wants the weather, so call the tool.",
+          "tool_calls" => [
+            %{
+              "id" => "call_123",
+              "type" => "function",
+              "function" => %{"name" => "get_weather", "arguments" => "{\"city\": \"Moab\"}"}
+            }
+          ]
+        }
+      }
+
+      assert %Message{role: :assistant} =
+               message = ChatOpenAI.do_process_response(model, response)
+
+      assert [
+               %ContentPart{
+                 type: :thinking,
+                 content: "The user wants the weather, so call the tool."
+               }
+             ] =
+               message.content
+
+      assert [%ToolCall{name: "get_weather", arguments: %{"city" => "Moab"}}] = message.tool_calls
+    end
+
+    test "a thinking delta merges separately from the answer text", %{model: model} do
+      thinking_delta = %{
+        "delta" => %{"role" => "assistant", "content" => nil, "reasoning_content" => "Let me "},
+        "finish_reason" => nil,
+        "index" => 0
+      }
+
+      more_thinking_delta = %{
+        "delta" => %{"content" => nil, "reasoning_content" => "think."},
+        "finish_reason" => nil,
+        "index" => 0
+      }
+
+      answer_delta = %{
+        "delta" => %{"content" => "9.9 ", "reasoning_content" => nil},
+        "finish_reason" => nil,
+        "index" => 0
+      }
+
+      more_answer_delta = %{
+        "delta" => %{"content" => "is larger.", "reasoning_content" => nil},
+        "finish_reason" => "stop",
+        "index" => 0
+      }
+
+      assert %MessageDelta{index: 0, content: %ContentPart{type: :thinking, content: "Let me "}} =
+               d1 = ChatOpenAI.do_process_response(model, thinking_delta)
+
+      assert %MessageDelta{index: 0} =
+               d2 = ChatOpenAI.do_process_response(model, more_thinking_delta)
+
+      assert %MessageDelta{index: 1} = d3 = ChatOpenAI.do_process_response(model, answer_delta)
+
+      assert %MessageDelta{index: 1} =
+               d4 = ChatOpenAI.do_process_response(model, more_answer_delta)
+
+      merged = MessageDelta.merge_deltas([d1, d2, d3, d4])
+
+      assert [
+               %ContentPart{type: :thinking, content: "Let me think."},
+               %ContentPart{type: :text, content: "9.9 is larger."}
+             ] = merged.merged_content
+    end
+
+    test "a delta without reasoning_content is unaffected", %{model: model} do
+      delta = %{
+        "delta" => %{"role" => "assistant", "content" => "Hello"},
+        "finish_reason" => nil,
+        "index" => 0
+      }
+
+      assert %MessageDelta{role: :assistant, content: "Hello", index: 0} =
+               ChatOpenAI.do_process_response(model, delta)
     end
   end
 

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -695,6 +695,22 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
                ChatOpenAI.content_parts_for_api(model, parts)
     end
 
+    test "omits unsupported parts" do
+      model = ChatOpenAI.new!(%{"model" => @test_model})
+
+      parts = [
+        %ContentPart{
+          type: :unsupported,
+          content: "<encrypted_thinking_data>",
+          options: [type: "redacted_thinking"]
+        },
+        ContentPart.text!("The answer is 42.")
+      ]
+
+      assert [%{"type" => "text", "text" => "The answer is 42."}] =
+               ChatOpenAI.content_parts_for_api(model, parts)
+    end
+
     test "a message of only thinking serializes with empty content" do
       model = ChatOpenAI.new!(%{"model" => @test_model})
 


### PR DESCRIPTION
## Problem

`ChatOpenAI` is used against OpenAI-compatible services by overriding `endpoint`, and several of those services expose reasoning models. Those providers return the model's thinking in a `reasoning_content` field beside `content` — on `choices[].message` for a single response, and on `choices[].delta` for each streamed chunk.

Nothing in `do_process_response/2` matched that field. Because `reasoning_content` is not a `MessageDelta` or `Message` field, Ecto's cast silently discarded it. The thinking was generated and billed, then dropped between the socket and the struct, with no error or warning to indicate it had happened.

OpenAI itself is unaffected — Chat Completions never returns reasoning text, only counts the tokens — so this only shows up on compatible services such as Cloudflare Workers AI.

Capturing thinking then exposed a second problem on the request side. `content_part_for_api/2` has no clause for `:thinking`, so the turn *after* a reasoning response raised a `FunctionClauseError`. `ChatAwsMantle` had already hit this and worked around it locally with a private `strip_thinking_parts/1`, filtering messages before delegating to `ChatOpenAI.for_api/2`.

## Solution

Two new `do_process_response/2` clauses recognize `reasoning_content` and turn it into a `ContentPart` of type `:thinking`, kept separate from and ordered ahead of the answer text.

Both clauses normalize and re-dispatch rather than duplicating the existing parsing. Each folds the thinking into `content`, deletes the `reasoning_content` key, and calls `do_process_response/2` again. With the key gone the new clause cannot re-match, so the payload falls through to the existing tool-call or plain-message clause. That is what lets a reasoning model that also calls a tool keep both.

For streaming, thinking merges into `merged_content` at position 0 and the answer text at position 1. `MessageDelta` uses `index` to select the merge position, so the choice index is repurposed; this is noted in the code as a limitation for `n > 1`.

On the request side, `content_parts_for_api/2` omits both `:thinking` and `:unsupported` parts. Both are response-side artifacts with no representation on this wire format, and both reach a request only by round-tripping a message the provider itself produced. Handling them in the shared function covers every module that delegates to it, so `ChatAwsMantle` drops its local `strip_thinking_parts/1` and serializes straight through.

Omission is unconditional so that a conversation presents a prefix that matches itself turn after turn, which is what keeps provider-side prompt caching viable.

`ChatOpenAIResponses` is untouched. It has its own role-aware `content_part_for_api/3` and its own `reasoning_item_for_api/1`, which deliberately *does* return reasoning when it carries `encrypted_content` — the continuity mechanism that API provides and Chat Completions does not.

## Changes

- `lib/chat_models/chat_open_ai.ex` — New `do_process_response/2` clause for a complete message carrying `reasoning_content`, placed ahead of the tool-call and plain-message clauses
- `lib/chat_models/chat_open_ai.ex` — New `do_process_response/2` clause for streamed deltas carrying `reasoning_content`, splitting thinking and answer text across merge positions
- `lib/chat_models/chat_open_ai.ex` — `reasoning_content_parts/2` helper, handling the thinking-only response (a model that stops on a token limit before answering)
- `lib/chat_models/chat_open_ai.ex` — `content_parts_for_api/2` rejects `:thinking` and `:unsupported` parts, fixing the crash on the request following a reasoning response
- `lib/chat_models/chat_aws_mantle.ex` — Removed the now-redundant private `strip_thinking_parts/1` and its call in `for_api/3`
- `lib/chat_models/chat_open_ai.ex` (`@moduledoc`) — New "Returned Thinking" section under Reasoning Model Support, documenting the field, the resulting content part order, and a worked `endpoint` plus `req_config` example
- `lib/chat_models/chat_open_ai.ex` (`content_parts_for_api/2` docs) — Records why thinking and unsupported parts are omitted from requests and why that omission must stay unconditional
- `test/chat_models/chat_open_ai_test.exs` — Seven unit tests across two new describe blocks
- `test/chat_models/chat_open_ai_reasoning_live_test.exs` — New live test module, seven tests in three describe blocks
- `test/chat_models/chat_aws_mantle_test.exs` — Updated comments in the two stripping tests to describe the shared serialization path

## Testing

Seven unit tests, no API calls, in `test/chat_models/chat_open_ai_test.exs`:

- `do_process_response/2 with reasoning content` — complete message split into thinking and text; thinking preserved alongside a tool call; a four-delta stream merging to `[thinking, text]`; and a delta *without* `reasoning_content` confirming unchanged behavior for every other provider
- `content_parts_for_api/2` — thinking dropped from a mixed part list; unsupported dropped from a mixed part list; a thinking-only message with a tool call serializing to empty content

`ChatAwsMantle`'s two existing stripping tests — one for `:thinking`, one for a `redacted_thinking` `:unsupported` part — pass unchanged against the shared implementation, which is what confirms the consolidation preserves its behavior. Its full suite is green at 37 tests.

Seven live tests in `test/chat_models/chat_open_ai_reasoning_live_test.exs`, tagged `live_call: true, live_cloudflare: true` and excluded from `mix test` by default:

```
mix test test/chat_models/chat_open_ai_reasoning_live_test.exs --include live_cloudflare
```

- `raw wire format` — dumps the unparsed SSE stream and JSON body, asserting the provider really sends `reasoning_content` in both modes. These pin the wire format independently of how the library parses it
- `ChatOpenAI parsing` — the same prompt through `LLMChain`, asserting a `:thinking` part survives into the final message for both streaming and non-streaming
- `reasoning with tool calls` — a single tool round trip, and a multi-turn chain where `get_vacation_days` requires an ID that only `lookup_employee_id` can produce. The dependency forces three sequential requests, so requests two and three each re-serialize assistant messages carrying thinking parts. This is the crash case, exercised twice per run

Verified live against Cloudflare Workers AI with `@cf/zai-org/glm-5.3-flash`. The multi-turn chain produces:

```
user:      content=[:text]
assistant: content=[:thinking, :text]  calls=["lookup_employee_id"]
tool:                                  results=["lookup_employee_id"]
assistant: content=[:thinking, :text]  calls=["get_vacation_days"]
tool:                                  results=["get_vacation_days"]
assistant: content=[:text]
```

`mix precommit` passes: 2386 tests, 41 doctests, 152 excluded.