### PR TITLE
Support OpenAI Bedrock Chat Completions options

### DIFF
--- a/lib/chat_models/chat_aws_mantle.ex
+++ b/lib/chat_models/chat_aws_mantle.ex
@@ -101,8 +101,47 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
     reasonable starting defense.**
   - `:presence_penalty` — -2.0 to 2.0. Binary variant of frequency_penalty
     (penalizes any token that has appeared at all)
-  - `:max_completion_tokens` — Some OpenAI models use this field instead of
-    `:max_tokens`. This field replaces `:max_tokens` in the request.
+
+  ## Token Limits
+
+  `:max_tokens` sets the upper bound on generated tokens. It is sent as
+  `max_completion_tokens`, the name AWS documents for Mantle. The Kimi and
+  gpt-oss models accept either name; OpenAI's newer models reject the older
+  `max_tokens` and accept only this one.
+
+      ChatAwsMantle.new!(%{model: "openai.gpt-oss-120b", max_tokens: 4096})
+
+  The default is `4096`, low enough to cap a runaway generation. Raise it when
+  a reasoning budget needs more headroom.
+
+  A model that accepts only the older `max_tokens` key needs the key swapped
+  with `:extra_body`:
+
+      ChatAwsMantle.new!(%{
+        model: "some.legacy-model",
+        max_tokens: 4096,
+        extra_body: %{"max_completion_tokens" => nil, "max_tokens" => 4096}
+      })
+
+  Keep the `:max_tokens` field set as well, since telemetry reports the limit
+  from it.
+
+  ## Provider-Specific Parameters
+
+  Mantle hosts models from several vendors, each of which accepts parameters
+  this module has no field for. `:extra_body` is a map of values merged into
+  the request body last, so they override anything the model computed:
+
+      ChatAwsMantle.new!(%{
+        model: "moonshotai.kimi-k2.5",
+        extra_body: %{"repetition_penalty" => 1.05}
+      })
+
+  Keys may be strings or atoms, a `nil` value removes the key from the body,
+  and nested maps merge key by key. See `LangChain.Utils.merge_extra_body/2`
+  for the full rules. Overriding `stream`, `messages`, `tools` or `model` can
+  break response handling; headers and transport options belong in
+  `:req_config`, not `:extra_body`.
 
   ## Streaming
 
@@ -182,10 +221,11 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
 
     # Standard OpenAI-shaped knobs
     field :temperature, :float, default: 1.0
+    # Upper bound on generated tokens. Sent as `max_completion_tokens`, the
+    # name AWS documents for Mantle. A model that instead wants the older
+    # `max_tokens` key needs the swap shown in the "Token Limits" section of
+    # the module docs.
     field :max_tokens, :integer, default: @default_max_tokens
-    # Use this field for models that do not accept max_tokens.
-    # The request omits max_tokens when this field has a value.
-    field :max_completion_tokens, :integer
     field :stream, :boolean, default: false
 
     # Nucleus sampling (0.0–1.0). OpenAI docs recommend altering *either* this
@@ -227,6 +267,11 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
 
     # Req options to merge into the request
     field :req_config, :map, default: %{}
+
+    # Provider-specific values merged into the request body last, overriding
+    # anything the model computed. A `nil` value removes that key from the
+    # body. See `LangChain.Utils.merge_extra_body/2` for the merge rules.
+    field :extra_body, :map, default: nil
   end
 
   @type t :: %ChatAwsMantle{}
@@ -239,7 +284,6 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
     :credentials,
     :temperature,
     :max_tokens,
-    :max_completion_tokens,
     :stream,
     :top_p,
     :frequency_penalty,
@@ -252,6 +296,7 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
     :stream_options,
     :verbose_api,
     :req_config,
+    :extra_body,
     :callbacks
   ]
   @required_fields [:model]
@@ -378,8 +423,6 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
   """
   @spec for_api(t(), [Message.t()], [LangChain.Function.t()]) :: %{atom() => any()}
   def for_api(%ChatAwsMantle{} = model, messages, tools) do
-    max_tokens = if is_nil(model.max_completion_tokens), do: model.max_tokens
-
     %{
       model: model.model,
       stream: model.stream,
@@ -394,8 +437,7 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
         |> Enum.reverse()
     }
     |> Utils.conditionally_add_to_map(:temperature, model.temperature)
-    |> Utils.conditionally_add_to_map(:max_tokens, max_tokens)
-    |> Utils.conditionally_add_to_map(:max_completion_tokens, model.max_completion_tokens)
+    |> Utils.conditionally_add_to_map(:max_completion_tokens, model.max_tokens)
     |> Utils.conditionally_add_to_map(:top_p, model.top_p)
     |> Utils.conditionally_add_to_map(:frequency_penalty, model.frequency_penalty)
     |> Utils.conditionally_add_to_map(:presence_penalty, model.presence_penalty)
@@ -407,6 +449,7 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
       :stream_options,
       stream_options_for_api(model.stream_options)
     )
+    |> Utils.merge_extra_body(model.extra_body)
   end
 
   defp response_format(%ChatAwsMantle{json_response: true, json_schema: schema})

--- a/lib/chat_models/chat_aws_mantle.ex
+++ b/lib/chat_models/chat_aws_mantle.ex
@@ -82,6 +82,10 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
   K2 Thinking always reasons (it's the model's default mode); the field is
   populated regardless of `:reasoning_effort`.
 
+  Use `reasoning_effort: "none"` to disable reasoning. Some OpenAI Chat
+  Completions models require this value when the request contains function
+  tools.
+
   ## Sampling controls
 
   Standard OpenAI sampling parameters are supported and passed through to
@@ -97,6 +101,8 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
     reasonable starting defense.**
   - `:presence_penalty` — -2.0 to 2.0. Binary variant of frequency_penalty
     (penalizes any token that has appeared at all)
+  - `:max_completion_tokens` — Some OpenAI models use this field instead of
+    `:max_tokens`. This field replaces `:max_tokens` in the request.
 
   ## Streaming
 
@@ -177,6 +183,9 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
     # Standard OpenAI-shaped knobs
     field :temperature, :float, default: 1.0
     field :max_tokens, :integer, default: @default_max_tokens
+    # Use this field for models that do not accept max_tokens.
+    # The request omits max_tokens when this field has a value.
+    field :max_completion_tokens, :integer
     field :stream, :boolean, default: false
 
     # Nucleus sampling (0.0–1.0). OpenAI docs recommend altering *either* this
@@ -192,9 +201,8 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
     # than frequency-weighted). Positive values encourage topic diversity.
     field :presence_penalty, :float
 
-    # OpenAI-standard reasoning control. Passed through to Mantle, which
-    # translates into the upstream model's thinking mode (verified working
-    # for Kimi K2.5).
+    # Control reasoning for OpenAI-compatible models.
+    # Some models require "none" when a request contains function tools.
     field :reasoning_effort, :string
 
     # Tool choice option, mirrors ChatOpenAI's shape
@@ -231,6 +239,7 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
     :credentials,
     :temperature,
     :max_tokens,
+    :max_completion_tokens,
     :stream,
     :top_p,
     :frequency_penalty,
@@ -247,7 +256,7 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
   ]
   @required_fields [:model]
 
-  @valid_reasoning_efforts ~w(low medium high)
+  @valid_reasoning_efforts ~w(none low medium high)
 
   @doc """
   Build a new `ChatAwsMantle` instance from attributes.
@@ -369,6 +378,8 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
   """
   @spec for_api(t(), [Message.t()], [LangChain.Function.t()]) :: %{atom() => any()}
   def for_api(%ChatAwsMantle{} = model, messages, tools) do
+    max_tokens = if is_nil(model.max_completion_tokens), do: model.max_tokens
+
     %{
       model: model.model,
       stream: model.stream,
@@ -383,7 +394,8 @@ defmodule LangChain.ChatModels.ChatAwsMantle do
         |> Enum.reverse()
     }
     |> Utils.conditionally_add_to_map(:temperature, model.temperature)
-    |> Utils.conditionally_add_to_map(:max_tokens, model.max_tokens)
+    |> Utils.conditionally_add_to_map(:max_tokens, max_tokens)
+    |> Utils.conditionally_add_to_map(:max_completion_tokens, model.max_completion_tokens)
     |> Utils.conditionally_add_to_map(:top_p, model.top_p)
     |> Utils.conditionally_add_to_map(:frequency_penalty, model.frequency_penalty)
     |> Utils.conditionally_add_to_map(:presence_penalty, model.presence_penalty)

--- a/test/chat_models/chat_aws_mantle_test.exs
+++ b/test/chat_models/chat_aws_mantle_test.exs
@@ -2,6 +2,7 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
   use LangChain.BaseCase
 
   alias LangChain.ChatModels.ChatAwsMantle
+  alias LangChain.ChatModels.ChatModel
   alias LangChain.Chains.LLMChain
   alias LangChain.Function
   alias LangChain.FunctionParam
@@ -178,7 +179,8 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
       assert body.model == @kimi_model
       assert body.stream == false
       assert body.temperature == 0.0
-      assert body.max_tokens == 64
+      assert body.max_completion_tokens == 64
+      refute Map.has_key?(body, :max_tokens)
       assert is_list(body.messages)
       assert [%{} = msg] = body.messages
       assert msg["role"] == :user
@@ -195,12 +197,36 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
       refute Map.has_key?(body, :reasoning_effort)
     end
 
-    test "uses :max_completion_tokens and omits :max_tokens", %{model: m} do
-      updated = %{m | max_completion_tokens: 64}
+    test "sends the default :max_tokens as max_completion_tokens" do
+      m = ChatAwsMantle.new!(%{model: @kimi_model, region: "us-east-1", api_key: "k"})
+      body = ChatAwsMantle.for_api(m, [Message.new_user!("hi")], [])
+
+      assert body.max_completion_tokens == 4096
+      refute Map.has_key?(body, :max_tokens)
+    end
+
+    test ":extra_body can swap the limit back to the legacy max_tokens key", %{model: m} do
+      updated = %{m | extra_body: %{"max_completion_tokens" => nil, "max_tokens" => 64}}
       body = ChatAwsMantle.for_api(updated, [Message.new_user!("hi")], [])
 
+      assert body["max_tokens"] == 64
+      refute Map.has_key?(body, :max_completion_tokens)
+    end
+
+    test ":extra_body adds vendor parameters the schema has no field for", %{model: m} do
+      updated = %{m | extra_body: %{"repetition_penalty" => 1.05}}
+      body = ChatAwsMantle.for_api(updated, [Message.new_user!("hi")], [])
+
+      assert body["repetition_penalty"] == 1.05
       assert body.max_completion_tokens == 64
-      refute Map.has_key?(body, :max_tokens)
+    end
+
+    test ":extra_body overrides a value the model computed", %{model: m} do
+      updated = %{m | extra_body: %{"temperature" => 0.9}}
+      body = ChatAwsMantle.for_api(updated, [Message.new_user!("hi")], [])
+
+      assert body[:temperature] == 0.9
+      refute Map.has_key?(body, "temperature")
     end
 
     test "passes :top_p, :frequency_penalty, :presence_penalty through to the body when set", %{
@@ -286,6 +312,46 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
 
       # :unsupported was stripped; text survived.
       assert [%{"type" => "text", "text" => "The answer is 42."}] = content
+    end
+  end
+
+  describe "serialize_config/1 and restore_from_map/1" do
+    test "round-trips :extra_body and the token limit" do
+      original =
+        ChatAwsMantle.new!(%{
+          model: @kimi_model,
+          region: "us-east-1",
+          api_key: "k",
+          max_tokens: 512,
+          extra_body: %{"repetition_penalty" => 1.05}
+        })
+
+      config = ChatAwsMantle.serialize_config(original)
+
+      # serialize_config/1 drops the credentials, so a caller re-supplies them
+      # when restoring.
+      config = Map.put(config, "api_key", "k")
+
+      assert {:ok, %ChatAwsMantle{} = restored} = ChatAwsMantle.restore_from_map(config)
+      assert restored.max_tokens == 512
+      assert restored.extra_body == %{"repetition_penalty" => 1.05}
+    end
+  end
+
+  describe "telemetry request options" do
+    test "reports the limit that is actually sent" do
+      m =
+        ChatAwsMantle.new!(%{
+          model: @kimi_model,
+          region: "us-east-1",
+          api_key: "k",
+          max_tokens: 512
+        })
+
+      body = ChatAwsMantle.for_api(m, [Message.new_user!("hi")], [])
+
+      assert %{max_tokens: 512} = ChatModel.request_options(m)
+      assert body.max_completion_tokens == 512
     end
   end
 

--- a/test/chat_models/chat_aws_mantle_test.exs
+++ b/test/chat_models/chat_aws_mantle_test.exs
@@ -94,11 +94,12 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
                  reasoning_effort: "extreme"
                })
 
-      assert {"must be one of: low, medium, high", _} = changeset.errors[:reasoning_effort]
+      assert {"must be one of: none, low, medium, high", _} =
+               changeset.errors[:reasoning_effort]
     end
 
     test "accepts valid reasoning_effort values" do
-      for effort <- ~w(low medium high) do
+      for effort <- ~w(none low medium high) do
         assert {:ok, %ChatAwsMantle{reasoning_effort: ^effort}} =
                  ChatAwsMantle.new(%{
                    model: @kimi_model,
@@ -192,6 +193,14 @@ defmodule LangChain.ChatModels.ChatAwsMantleTest do
     test "omits :reasoning_effort when not set", %{model: m} do
       body = ChatAwsMantle.for_api(m, [Message.new_user!("hi")], [])
       refute Map.has_key?(body, :reasoning_effort)
+    end
+
+    test "uses :max_completion_tokens and omits :max_tokens", %{model: m} do
+      updated = %{m | max_completion_tokens: 64}
+      body = ChatAwsMantle.for_api(updated, [Message.new_user!("hi")], [])
+
+      assert body.max_completion_tokens == 64
+      refute Map.has_key?(body, :max_tokens)
     end
 
     test "passes :top_p, :frequency_penalty, :presence_penalty through to the body when set", %{


### PR DESCRIPTION
## Problem

`ChatAwsMantle` rejects `reasoning_effort: "none"`. It accepts only `low`,
`medium`, and `high`.

Some OpenAI models require `"none"` when a Chat Completions request contains
function tools. The adapter can add this value to the request. However,
`ChatAwsMantle.new/1` rejects the value first.

`ChatAwsMantle` also sends `max_tokens` by default. Current OpenAI models on
Amazon Bedrock reject this field. They accept `max_completion_tokens`.

AWS provides the following documentation:

- [OpenAI model request parameters](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html)
  lists `max_completion_tokens` and maps it to the Converse `maxTokens` field.
- [GPT-5.6 Luna](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html)
  lists the model IDs and URLs for both Bedrock endpoints.
- [Bedrock endpoints](https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html)
  explains the differences between `bedrock-runtime` and `bedrock-mantle`.

## Change

- Accept `none` as a reasoning effort value.
- Add the optional `max_completion_tokens` field.
- Omit `max_tokens` when `max_completion_tokens` has a value.
- Keep the current `max_tokens: 4096` default for all other requests.
- Add module documentation and unit tests.

This change does not change existing requests unless a caller sets
`max_completion_tokens`.

## Investigation

We sent small synthetic requests to GPT-5.6 Luna through both Bedrock endpoint
families. We used the model ID that AWS documents for each endpoint.

| Endpoint | Model | Token field | Result |
| --- | --- | --- | --- |
| `bedrock-runtime` | `us.openai.gpt-5.6-luna` | `max_tokens` | HTTP 400: unsupported parameter |
| `bedrock-runtime` | `us.openai.gpt-5.6-luna` | `max_completion_tokens` | HTTP 200 |
| `bedrock-mantle` | `openai.gpt-5.6-luna` | `max_tokens` | HTTP 400: unsupported parameter |
| `bedrock-mantle` | `openai.gpt-5.6-luna` | `max_completion_tokens` | HTTP 200 |

We also tested client-side function tools through `bedrock-runtime`. The API
returned HTTP 400 when the request did not disable reasoning. The same tool
request succeeded with `reasoning_effort: "none"`. GPT-5.6 Luna, Sol, and Terra
each called the test tool and returned the correct result.

## Verification

- `mix precommit`: 2,498 tests and 41 doctests passed. The suite excluded 152
  live tests.
- `mix dialyzer --format dialyxir`: passed.
- The live request results are listed above.
