### PR TITLE
Add extra_body and service_tier to OpenAI chat models

### DIFF
--- a/lib/chat_models/chat_open_ai.ex
+++ b/lib/chat_models/chat_open_ai.ex
@@ -235,6 +235,72 @@ defmodule LangChain.ChatModels.ChatOpenAI do
 
   `https://some-subdomain.cognitiveservices.azure.com/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-08-01-preview"`
 
+  ## Service Tier
+
+  The `service_tier` option asks the provider to serve the request with a
+  particular processing tier, trading cost against latency:
+
+      ChatOpenAI.new!(%{model: "gpt-5", service_tier: "priority"})
+
+  OpenAI accepts values such as `"auto"`, `"default"`, `"flex"`, `"scale"`,
+  `"priority"` and `"fast"`. OpenAI-compatible providers accept their own
+  subset, so the value is passed through without validation.
+
+  The tier that actually served the request can differ from the one requested.
+  When the provider reports it, it is kept in the token usage's `raw` map:
+
+      %Message{metadata: %{usage: %TokenUsage{raw: %{"service_tier" => tier}}}} = message
+
+  When streaming, token usage (and the tier with it) is only reported when
+  `stream_options: %{include_usage: true}` is set. Some providers don't report a
+  tier at all.
+
+  ## Token Limits
+
+  `max_tokens` sets the upper bound on generated tokens. It is sent as
+  `max_completion_tokens`, OpenAI's current name for the limit. OpenAI's
+  reasoning models require that name, and the limit includes reasoning tokens.
+
+      ChatOpenAI.new!(%{model: "gpt-5", max_tokens: 4000})
+
+  Some OpenAI-compatible servers, such as Ollama's `/v1` endpoint, only accept
+  the older `max_tokens` key. They ignore `max_completion_tokens`, which leaves
+  the request with no limit at all. For those servers, swap the key with
+  `extra_body`:
+
+      ChatOpenAI.new!(%{
+        endpoint: "http://localhost:11434/v1/chat/completions",
+        model: "llama3.2",
+        max_tokens: 4000,
+        extra_body: %{"max_completion_tokens" => nil, "max_tokens" => 4000}
+      })
+
+  Keep the `max_tokens` field set as well, since telemetry reports the limit
+  from it.
+
+  ## Provider-Specific Parameters
+
+  OpenAI-compatible providers accept parameters of their own that `ChatOpenAI`
+  has no field for. `extra_body` is a map of values merged into the request
+  body last, so they override anything the model computed:
+
+      ChatOpenAI.new!(%{
+        endpoint: "http://localhost:8000/v1/chat/completions",
+        model: "Qwen/Qwen3-8B",
+        extra_body: %{"top_k" => 20, "repetition_penalty" => 1.05}
+      })
+
+  - Keys may be strings or atoms. A key naming one the model already sends
+    replaces that value, so `%{"n" => 2}` overrides the `n` field.
+  - A `nil` value removes the key from the body. `%{"n" => nil}` stops the
+    always-sent `n` from going out, for providers that reject it.
+  - Nested maps are merged key by key. Any other value replaces the existing
+    one.
+
+  Overriding `stream`, `messages`, `tools` or `model` can break response
+  handling. Headers and transport options belong in `req_config`, not
+  `extra_body`. See `LangChain.Utils.merge_extra_body/2` for the full rules.
+
   ## Reasoning Model Support
 
   OpenAI made some significant API changes with the introduction of their
@@ -279,6 +345,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
         model: "@cf/zai-org/glm-5.3-flash",
         reasoning_mode: true,
         reasoning_effort: "medium",
+        service_tier: "priority",
         req_config: %{headers: [{"cf-aig-gateway-id", gateway_id}]}
       })
 
@@ -376,6 +443,14 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     # https://platform.openai.com/docs/api-reference/chat/create#chat-create-verbosity
     field :verbosity, :string
 
+    # The processing tier to serve the request with. Known values include
+    # "auto", "default", "flex", "scale", "priority" and "fast"; the set differs
+    # between OpenAI and compatible providers, so it is not validated here. The
+    # tier that actually served the request is reported in the token usage's
+    # `raw` map under "service_tier".
+    # https://platform.openai.com/docs/api-reference/chat/create#chat-create-service_tier
+    field :service_tier, :string
+
     # Duration in seconds for the response to be received. When streaming a very
     # lengthy response, a longer time limit may be required. However, when it
     # goes on too long by itself, it tends to hallucinate more.
@@ -388,6 +463,10 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     field :json_response, :boolean, default: false
     field :json_schema, :map, default: nil
     field :stream, :boolean, default: false
+    # Upper bound on generated tokens. Sent as `max_completion_tokens`, OpenAI's
+    # current name for the limit, which also counts reasoning tokens. A server
+    # that only accepts the older `max_tokens` key needs the swap shown in the
+    # "Token Limits" section of the module docs.
     field :max_tokens, :integer, default: nil
     # Options for streaming response. Only set this when you set `stream: true`
     # https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream_options
@@ -430,6 +509,11 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     # Refer to `https://hexdocs.pm/req/Req.html#new/1-options` for
     # `Req.new` supported set of options.
     field :req_config, :map, default: %{}
+
+    # Provider-specific values merged into the request body last, overriding
+    # anything the model computed. A `nil` value removes that key from the
+    # body. See `LangChain.Utils.merge_extra_body/2` for the merge rules.
+    field :extra_body, :map, default: nil
   end
 
   @type t :: %ChatOpenAI{}
@@ -447,6 +531,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     :reasoning_mode,
     :reasoning_effort,
     :verbosity,
+    :service_tier,
     :receive_timeout,
     :json_response,
     :json_schema,
@@ -460,6 +545,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     :verbose_api,
     :retry_count,
     :req_config,
+    :extra_body,
     :callbacks
   ]
   @required_fields [:endpoint, :model]
@@ -560,7 +646,8 @@ defmodule LangChain.ChatModels.ChatOpenAI do
       if(openai.reasoning_mode, do: openai.reasoning_effort, else: nil)
     )
     |> Utils.conditionally_add_to_map(:verbosity, openai.verbosity)
-    |> Utils.conditionally_add_to_map(:max_tokens, openai.max_tokens)
+    |> Utils.conditionally_add_to_map(:max_completion_tokens, openai.max_tokens)
+    |> Utils.conditionally_add_to_map(:service_tier, openai.service_tier)
     |> Utils.conditionally_add_to_map(:seed, openai.seed)
     |> Utils.conditionally_add_to_map(
       :stream_options,
@@ -571,6 +658,7 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     |> Utils.conditionally_add_to_map(:parallel_tool_calls, openai.parallel_tool_calls)
     |> Utils.conditionally_add_to_map(:logprobs, openai.logprobs)
     |> Utils.conditionally_add_to_map(:top_logprobs, openai.top_logprobs)
+    |> Utils.merge_extra_body(openai.extra_body)
   end
 
   defp get_tools_for_api(%_{} = _model, nil), do: []
@@ -1509,14 +1597,18 @@ defmodule LangChain.ChatModels.ChatOpenAI do
     return
   end
 
-  defp get_token_usage(%{"usage" => usage} = _response_body) when is_map(usage) do
+  defp get_token_usage(%{"usage" => usage} = response_body) when is_map(usage) do
     # extract out the reported response token usage
     #
     #  https://platform.openai.com/docs/api-reference/chat/object#chat/object-usage
+    #
+    # The tier that served the request is reported beside `usage`, not inside
+    # it. Keeping it in `raw` carries it to the final message along with the
+    # usage, which is also where ChatAnthropic reports its tier.
     TokenUsage.new!(%{
       input: Map.get(usage, "prompt_tokens"),
       output: Map.get(usage, "completion_tokens"),
-      raw: usage
+      raw: Utils.conditionally_add_to_map(usage, "service_tier", response_body["service_tier"])
     })
   end
 
@@ -1561,7 +1653,9 @@ defmodule LangChain.ChatModels.ChatOpenAI do
         :json_schema,
         :stream,
         :max_tokens,
-        :stream_options
+        :stream_options,
+        :service_tier,
+        :extra_body
       ],
       @current_config_version
     )

--- a/lib/chat_models/chat_open_ai_responses.ex
+++ b/lib/chat_models/chat_open_ai_responses.ex
@@ -244,6 +244,32 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
   through to the API as given, so new types and options work without a library
   change.
 
+  ## Service Tier
+
+  The `service_tier` option asks OpenAI to serve the request with a particular
+  processing tier, such as `"flex"` or `"priority"`:
+
+      ChatOpenAIResponses.new!(%{model: "gpt-5", service_tier: "priority"})
+
+  The tier that actually served the request can differ from the one requested.
+  It is kept in the token usage's `raw` map under `"service_tier"`.
+
+  ## Provider-Specific Parameters
+
+  `extra_body` is a map of values merged into the request body last, so they
+  override anything the model computed. Use it for parameters this module has
+  no field for:
+
+      ChatOpenAIResponses.new!(%{
+        model: "gpt-5",
+        extra_body: %{"prompt_cache_key" => "user-123"}
+      })
+
+  A `nil` value removes the key from the body. The WebSocket transport always
+  removes `stream`, `background`, `temperature` and `top_p` from the payload,
+  including values supplied through `extra_body`. See
+  `LangChain.Utils.merge_extra_body/2` for the full merge rules.
+
   ## WebSocket Transport
 
   Instead of HTTP, requests can be sent over a persistent WebSocket connection
@@ -372,7 +398,11 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     field :previous_response_id, :string, default: nil
     # Reasoning options for gpt-5 and o-series models
     embeds_one(:reasoning, ReasoningOptions)
-    # omit service_tier because chat_open_ai also omits it
+    # The processing tier to serve the request with. Known values include
+    # "auto", "default", "flex", "scale", "priority" and "fast"; the set changes
+    # over time, so it is not validated here. The tier that actually served the
+    # request is reported in the token usage's `raw` map under "service_tier".
+    field :service_tier, :string
     field :store, :boolean, default: false
     field :stream, :boolean, default: false
     field :temperature, :float, default: nil
@@ -398,6 +428,11 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     # Refer to `https://hexdocs.pm/req/Req.html#new/1-options` for
     # `Req.new` supported set of options.
     field :req_config, :map, default: %{}
+
+    # Provider-specific values merged into the request body last, overriding
+    # anything the model computed. A `nil` value removes that key from the
+    # body. See `LangChain.Utils.merge_extra_body/2` for the merge rules.
+    field :extra_body, :map, default: nil
 
     # Optional WebSocket transport. When set to a PID of a
     # `LangChain.WebSocket` process, requests will be sent over the
@@ -431,6 +466,8 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     :verbose_api,
     :retry_count,
     :req_config,
+    :service_tier,
+    :extra_body,
     :websocket,
     :callbacks
   ]
@@ -654,10 +691,12 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     |> Utils.conditionally_add_to_map(:text, set_text_format(openai))
     |> Utils.conditionally_add_to_map(:tool_choice, get_tool_choice(openai))
     |> Utils.conditionally_add_to_map(:truncation, openai.truncation)
+    |> Utils.conditionally_add_to_map(:service_tier, openai.service_tier)
     |> Utils.conditionally_add_to_map(:tools, get_tools_for_api(openai, tools))
     |> Utils.conditionally_add_to_map(:user, openai.user)
     |> Utils.conditionally_add_to_map(:temperature, openai.temperature)
     |> maybe_add_top_p(openai)
+    |> Utils.merge_extra_body(openai.extra_body)
   end
 
   # Build the payload for WebSocket mode. Wraps the standard API payload
@@ -671,9 +710,16 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     defp for_api_websocket(%ChatOpenAIResponses{} = openai, messages, tools) do
       payload = for_api(openai, messages, tools)
 
-      dropped = [:stream, :background, :temperature, :top_p]
+      # Matched by string form, so the same keys supplied as strings through
+      # `extra_body` are dropped too.
+      dropped = ["stream", "background", "temperature", "top_p"]
 
-      if payload[:temperature] || payload[:top_p] do
+      sampling_values_present? =
+        Enum.any?(payload, fn {key, value} ->
+          to_string(key) in ["temperature", "top_p"] and value != nil
+        end)
+
+      if sampling_values_present? do
         Logger.warning(
           "WebSocket transport: dropping :temperature and :top_p from payload " <>
             "due to an OpenAI bug that silently closes the connection when these " <>
@@ -682,7 +728,7 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
       end
 
       payload
-      |> Map.drop(dropped)
+      |> Map.reject(fn {key, _value} -> to_string(key) in dropped end)
       |> Map.put(:type, "response.create")
       |> Jason.encode!()
     end
@@ -2011,14 +2057,18 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
     end
   end
 
-  defp get_token_usage(%{"usage" => usage} = _response_body) when is_map(usage) do
+  defp get_token_usage(%{"usage" => usage} = response_body) when is_map(usage) do
     # extract out the reported response token usage
     #
     # https://platform.openai.com/docs/api-reference/responses_streaming/response/completed#responses_streaming/response/completed-response-usage
+    #
+    # The tier that served the request is reported beside `usage`, not inside
+    # it. Keeping it in `raw` carries it to the final message along with the
+    # usage, which is also where ChatAnthropic reports its tier.
     TokenUsage.new!(%{
       input: Map.get(usage, "input_tokens"),
       output: Map.get(usage, "output_tokens"),
-      raw: usage
+      raw: Utils.conditionally_add_to_map(usage, "service_tier", response_body["service_tier"])
     })
   end
 
@@ -2278,7 +2328,9 @@ defmodule LangChain.ChatModels.ChatOpenAIResponses do
         :stream,
         :max_tokens,
         :stream_options,
-        :verbosity
+        :verbosity,
+        :service_tier,
+        :extra_body
       ],
       @current_config_version
     )

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -30,6 +30,66 @@ defmodule LangChain.Utils do
     Map.put(map, key, value)
   end
 
+  @doc """
+  Merge user-supplied `extra_body` values into a request body built by a chat
+  model's `for_api/3`.
+
+  Values in `extra` win over values in `body`:
+
+  - Keys are matched by their string form, so a string key in `extra`
+    overwrites an existing atom key of the same name in place instead of
+    producing a duplicate key in the encoded JSON. Keys not already present are
+    added exactly as given; no atoms are created.
+  - A `nil` value removes the key from the body.
+  - When both sides hold a map, they are merged recursively by the same rules.
+    Any other value, lists included, replaces the existing value.
+
+  Returns `body` unchanged when `extra` is `nil` or empty.
+
+  Overriding keys the model depends on to parse the response, such as
+  `stream`, `messages`, `model` or `tools`, can break response handling.
+
+  ## Examples
+
+      iex> LangChain.Utils.merge_extra_body(%{max_tokens: 100, n: 1}, %{"max_tokens" => 10, "n" => nil})
+      %{max_tokens: 10}
+
+      iex> LangChain.Utils.merge_extra_body(%{model: "gpt-4o"}, %{"service_tier" => "priority"})
+      %{:model => "gpt-4o", "service_tier" => "priority"}
+  """
+  @spec merge_extra_body(map(), map() | nil) :: map()
+  def merge_extra_body(body, nil), do: body
+  def merge_extra_body(body, extra) when map_size(extra) == 0, do: body
+
+  def merge_extra_body(body, %{} = extra) when is_map(body) do
+    Enum.reduce(extra, body, fn {key, value}, acc ->
+      existing_key = find_key_by_string(acc, key)
+      target_key = existing_key || key
+
+      case {Map.get(acc, existing_key), value} do
+        {_current, nil} ->
+          Map.delete(acc, target_key)
+
+        {%{} = current, %{} = incoming} ->
+          Map.put(acc, target_key, merge_extra_body(current, incoming))
+
+        _other ->
+          Map.put(acc, target_key, value)
+      end
+    end)
+  end
+
+  # Find the key in `map` whose string form equals that of `key`, so `:n` and
+  # `"n"` are treated as the same JSON key. Returns `nil` when there is none.
+  defp find_key_by_string(map, key) do
+    if Map.has_key?(map, key) do
+      key
+    else
+      target = to_string(key)
+      Enum.find(Map.keys(map), fn existing -> to_string(existing) == target end)
+    end
+  end
+
   # Generate wrapped LLM callbacks on the model that include the chain as part
   # of the context.
   @doc false

--- a/test/chat_models/chat_open_ai_responses_test.exs
+++ b/test/chat_models/chat_open_ai_responses_test.exs
@@ -2209,6 +2209,93 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
     end
   end
 
+  describe "service_tier" do
+    test "is not sent when not set" do
+      openai = ChatOpenAIResponses.new!(%{"model" => @test_model})
+
+      refute Map.has_key?(ChatOpenAIResponses.for_api(openai, [], []), :service_tier)
+    end
+
+    test "is sent when set" do
+      openai = ChatOpenAIResponses.new!(%{"model" => @test_model, "service_tier" => "flex"})
+
+      assert %{service_tier: "flex"} = ChatOpenAIResponses.for_api(openai, [], [])
+    end
+
+    test "the served tier is kept in the token usage of a completed response" do
+      model = ChatOpenAIResponses.new!(%{"model" => @test_model})
+
+      response = %{
+        "status" => "completed",
+        "service_tier" => "flex",
+        "output" => [
+          %{
+            "type" => "message",
+            "role" => "assistant",
+            "status" => "completed",
+            "content" => [%{"type" => "output_text", "text" => "hello", "annotations" => []}]
+          }
+        ],
+        "usage" => %{"input_tokens" => 27, "output_tokens" => 5, "total_tokens" => 32}
+      }
+
+      assert %Message{metadata: %{usage: %LangChain.TokenUsage{raw: raw}}} =
+               ChatOpenAIResponses.do_process_response(model, response)
+
+      assert raw["service_tier"] == "flex"
+    end
+
+    test "the served tier is kept in the token usage of a streamed response.completed event" do
+      model = ChatOpenAIResponses.new!(%{"model" => @test_model, "stream" => true})
+
+      completed = %{
+        "type" => "response.completed",
+        "response" => %{
+          "service_tier" => "priority",
+          "usage" => %{"input_tokens" => 5, "output_tokens" => 2}
+        }
+      }
+
+      assert %LangChain.MessageDelta{
+               metadata: %{usage: %LangChain.TokenUsage{raw: %{"service_tier" => "priority"}}}
+             } = ChatOpenAIResponses.do_process_response(model, completed)
+    end
+  end
+
+  describe "extra_body" do
+    test "values override computed keys and add new ones" do
+      openai =
+        ChatOpenAIResponses.new!(%{
+          "model" => @test_model,
+          "max_output_tokens" => 1000,
+          "extra_body" => %{"max_output_tokens" => 10, "prompt_cache_key" => "user-123"}
+        })
+
+      data = ChatOpenAIResponses.for_api(openai, [], [])
+      assert data.max_output_tokens == 10
+      refute Map.has_key?(data, "max_output_tokens")
+      assert data["prompt_cache_key"] == "user-123"
+    end
+
+    test "service_tier and extra_body survive a serialize and restore round trip" do
+      original =
+        ChatOpenAIResponses.new!(%{
+          "model" => @test_model,
+          "service_tier" => "flex",
+          "extra_body" => %{"prompt_cache_key" => "user-123"}
+        })
+
+      config = ChatOpenAIResponses.serialize_config(original)
+      assert config["service_tier"] == "flex"
+      assert config["extra_body"] == %{"prompt_cache_key" => "user-123"}
+
+      assert {:ok, restored} = ChatOpenAIResponses.restore_from_map(config)
+
+      assert ChatOpenAIResponses.for_api(restored, [], []) ==
+               ChatOpenAIResponses.for_api(original, [], [])
+    end
+  end
+
   describe "serialize and restore" do
     test "serializes and restores config" do
       original =
@@ -2544,6 +2631,55 @@ defmodule LangChain.ChatModels.ChatOpenAIResponsesTest do
       assert [%LangChain.Message.ContentPart{type: :text, content: "Hello from WebSocket!"}] =
                content
 
+      verify!()
+    end
+
+    test "do_api_request with websocket drops transport keys supplied through extra_body" do
+      fake_pid = spawn(fn -> Process.sleep(:infinity) end)
+      on_exit(fn -> Process.exit(fake_pid, :kill) end)
+
+      completed_response = %{
+        "status" => "completed",
+        "output" => [
+          %{
+            "type" => "message",
+            "role" => "assistant",
+            "content" => [%{"type" => "output_text", "text" => "Hi"}]
+          }
+        ],
+        "usage" => %{"input_tokens" => 3, "output_tokens" => 1, "total_tokens" => 4},
+        "id" => "resp_ws_456"
+      }
+
+      LangChain.WebSocket
+      |> expect(:send_and_collect, fn ^fake_pid, payload, _done_fn, _opts ->
+        decoded = Jason.decode!(payload)
+
+        refute Map.has_key?(decoded, "temperature")
+        refute Map.has_key?(decoded, "top_p")
+        refute Map.has_key?(decoded, "stream")
+        assert decoded["service_tier"] == "flex"
+        assert decoded["prompt_cache_key"] == "user-123"
+
+        {:ok, [%{"type" => "response.completed", "response" => completed_response}]}
+      end)
+
+      model =
+        ChatOpenAIResponses.new!(%{
+          model: @test_model,
+          stream: false,
+          service_tier: "flex",
+          extra_body: %{"temperature" => 0.5, "top_p" => 0.9, "prompt_cache_key" => "user-123"},
+          websocket: fake_pid
+        })
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert %Message{role: :assistant} =
+                   ChatOpenAIResponses.do_api_request(model, [Message.new_user!("Hi")], [])
+        end)
+
+      assert log =~ "dropping :temperature and :top_p"
       verify!()
     end
 

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -253,7 +253,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
              }
     end
 
-    test "generates a map for an API call with max_tokens set" do
+    test "generates a map for an API call with max_tokens sent as max_completion_tokens" do
       {:ok, openai} =
         ChatOpenAI.new(%{
           "model" => @test_model,
@@ -266,7 +266,8 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert data.model == @test_model
       assert data.temperature == 1
       assert data.frequency_penalty == 0.5
-      assert data.max_tokens == 1234
+      assert data.max_completion_tokens == 1234
+      refute Map.has_key?(data, :max_tokens)
     end
 
     test "generates a map for an API call with stream_options set correctly" do
@@ -1553,6 +1554,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert usage.output == 4
 
       assert usage.raw == %{
+               "service_tier" => "default",
                "completion_tokens" => 4,
                "completion_tokens_details" => %{
                  "accepted_prediction_tokens" => 0,
@@ -1597,6 +1599,7 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
                input: 15,
                output: 3,
                raw: %{
+                 "service_tier" => "default",
                  "completion_tokens" => 3,
                  "completion_tokens_details" => %{
                    "accepted_prediction_tokens" => 0,
@@ -2991,6 +2994,176 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
     ]
   end
 
+  describe "service_tier" do
+    test "is not sent when not set" do
+      openai = ChatOpenAI.new!(%{model: @test_model})
+
+      refute Map.has_key?(ChatOpenAI.for_api(openai, [], []), :service_tier)
+    end
+
+    test "is sent when set" do
+      openai = ChatOpenAI.new!(%{model: @test_model, service_tier: "priority"})
+
+      assert %{service_tier: "priority"} = ChatOpenAI.for_api(openai, [], [])
+    end
+
+    test "the served tier is kept in the token usage of a complete message" do
+      model = ChatOpenAI.new!(%{model: @test_model})
+
+      response = %{
+        "choices" => [
+          %{
+            "finish_reason" => "stop",
+            "index" => 0,
+            "logprobs" => nil,
+            "message" => %{
+              "annotations" => [],
+              "content" => "Hello",
+              "refusal" => nil,
+              "role" => "assistant"
+            }
+          }
+        ],
+        "object" => "chat.completion",
+        "service_tier" => "priority",
+        "usage" => %{"completion_tokens" => 1, "prompt_tokens" => 5, "total_tokens" => 6}
+      }
+
+      assert [%Message{metadata: %{usage: %TokenUsage{raw: raw}}}] =
+               ChatOpenAI.do_process_response(model, response)
+
+      assert raw["service_tier"] == "priority"
+    end
+
+    test "the served tier is kept in the token usage of the final streamed chunk" do
+      model = ChatOpenAI.new!(%{model: @test_model, stream: true})
+
+      response = %{
+        "choices" => [],
+        "object" => "chat.completion.chunk",
+        "service_tier" => "flex",
+        "usage" => %{"completion_tokens" => 1, "prompt_tokens" => 5, "total_tokens" => 6}
+      }
+
+      assert %TokenUsage{raw: %{"service_tier" => "flex"}} =
+               ChatOpenAI.do_process_response(model, response)
+    end
+
+    test "token usage raw is the reported usage when no tier is reported" do
+      model = ChatOpenAI.new!(%{model: @test_model, stream: true})
+      usage = %{"completion_tokens" => 1, "prompt_tokens" => 5, "total_tokens" => 6}
+
+      assert %TokenUsage{raw: ^usage} =
+               ChatOpenAI.do_process_response(model, %{"choices" => [], "usage" => usage})
+    end
+  end
+
+  describe "extra_body" do
+    test "defaults to nil and leaves the body unchanged" do
+      plain = ChatOpenAI.new!(%{model: @test_model, max_tokens: 100})
+      assert plain.extra_body == nil
+
+      with_empty = ChatOpenAI.new!(%{model: @test_model, max_tokens: 100, extra_body: %{}})
+
+      assert ChatOpenAI.for_api(with_empty, [], []) == ChatOpenAI.for_api(plain, [], [])
+    end
+
+    test "adds provider-specific keys to the body" do
+      openai =
+        ChatOpenAI.new!(%{
+          model: @test_model,
+          extra_body: %{"top_k" => 20, "repetition_penalty" => 1.05}
+        })
+
+      data = ChatOpenAI.for_api(openai, [], [])
+      assert data["top_k"] == 20
+      assert data["repetition_penalty"] == 1.05
+    end
+
+    test "a string key overrides the computed atom key, leaving a single key" do
+      openai =
+        ChatOpenAI.new!(%{
+          model: @test_model,
+          max_tokens: 64_000,
+          extra_body: %{"max_completion_tokens" => 10}
+        })
+
+      data = ChatOpenAI.for_api(openai, [], [])
+      assert data.max_completion_tokens == 10
+      refute Map.has_key?(data, "max_completion_tokens")
+    end
+
+    test "swaps in max_tokens for servers that only accept the older key" do
+      openai =
+        ChatOpenAI.new!(%{
+          model: @test_model,
+          max_tokens: 4000,
+          extra_body: %{"max_completion_tokens" => nil, "max_tokens" => 4000}
+        })
+
+      data = ChatOpenAI.for_api(openai, [], [])
+      assert data["max_tokens"] == 4000
+      refute Map.has_key?(data, :max_completion_tokens)
+
+      json = Jason.encode!(data)
+      assert json =~ ~s("max_tokens":4000)
+      refute json =~ "max_completion_tokens"
+    end
+
+    test "a nil value removes the always-sent n" do
+      openai = ChatOpenAI.new!(%{model: @test_model, extra_body: %{"n" => nil}})
+
+      refute Map.has_key?(ChatOpenAI.for_api(openai, [], []), :n)
+    end
+
+    test "overrides service_tier" do
+      openai =
+        ChatOpenAI.new!(%{
+          model: @test_model,
+          service_tier: "default",
+          extra_body: %{"service_tier" => "priority"}
+        })
+
+      assert %{service_tier: "priority"} = ChatOpenAI.for_api(openai, [], [])
+    end
+
+    test "rejects a keyword list" do
+      assert {:error, changeset} =
+               ChatOpenAI.new(%{model: @test_model, extra_body: [top_k: 5]})
+
+      assert {"is invalid", _} = changeset.errors[:extra_body]
+    end
+
+    test "sends the same body after a serialize and restore round trip" do
+      original =
+        ChatOpenAI.new!(%{
+          model: @test_model,
+          max_tokens: 4000,
+          service_tier: "flex",
+          extra_body: %{max_completion_tokens: nil, max_tokens: 4000, top_k: 20}
+        })
+
+      config = ChatOpenAI.serialize_config(original)
+      assert config["service_tier"] == "flex"
+
+      assert config["extra_body"] == %{
+               "max_completion_tokens" => nil,
+               "max_tokens" => 4000,
+               "top_k" => 20
+             }
+
+      assert {:ok, restored} = ChatOpenAI.restore_from_map(config)
+      assert restored.service_tier == "flex"
+
+      sent = fn model ->
+        model |> ChatOpenAI.for_api([], []) |> Jason.encode!() |> Jason.decode!()
+      end
+
+      assert sent.(restored) == sent.(original)
+      refute Map.has_key?(sent.(restored), "max_completion_tokens")
+    end
+  end
+
   describe "serialize_config/2" do
     test "does not include the API key or callbacks" do
       model = ChatOpenAI.new!(%{model: "gpt-4o"})
@@ -3030,6 +3203,8 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
                "temperature" => 0.0,
                "version" => 1,
                "json_schema" => nil,
+               "service_tier" => nil,
+               "extra_body" => nil,
                "module" => "Elixir.LangChain.ChatModels.ChatOpenAI"
              }
     end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -98,6 +98,96 @@ defmodule LangChain.UtilsTest do
     end
   end
 
+  describe "merge_extra_body/2" do
+    test "an atom key and a string key of the same name encode as duplicate JSON keys" do
+      naive = Map.merge(%{max_tokens: 64_000}, %{"max_tokens" => 10})
+      naive_json = Jason.encode!(naive)
+
+      assert length(Regex.scan(~r/"max_tokens"/, naive_json)) == 2
+      # Jason keeps the first occurrence when decoding, so the override is lost
+      assert %{"max_tokens" => 64_000} = Jason.decode!(naive_json)
+
+      merged = Utils.merge_extra_body(%{max_tokens: 64_000}, %{"max_tokens" => 10})
+      merged_json = Jason.encode!(merged)
+
+      assert length(Regex.scan(~r/"max_tokens"/, merged_json)) == 1
+      assert %{"max_tokens" => 10} = Jason.decode!(merged_json)
+    end
+
+    test "returns the body unchanged for nil or an empty map" do
+      body = %{model: "gpt-4o", messages: [%{"role" => "user", "content" => "Hi"}]}
+
+      assert Utils.merge_extra_body(body, nil) === body
+      assert Utils.merge_extra_body(body, %{}) === body
+    end
+
+    test "adds a new string key as a string key" do
+      assert Utils.merge_extra_body(%{model: "gpt-4o"}, %{"service_tier" => "priority"}) ==
+               %{:model => "gpt-4o", "service_tier" => "priority"}
+    end
+
+    test "a string key overwrites the atom key of the same name in place" do
+      assert Utils.merge_extra_body(%{model: "gpt-4o", max_tokens: 64_000}, %{"max_tokens" => 10}) ==
+               %{model: "gpt-4o", max_tokens: 10}
+    end
+
+    test "an atom key overwrites the string key of the same name in place" do
+      body = %{"generationConfig" => %{"topK" => 1}}
+
+      assert Utils.merge_extra_body(body, %{generationConfig: %{topK: 5}}) ==
+               %{"generationConfig" => %{"topK" => 5}}
+    end
+
+    test "a nil value removes the key" do
+      body = %{model: "gpt-4o", max_completion_tokens: 4000}
+
+      assert Utils.merge_extra_body(body, %{"max_completion_tokens" => nil, "max_tokens" => 4000}) ==
+               %{:model => "gpt-4o", "max_tokens" => 4000}
+    end
+
+    test "a nil value for a missing key leaves the body unchanged" do
+      assert Utils.merge_extra_body(%{model: "gpt-4o"}, %{"n" => nil}) == %{model: "gpt-4o"}
+    end
+
+    test "deep-merges nested maps, keeping sibling keys" do
+      body = %{model: "llama3", options: %{num_ctx: 2048, top_k: 40}}
+
+      assert Utils.merge_extra_body(body, %{"options" => %{"num_ctx" => 8192, "min_p" => 0.05}}) ==
+               %{model: "llama3", options: %{:num_ctx => 8192, :top_k => 40, "min_p" => 0.05}}
+    end
+
+    test "a nested nil removes only that nested key" do
+      body = %{thinking: %{"type" => "enabled", "budget_tokens" => 2000}}
+
+      assert Utils.merge_extra_body(body, %{"thinking" => %{"budget_tokens" => nil}}) ==
+               %{thinking: %{"type" => "enabled"}}
+    end
+
+    test "a list replaces the existing list" do
+      body = %{stop: ["a", "b"]}
+
+      assert Utils.merge_extra_body(body, %{"stop" => ["c"]}) == %{stop: ["c"]}
+    end
+
+    test "a map replaces a non-map value and a non-map replaces a map" do
+      body = %{user: "someone", response_format: %{"type" => "json_object"}}
+
+      assert Utils.merge_extra_body(body, %{
+               "user" => %{"id" => 1},
+               "response_format" => "text"
+             }) == %{user: %{"id" => 1}, response_format: "text"}
+    end
+
+    test "does not create atoms from new keys" do
+      key = "never_an_atom_#{System.unique_integer([:positive])}"
+
+      assert Utils.merge_extra_body(%{model: "gpt-4o"}, %{key => true}) ==
+               %{:model => "gpt-4o", key => true}
+
+      assert_raise ArgumentError, fn -> String.to_existing_atom(key) end
+    end
+  end
+
   describe "put_in_list/3" do
     test "adds to empty list" do
       assert [1] == Utils.put_in_list([], 0, 1)


### PR DESCRIPTION
## Problem

`ChatOpenAI` and `ChatOpenAIResponses` only send the parameters they have struct fields for, which leaves OpenAI-compatible servers underserved in three ways:

1. Providers such as vLLM, Ollama and OpenRouter accept parameters this library has no field for (`top_k`, `repetition_penalty`, `prompt_cache_key`, and so on), and there was no escape hatch for them.
2. Neither model supported `service_tier`, so requests could not ask for `flex`, `priority` or `fast` processing, and the tier that actually served a request was not visible to the caller.
3. `max_tokens` was sent under its deprecated name. OpenAI's reasoning models require `max_completion_tokens`, and the limit they enforce includes reasoning tokens.

## Solution

A single merge helper, [`LangChain.Utils.merge_extra_body/2`](https://github.com/brainlid/langchain/blob/me-broaden-chat-model-arguments/lib/utils.ex#L61-L84), is applied as the last step of `for_api/3` on both models, so a new `extra_body` map overrides anything the model computed.

The merge is key-aware rather than a plain `Map.merge/2`. In Elixir, `%{max_tokens: 10}` and `%{"max_tokens" => 5}` are distinct keys that `Jason.encode!` emits as duplicate JSON keys, which servers resolve inconsistently. `find_key_by_string/2` matches keys by their string form and overwrites the existing key in place, so a string key supplied by the caller replaces the atom key the model built instead of sitting alongside it. No atoms are created from caller input. A `nil` value deletes the key, which is how a provider that rejects an always-sent parameter like `n` can have it removed, and nested maps merge recursively.

`service_tier` is added as a plain pass-through string field on both models, deliberately unvalidated, since the accepted set differs between OpenAI and compatible providers and changes over time. The tier that served the request is reported *beside* `usage` in the response body rather than inside it, so `get_token_usage/1` now receives the whole body and folds `"service_tier"` into the `TokenUsage` `raw` map. That matches where `ChatAnthropic` already reports its tier, and it carries through to the final message for both complete and streamed responses.

`max_tokens` is now sent as `max_completion_tokens`. The struct field name is unchanged, which keeps the public API and the `gen_ai.request.max_tokens` telemetry attribute intact. Servers that only accept the older key, notably Ollama's `/v1` endpoint, can swap it back with `extra_body: %{"max_completion_tokens" => nil, "max_tokens" => 4000}`, and the module docs spell that out.

One follow-on fix in the Responses WebSocket transport: its payload drop-list compared atoms, so a string `"temperature"` arriving through `extra_body` would have slipped past and triggered the OpenAI bug that silently closes the connection. [`for_api_websocket/3`](https://github.com/brainlid/langchain/blob/me-broaden-chat-model-arguments/lib/chat_models/chat_open_ai_responses.ex#L710-L734) now matches by string form for both the warning and the drop.

## Changes

- [`lib/utils.ex`](https://github.com/brainlid/langchain/blob/me-broaden-chat-model-arguments/lib/utils.ex#L33-L94): new `merge_extra_body/2` with string-form key matching, `nil` deletion and recursive map merging, plus doctests.
- [`lib/chat_models/chat_open_ai.ex`](https://github.com/brainlid/langchain/blob/me-broaden-chat-model-arguments/lib/chat_models/chat_open_ai.ex): added `service_tier` and `extra_body` fields, send `max_tokens` as `max_completion_tokens`, merge `extra_body` last in `for_api/3`, carry the served tier into `TokenUsage.raw`, and include both new fields in `serialize_config/1`.
- [`lib/chat_models/chat_open_ai_responses.ex`](https://github.com/brainlid/langchain/blob/me-broaden-chat-model-arguments/lib/chat_models/chat_open_ai_responses.ex): same `service_tier` and `extra_body` support (replacing the previous "omit service_tier" note), string-form key matching in the WebSocket drop-list, served tier in `TokenUsage.raw`, and both fields in `serialize_config/1`.
- Module docs: new "Service Tier", "Token Limits" and "Provider-Specific Parameters" sections on `ChatOpenAI`, and "Service Tier" and "Provider-Specific Parameters" on `ChatOpenAIResponses`. These cover the override and deletion rules, the Ollama `max_tokens` workaround, the caution against overriding `stream`/`messages`/`model`/`tools`, and the distinction between `extra_body` (request body) and `req_config` (headers and transport). Inline field comments document the same rules at the struct.
- [`test/utils_test.exs`](https://github.com/brainlid/langchain/blob/me-broaden-chat-model-arguments/test/utils_test.exs): 12 tests for `merge_extra_body/2`, opening with one that pins the duplicate-JSON-key hazard the helper exists to avoid.
- [`test/chat_models/chat_open_ai_test.exs`](https://github.com/brainlid/langchain/blob/me-broaden-chat-model-arguments/test/chat_models/chat_open_ai_test.exs): `service_tier` send/omit plus served-tier extraction from complete and streamed responses, and `extra_body` coverage for key override, `nil` removal, the `max_tokens` swap, keyword-list rejection and serialize round trip.
- [`test/chat_models/chat_open_ai_responses_test.exs`](https://github.com/brainlid/langchain/blob/me-broaden-chat-model-arguments/test/chat_models/chat_open_ai_responses_test.exs): equivalent `service_tier` and `extra_body` coverage, `max_completion_tokens` in the API payload, and a WebSocket test asserting transport keys supplied through `extra_body` are dropped.

## Testing

309 tests pass across the three affected files (`mix test test/utils_test.exs test/chat_models/chat_open_ai_test.exs test/chat_models/chat_open_ai_responses_test.exs`), including 4 doctests on `merge_extra_body/2`. All new coverage is unit-level with no external API calls, using mocked response bodies for the token usage assertions.

Two areas worth a reviewer's attention:

- The serialize and restore round trip is covered on both models, since `service_tier` and `extra_body` had to be added to the `serialize_config/1` field lists for persisted configs to survive.
- The `max_completion_tokens` rename changes the wire format for every `ChatOpenAI` caller that sets `max_tokens`. OpenAI-compatible servers that only honour the old key will stop applying a limit until they use the documented `extra_body` swap, so this is worth a CHANGELOG migration note at release time.