### PR TITLE
Keep streamed answer text when a provider omits reasoning_content

### DIFF
--- a/lib/message_delta.ex
+++ b/lib/message_delta.ex
@@ -357,21 +357,52 @@ defmodule LangChain.MessageDelta do
         parts_list
       end
 
-    # Get the content part at the specified index from the primary's content list
-    primary_part = Enum.at(padded_list, position)
+    case Enum.at(padded_list, position) do
+      nil ->
+        put_content_part(primary, padded_list, position, new_content_part)
 
-    # Merge the parts if we have an existing part, otherwise use the new part
-    merged_part =
-      if primary_part do
-        ContentPart.merge_part(primary_part, new_content_part)
-      else
-        new_content_part
-      end
+      %ContentPart{type: type} = existing when type == new_content_part.type ->
+        merged_part = ContentPart.merge_part(existing, new_content_part)
+        put_content_part(primary, padded_list, position, merged_part)
 
-    # Replace the part at the specified index
-    updated_list = List.replace_at(padded_list, position, merged_part)
+      %ContentPart{} ->
+        merge_content_part_after(primary, padded_list, position, new_content_part)
+    end
+  end
 
-    %MessageDelta{primary | merged_content: updated_list}
+  # A part of a different type already holds the position. That happens when a
+  # provider streams thinking and answer text without keeping them apart, for
+  # example by leaving the reasoning field off answer chunks instead of sending
+  # it as null. Merging the two would drop the new part, so it goes to the next
+  # position that already holds its type, or else the next free one.
+  defp merge_content_part_after(
+         %MessageDelta{} = primary,
+         parts_list,
+         position,
+         %ContentPart{type: type} = part
+       ) do
+    later_parts =
+      parts_list
+      |> Enum.with_index()
+      |> Enum.drop(position + 1)
+
+    same_type = Enum.find(later_parts, &match?({%ContentPart{type: ^type}, _index}, &1))
+    free = Enum.find(later_parts, &match?({nil, _index}, &1))
+
+    case {same_type, free} do
+      {{existing, index}, _free} ->
+        put_content_part(primary, parts_list, index, ContentPart.merge_part(existing, part))
+
+      {nil, {nil, index}} ->
+        put_content_part(primary, parts_list, index, part)
+
+      {nil, nil} ->
+        %MessageDelta{primary | merged_content: parts_list ++ [part]}
+    end
+  end
+
+  defp put_content_part(%MessageDelta{} = primary, parts_list, position, part) do
+    %MessageDelta{primary | merged_content: List.replace_at(parts_list, position, part)}
   end
 
   # Merge tool call deltas by matching on each fragment's index value (not

--- a/test/chat_models/chat_open_ai_test.exs
+++ b/test/chat_models/chat_open_ai_test.exs
@@ -2383,6 +2383,31 @@ defmodule LangChain.ChatModels.ChatOpenAITest do
       assert %MessageDelta{role: :assistant, content: "Hello", index: 0} =
                ChatOpenAI.do_process_response(model, delta)
     end
+
+    test "keeps the answer when answer chunks leave out reasoning_content", %{model: model} do
+      # Fireworks sends `reasoning_content` only on chunks that carry thinking.
+      # Its answer chunks leave the key out instead of sending it as null.
+      chunks = [
+        %{
+          "delta" => %{"role" => "assistant", "reasoning_content" => "9.9 = 9.90 "},
+          "finish_reason" => nil,
+          "index" => 0
+        },
+        %{"delta" => %{"reasoning_content" => "> 9.11."}, "finish_reason" => nil, "index" => 0},
+        %{"delta" => %{"content" => "9.9 "}, "finish_reason" => nil, "index" => 0},
+        %{"delta" => %{"content" => "is larger."}, "finish_reason" => "stop", "index" => 0}
+      ]
+
+      merged =
+        chunks
+        |> Enum.map(&ChatOpenAI.do_process_response(model, &1))
+        |> MessageDelta.merge_deltas()
+
+      assert [
+               %ContentPart{type: :thinking, content: "9.9 = 9.90 > 9.11."},
+               %ContentPart{type: :text, content: "9.9 is larger."}
+             ] = merged.merged_content
+    end
   end
 
   describe "do_process_response - MessageDeltas" do

--- a/test/message_delta_test.exs
+++ b/test/message_delta_test.exs
@@ -838,6 +838,31 @@ defmodule LangChain.MessageDeltaTest do
              }
     end
 
+    test "keeps text that arrives at a position already holding thinking" do
+      deltas = [
+        %MessageDelta{
+          content: %ContentPart{type: :thinking, content: "Let me "},
+          index: 0,
+          role: :assistant
+        },
+        %MessageDelta{content: %ContentPart{type: :thinking, content: "think."}, index: 0},
+        %MessageDelta{content: "9.9 ", index: 0},
+        %MessageDelta{content: "is larger.", index: 0, status: :complete}
+      ]
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn -> send(self(), MessageDelta.merge_deltas(deltas)) end)
+
+      assert_received %MessageDelta{} = merged
+
+      assert [
+               %ContentPart{type: :thinking, content: "Let me think."},
+               %ContentPart{type: :text, content: "9.9 is larger."}
+             ] = merged.merged_content
+
+      refute log =~ "Cannot merge content parts"
+    end
+
     test "handles merging a thinking part with the signature" do
       merged =
         [


### PR DESCRIPTION
ChatOpenAI puts streamed thinking at content position 0 and answer text at position 1, but only when a chunk carries a `reasoning_content` key. Cloudflare sends that key as null on answer chunks. Fireworks leaves it out, so its answer chunks keep the choice index, land on the thinking part, and MessageDelta dropped each one with a "Cannot merge content parts of different types" warning. A streamed GLM-5.3-Flash response from Fireworks came back as thinking only.

When a part lands on a position that holds a part of another type, MessageDelta now puts it in the next position holding its type, or the next free one, instead of dropping it. Merges between parts of the same type, and parts landing on free positions, work as before.

The new MessageDelta test and the ChatOpenAI test built from Fireworks' chunk shape both fail without the change.